### PR TITLE
Empty Address into Contracts

### DIFF
--- a/contracts/consumer/test/Consumer-unit.js
+++ b/contracts/consumer/test/Consumer-unit.js
@@ -6,9 +6,8 @@ const abi = require('ethereumjs-abi')
 const { intents } = require('@airswap/indexer-utils')
 const { equal, passes } = require('@airswap/test-utils').assert
 const { takeSnapshot, revertToSnapShot } = require('@airswap/test-utils').time
+const { EMPTY_ADDRESS } = require('@airswap/order-utils').constants
 const BigNumber = require('bignumber.js')
-
-const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 contract('Consumer Unit Tests', async () => {
   const highVal = 400

--- a/contracts/delegate/test/Delegate-unit.js
+++ b/contracts/delegate/test/Delegate-unit.js
@@ -11,8 +11,7 @@ const {
   reverted,
 } = require('@airswap/test-utils').assert
 const { takeSnapshot, revertToSnapShot } = require('@airswap/test-utils').time
-
-const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
+const { EMPTY_ADDRESS } = require('@airswap/order-utils').constants
 
 contract('Delegate Unit Tests', async accounts => {
   const owner = accounts[0]

--- a/packages/order-utils/src/constants.js
+++ b/packages/order-utils/src/constants.js
@@ -18,6 +18,7 @@ module.exports = {
   DOMAIN_NAME: 'SWAP',
   DOMAIN_VERSION: '2',
   SECONDS_IN_DAY: 86400,
+  EMPTY_ADDRESS: '0x0000000000000000000000000000000000000000',
   types: {
     EIP712Domain: [
       { name: 'name', type: 'string' },


### PR DESCRIPTION
Empty address is common amongst all tests. Give it a central spot.
This will permeate into the the other unit tests for swap and wrapper