### PR TITLE
Reduce Concurrency to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "yarn eslint \"./**/test/**/*.js\" \"./packages/**/*.js\"",
     "ganache": "ganache-cli -p 8545 --gasLimit 0xfffffffffff --time '2017-05-10T00:00:00+00:00'",
     "publish": "lerna publish",
-    "test": "yarn clean && lerna run test"
+    "test": "yarn clean && lerna run test --concurrency=1"
   },
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^3.0.7",


### PR DESCRIPTION
> How many threads to use when Lerna parallelizes the tasks (defaults to count of logical CPU cores)

We reduce this to 1 to make tests deterministic

