### PR TITLE
Fix NFT Bug

### DIFF
--- a/contracts/swap/test/Swap.js
+++ b/contracts/swap/test/Swap.js
@@ -906,7 +906,7 @@ contract('Swap', ([aliceAddress, bobAddress, carolAddress, davidAddress]) => {
 
   describe('Minting...', () => {
     it('Mints a concert ticket (#12345) for Alice', async () => {
-      emitted(await tokenTicket.mint(aliceAddress, 12345), 'Transfer')
+      emitted(await tokenTicket.mint(aliceAddress, 12345), 'NFTTransfer')
       ok(
         balances(aliceAddress, [[tokenTicket, 1]]),
         'Alice balances are incorrect'
@@ -914,7 +914,7 @@ contract('Swap', ([aliceAddress, bobAddress, carolAddress, davidAddress]) => {
     })
 
     it('Mints a kitty collectible (#54321) for Bob', async () => {
-      emitted(await tokenKitty.mint(bobAddress, 54321), 'Transfer')
+      emitted(await tokenKitty.mint(bobAddress, 54321), 'NFTTransfer')
       ok(balances(bobAddress, [[tokenKitty, 1]]), 'Bob balances are incorrect')
     })
   })
@@ -923,7 +923,7 @@ contract('Swap', ([aliceAddress, bobAddress, carolAddress, davidAddress]) => {
     it('Alice approves Swap to transfer her concert ticket', async () => {
       emitted(
         await tokenTicket.approve(swapAddress, 12345, { from: aliceAddress }),
-        'Approval'
+        'NFTApproval'
       )
     })
 
@@ -946,7 +946,7 @@ contract('Swap', ([aliceAddress, bobAddress, carolAddress, davidAddress]) => {
     it('Bob approves Swap to transfer his kitty collectible', async () => {
       emitted(
         await tokenKitty.approve(swapAddress, 54321, { from: bobAddress }),
-        'Approval'
+        'NFTApproval'
       )
     })
 
@@ -969,7 +969,7 @@ contract('Swap', ([aliceAddress, bobAddress, carolAddress, davidAddress]) => {
     it('Alice approves Swap to transfer her kitty collectible', async () => {
       emitted(
         await tokenKitty.approve(swapAddress, 54321, { from: aliceAddress }),
-        'Approval'
+        'NFTApproval'
       )
     })
 
@@ -999,7 +999,7 @@ contract('Swap', ([aliceAddress, bobAddress, carolAddress, davidAddress]) => {
     it('Carol approves Swap to transfer her kitty collectible', async () => {
       emitted(
         await tokenKitty.approve(swapAddress, 54321, { from: carolAddress }),
-        'Approval'
+        'NFTApproval'
       )
     })
 

--- a/contracts/tokens/contracts/AdaptedERC721.sol
+++ b/contracts/tokens/contracts/AdaptedERC721.sol
@@ -1,0 +1,303 @@
+pragma solidity ^0.5.0;
+
+import "openzeppelin-solidity/contracts/token/ERC721//IERC721Receiver.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/utils/Address.sol";
+import "openzeppelin-solidity/contracts/drafts/Counters.sol";
+import "openzeppelin-solidity/contracts/introspection/ERC165.sol";
+
+/**
+ * @title ERC721 Non-Fungible Token Standard basic implementation
+ * @dev see https://eips.ethereum.org/EIPS/eip-721
+ */
+contract AdaptedERC721 is ERC165 {
+    using SafeMath for uint256;
+    using Address for address;
+    using Counters for Counters.Counter;
+
+    // NEW EVENTS
+    event NFTTransfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event NFTApproval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event NFTApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    // Equals to `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
+    // which can be also obtained as `IERC721Receiver(0).onERC721Received.selector`
+    bytes4 private constant _ERC721_RECEIVED = 0x150b7a02;
+
+    // Mapping from token ID to owner
+    mapping (uint256 => address) private _tokenOwner;
+
+    // Mapping from token ID to approved address
+    mapping (uint256 => address) private _tokenApprovals;
+
+    // Mapping from owner to number of owned token
+    mapping (address => Counters.Counter) private _ownedTokensCount;
+
+    // Mapping from owner to operator approvals
+    mapping (address => mapping (address => bool)) private _operatorApprovals;
+
+    /*
+     *     bytes4(keccak256('balanceOf(address)')) == 0x70a08231
+     *     bytes4(keccak256('ownerOf(uint256)')) == 0x6352211e
+     *     bytes4(keccak256('approve(address,uint256)')) == 0x095ea7b3
+     *     bytes4(keccak256('getApproved(uint256)')) == 0x081812fc
+     *     bytes4(keccak256('setApprovalForAll(address,bool)')) == 0xa22cb465
+     *     bytes4(keccak256('isApprovedForAll(address,address)')) == 0xe985e9c5
+     *     bytes4(keccak256('transferFrom(address,address,uint256)')) == 0x23b872dd
+     *     bytes4(keccak256('safeTransferFrom(address,address,uint256)')) == 0x42842e0e
+     *     bytes4(keccak256('safeTransferFrom(address,address,uint256,bytes)')) == 0xb88d4fde
+     *
+     *     => 0x70a08231 ^ 0x6352211e ^ 0x095ea7b3 ^ 0x081812fc ^
+     *        0xa22cb465 ^ 0xe985e9c ^ 0x23b872dd ^ 0x42842e0e ^ 0xb88d4fde == 0x80ac58cd
+     */
+    bytes4 private constant _INTERFACE_ID_ERC721 = 0x80ac58cd;
+
+    constructor () public {
+        // register the supported interfaces to conform to ERC721 via ERC165
+        _registerInterface(_INTERFACE_ID_ERC721);
+    }
+
+    /**
+     * @dev Gets the balance of the specified address.
+     * @param owner address to query the balance of
+     * @return uint256 representing the amount owned by the passed address
+     */
+    function balanceOf(address owner) public view returns (uint256) {
+        require(owner != address(0), "ERC721: balance query for the zero address");
+
+        return _ownedTokensCount[owner].current();
+    }
+
+    /**
+     * @dev Gets the owner of the specified token ID.
+     * @param tokenId uint256 ID of the token to query the owner of
+     * @return address currently marked as the owner of the given token ID
+     */
+    function ownerOf(uint256 tokenId) public view returns (address) {
+        address owner = _tokenOwner[tokenId];
+        require(owner != address(0), "ERC721: owner query for nonexistent token");
+
+        return owner;
+    }
+
+    /**
+     * @dev Approves another address to transfer the given token ID
+     * The zero address indicates there is no approved address.
+     * There can only be one approved address per token at a given time.
+     * Can only be called by the token owner or an approved operator.
+     * @param to address to be approved for the given token ID
+     * @param tokenId uint256 ID of the token to be approved
+     */
+    function approve(address to, uint256 tokenId) public {
+        address owner = ownerOf(tokenId);
+        require(to != owner, "ERC721: approval to current owner");
+
+        require(msg.sender == owner || isApprovedForAll(owner, msg.sender),
+            "ERC721: approve caller is not owner nor approved for all"
+        );
+
+        _tokenApprovals[tokenId] = to;
+        emit NFTApproval(owner, to, tokenId);
+    }
+
+    /**
+     * @dev Gets the approved address for a token ID, or zero if no address set
+     * Reverts if the token ID does not exist.
+     * @param tokenId uint256 ID of the token to query the approval of
+     * @return address currently approved for the given token ID
+     */
+    function getApproved(uint256 tokenId) public view returns (address) {
+        require(_exists(tokenId), "ERC721: approved query for nonexistent token");
+
+        return _tokenApprovals[tokenId];
+    }
+
+    /**
+     * @dev Sets or unsets the approval of a given operator
+     * An operator is allowed to transfer all tokens of the sender on their behalf.
+     * @param to operator address to set the approval
+     * @param approved representing the status of the approval to be set
+     */
+    function setApprovalForAll(address to, bool approved) public {
+        require(to != msg.sender, "ERC721: approve to caller");
+
+        _operatorApprovals[msg.sender][to] = approved;
+        emit NFTApprovalForAll(msg.sender, to, approved);
+    }
+
+    /**
+     * @dev Tells whether an operator is approved by a given owner.
+     * @param owner owner address which you want to query the approval of
+     * @param operator operator address which you want to query the approval of
+     * @return bool whether the given operator is approved by the given owner
+     */
+    function isApprovedForAll(address owner, address operator) public view returns (bool) {
+        return _operatorApprovals[owner][operator];
+    }
+
+    /**
+     * @dev Transfers the ownership of a given token ID to another address.
+     * Usage of this method is discouraged, use {safeTransferFrom} whenever possible.
+     * Requires the msg.sender to be the owner, approved, or operator.
+     * @param from current owner of the token
+     * @param to address to receive the ownership of the given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+     */
+    function transferFrom(address from, address to, uint256 tokenId) public {
+        //solhint-disable-next-line max-line-length
+        require(_isApprovedOrOwner(msg.sender, tokenId), "ERC721: transfer caller is not owner nor approved");
+
+        _transferFrom(from, to, tokenId);
+    }
+
+    /**
+     * @dev Safely transfers the ownership of a given token ID to another address
+     * If the target address is a contract, it must implement {IERC721Receiver-onERC721Received},
+     * which is called upon a safe transfer, and return the magic value
+     * `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`; otherwise,
+     * the transfer is reverted.
+     * Requires the msg.sender to be the owner, approved, or operator
+     * @param from current owner of the token
+     * @param to address to receive the ownership of the given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId) public {
+        safeTransferFrom(from, to, tokenId, "");
+    }
+
+    /**
+     * @dev Safely transfers the ownership of a given token ID to another address
+     * If the target address is a contract, it must implement {IERC721Receiver-onERC721Received},
+     * which is called upon a safe transfer, and return the magic value
+     * `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`; otherwise,
+     * the transfer is reverted.
+     * Requires the msg.sender to be the owner, approved, or operator
+     * @param from current owner of the token
+     * @param to address to receive the ownership of the given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+     * @param _data bytes data to send along with a safe transfer check
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory _data) public {
+        transferFrom(from, to, tokenId);
+        require(_checkOnERC721Received(from, to, tokenId, _data), "ERC721: transfer to non ERC721Receiver implementer");
+    }
+
+    /**
+     * @dev Returns whether the specified token exists.
+     * @param tokenId uint256 ID of the token to query the existence of
+     * @return bool whether the token exists
+     */
+    function _exists(uint256 tokenId) internal view returns (bool) {
+        address owner = _tokenOwner[tokenId];
+        return owner != address(0);
+    }
+
+    /**
+     * @dev Returns whether the given spender can transfer a given token ID.
+     * @param spender address of the spender to query
+     * @param tokenId uint256 ID of the token to be transferred
+     * @return bool whether the msg.sender is approved for the given token ID,
+     * is an operator of the owner, or is the owner of the token
+     */
+    function _isApprovedOrOwner(address spender, uint256 tokenId) internal view returns (bool) {
+        require(_exists(tokenId), "ERC721: operator query for nonexistent token");
+        address owner = ownerOf(tokenId);
+        return (spender == owner || getApproved(tokenId) == spender || isApprovedForAll(owner, spender));
+    }
+
+    /**
+     * @dev Internal function to mint a new token.
+     * Reverts if the given token ID already exists.
+     * @param to The address that will own the minted token
+     * @param tokenId uint256 ID of the token to be minted
+     */
+    function _mint(address to, uint256 tokenId) internal {
+        require(to != address(0), "ERC721: mint to the zero address");
+        require(!_exists(tokenId), "ERC721: token already minted");
+
+        _tokenOwner[tokenId] = to;
+        _ownedTokensCount[to].increment();
+
+        emit NFTTransfer(address(0), to, tokenId);
+    }
+
+    /**
+     * @dev Internal function to burn a specific token.
+     * Reverts if the token does not exist.
+     * Deprecated, use {_burn} instead.
+     * @param owner owner of the token to burn
+     * @param tokenId uint256 ID of the token being burned
+     */
+    function _burn(address owner, uint256 tokenId) internal {
+        require(ownerOf(tokenId) == owner, "ERC721: burn of token that is not own");
+
+        _clearApproval(tokenId);
+
+        _ownedTokensCount[owner].decrement();
+        _tokenOwner[tokenId] = address(0);
+
+        emit NFTTransfer(owner, address(0), tokenId);
+    }
+
+    /**
+     * @dev Internal function to burn a specific token.
+     * Reverts if the token does not exist.
+     * @param tokenId uint256 ID of the token being burned
+     */
+    function _burn(uint256 tokenId) internal {
+        _burn(ownerOf(tokenId), tokenId);
+    }
+
+    /**
+     * @dev Internal function to transfer ownership of a given token ID to another address.
+     * As opposed to {transferFrom}, this imposes no restrictions on msg.sender.
+     * @param from current owner of the token
+     * @param to address to receive the ownership of the given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+     */
+    function _transferFrom(address from, address to, uint256 tokenId) internal {
+        require(ownerOf(tokenId) == from, "ERC721: transfer of token that is not own");
+        require(to != address(0), "ERC721: transfer to the zero address");
+
+        _clearApproval(tokenId);
+
+        _ownedTokensCount[from].decrement();
+        _ownedTokensCount[to].increment();
+
+        _tokenOwner[tokenId] = to;
+
+        emit NFTTransfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev Internal function to invoke {IERC721Receiver-onERC721Received} on a target address.
+     * The call is not executed if the target address is not a contract.
+     *
+     * This function is deprecated.
+     * @param from address representing the previous owner of the given token ID
+     * @param to target address that will receive the tokens
+     * @param tokenId uint256 ID of the token to be transferred
+     * @param _data bytes optional data to send along with the call
+     * @return bool whether the call correctly returned the expected magic value
+     */
+    function _checkOnERC721Received(address from, address to, uint256 tokenId, bytes memory _data)
+        internal returns (bool)
+    {
+        if (!to.isContract()) {
+            return true;
+        }
+
+        bytes4 retval = IERC721Receiver(to).onERC721Received(msg.sender, from, tokenId, _data);
+        return (retval == _ERC721_RECEIVED);
+    }
+
+    /**
+     * @dev Private function to clear current approval of a given token ID.
+     * @param tokenId uint256 ID of the token to be transferred
+     */
+    function _clearApproval(uint256 tokenId) private {
+        if (_tokenApprovals[tokenId] != address(0)) {
+            _tokenApprovals[tokenId] = address(0);
+        }
+    }
+}

--- a/contracts/tokens/contracts/NonFungibleToken.sol
+++ b/contracts/tokens/contracts/NonFungibleToken.sol
@@ -1,5 +1,21 @@
 pragma solidity 0.5.10;
 
-import "openzeppelin-solidity/contracts/token/ERC721/ERC721Mintable.sol";
+import "openzeppelin-solidity/contracts/access/roles/MinterRole.sol";
+import "./AdaptedERC721.sol";
 
-contract NonFungibleToken is ERC721Mintable {}
+// This contract definiition is the same as ERC721Mintable, however it uses an
+// adapted ERC721 - with different event names
+contract NonFungibleToken is AdaptedERC721, MinterRole {
+
+    /**
+     * @dev Function to mint tokens.
+     * @param to The address that will receive the minted tokens.
+     * @param tokenId The token id to mint.
+     * @return A boolean that indicates if the operation was successful.
+     */
+    function mint(address to, uint256 tokenId) public onlyMinter returns (bool) {
+        _mint(to, tokenId);
+        return true;
+    }
+
+}


### PR DESCRIPTION
### Description

Truffle was throwing errors which transpired to be because `swap` was emitting an ERC20 Transfer event, and an ERC721 Transfer event - same name, different definitions. Truffle broke.

The PR brings in a new NFT for the tests which is copied directly from OpenZeppelin. All I've done is rename the events to be `NFTTransfer`, `NFTApproval` etc