### PR TITLE
Silence Ganache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ references:
       - run:
           name: Run Tests
           command: |
-            ganache-cli -p 8545 &
+            ganache-cli -p 8545 > /dev/null &
             yarn test
       - save_cache:
           paths:


### PR DESCRIPTION
Ganache client was polluting the logs. This sends it to `/dev/null/`