### PR TITLE
Remove Mock Linkings from Delegate Unit Tests

### DIFF
--- a/contracts/delegate/contracts/Imports.sol
+++ b/contracts/delegate/contracts/Imports.sol
@@ -3,5 +3,3 @@ pragma solidity 0.5.10;
 import "@airswap/swap/contracts/Swap.sol";
 import "@airswap/tokens/contracts/FungibleToken.sol";
 import "@gnosis.pm/mock-contract/contracts/MockContract.sol";
-import "@airswap/common/libraries/Transfers.sol";
-import "@airswap/common/libraries/Types.sol";

--- a/contracts/delegate/test/Delegate-unit.js
+++ b/contracts/delegate/test/Delegate-unit.js
@@ -1,8 +1,6 @@
 /* global artifacts, contract, web3*/
 const Delegate = artifacts.require('Delegate')
 const Swap = artifacts.require('Swap')
-const Transfers = artifacts.require('Transfers')
-const Types = artifacts.require('Types')
 const MockContract = artifacts.require('MockContract')
 const {
   equal,
@@ -37,13 +35,6 @@ contract('Delegate Unit Tests', async accounts => {
   })
 
   async function setupMockSwap() {
-    // deploy both libs
-    const transfersLib = await Transfers.new()
-    const typesLib = await Types.new()
-
-    // link both libs to swap
-    await Swap.link(Transfers, transfersLib.address)
-    await Swap.link(Types, typesLib.address)
     let swapTemplate = await Swap.new()
     swap_swapSimple = swapTemplate.contract.methods
       .swapSimple(


### PR DESCRIPTION
It's not necessary to mock the linkings for a mock contract.