### PR TITLE
Removing unnecessary market logic

### DIFF
--- a/protocols/market/contracts/Market.sol
+++ b/protocols/market/contracts/Market.sol
@@ -114,12 +114,11 @@ contract Market is Ownable {
     Intent memory newIntent = Intent(_staker, _amount, _expiry, _locator);
 
     // Insert after the next highest amount on the linked list.
-    if (insertIntent(newIntent, findPosition(_amount))) {
+    insertIntent(newIntent, findPosition(_amount));
       // Increment the length of the linked list if successful.
-      length = length + 1;
+    length = length + 1;
 
-      emit SetIntent(_staker, _amount, _expiry, _locator, makerToken, takerToken);
-    }
+    emit SetIntent(_staker, _amount, _expiry, _locator, makerToken, takerToken);
   }
 
   /**
@@ -281,12 +280,7 @@ contract Market is Ownable {
   function insertIntent(
     Intent memory _newIntent,
     Intent memory _nextIntent
-  ) internal returns (bool) {
-
-    // Ensure the _existing intent is in the linked list.
-    if (!hasIntent(_nextIntent.staker)) {
-      return false;
-    }
+  ) internal {
 
     // Get the intent before the _nextIntent.
     Intent memory previousIntent = intentsLinkedList[_nextIntent.staker][PREV];
@@ -294,8 +288,6 @@ contract Market is Ownable {
     // Link the _newIntent into place.
     link(previousIntent, _newIntent);
     link(_newIntent, _nextIntent);
-
-    return true;
   }
 
   /**


### PR DESCRIPTION
### Description

This PR removes logic from the market that is not necessary:
- `insertIntent` was only returning false, when `_nextIntent` was not a real intent (i.e. `!hasIntent(_nextIntent.staker)`
- however `insertIntent` is internal, and only gets called in one location.
- In this location, `_nextIntent` is found using `findPosition`, which loops through the linked list, from the head, to find the new intent’s correct location.
- this means that` _nextIntent` is always in the linked list - as that’s how it’s found.
- `hasIntent(_nextIntent.staker)` will always return true ->  `insertIntent` will always return true ->  the if statement will always be carried out -> we don’t need an if statement, no do we need `insertIntent` to return a bool

## Coverage
This then removes the untestable lines of code, leaving us with:
```
--------------|----------|----------|----------|----------|----------------|
File          |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------|----------|----------|----------|----------|----------------|
 contracts/   |      100 |      100 |      100 |      100 |                |
  Imports.sol |      100 |      100 |      100 |      100 |                |
  Market.sol  |      100 |      100 |      100 |      100 |                |
--------------|----------|----------|----------|----------|----------------|
All files     |      100 |      100 |      100 |      100 |                |
--------------|----------|----------|----------|----------|----------------|
```