### PR TITLE
Expired intents bug

### DIFF
--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -173,19 +173,27 @@ contract Indexer is IIndexer, Ownable {
     require(markets[_makerToken][_takerToken] != Market(0),
       "MARKET_DOES_NOT_EXIST");
 
+    removeIntent(_makerToken, _takerToken, msg.sender);
+  }
+
+  function removeIntent(
+    address _makerToken,
+    address _takerToken,
+    address _staker
+  ) internal {
     // Get the intent for the sender.
-    Market.Intent memory intent = markets[_makerToken][_takerToken].getIntent(msg.sender);
+    Market.Intent memory intent = markets[_makerToken][_takerToken].getIntent(_staker);
 
     // Ensure the intent exists.
-    require(intent.staker == msg.sender,
+    require(intent.staker == _staker,
       "INTENT_DOES_NOT_EXIST");
 
     // Unset the intent on the market.
-    markets[_makerToken][_takerToken].unsetIntent(msg.sender);
+    markets[_makerToken][_takerToken].unsetIntent(_staker);
 
     // Return the staked tokens.
-    stakeToken.transfer(msg.sender, intent.amount);
-    emit Unstake(msg.sender, _makerToken, _takerToken, intent.amount);
+    stakeToken.transfer(_staker, intent.amount);
+    emit Unstake(_staker, _makerToken, _takerToken, intent.amount);
   }
 
   /**

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -224,13 +224,12 @@ contract Indexer is IIndexer, Ownable {
     }
     return new bytes32[](0);
   }
-  
+
   function removeIntents(
     address _makerToken,
     address _takerToken,
     address[] memory _stakers
   ) internal {
-
     for (uint256 i; i < _stakers.length; i++) {
       if (_stakers[i] != address(0)) {
         // Get the intent for the sender.

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -179,6 +179,14 @@ contract Indexer is IIndexer, Ownable {
     removeIntents(_makerToken, _takerToken, staker);
   }
 
+  /**
+    * @notice Loops through _count stakers from _startingPoint on a market and removes any expired intents
+    *
+    * @param _makerToken address
+    * @param _takerToken address
+    * @param _startingPoint the staker to start at
+    * @param _count the number of stakers to loop through
+    */
   function cleanExpiredIntents(
     address _makerToken,
     address _takerToken,
@@ -225,6 +233,13 @@ contract Indexer is IIndexer, Ownable {
     return new bytes32[](0);
   }
 
+/**
+    * @notice Removes stakers' intents from a market
+    *
+    * @param _makerToken address
+    * @param _takerToken address
+    * @param _stakers address[]
+    */
   function removeIntents(
     address _makerToken,
     address _takerToken,

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -232,19 +232,21 @@ contract Indexer is IIndexer, Ownable {
   ) internal {
 
     for (uint256 i; i < _stakers.length; i++) {
-      // Get the intent for the sender.
-      Market.Intent memory intent = markets[_makerToken][_takerToken].getIntent(_stakers[i]);
+      if (_stakers[i] != address(0)) {
+        // Get the intent for the sender.
+        Market.Intent memory intent = markets[_makerToken][_takerToken].getIntent(_stakers[i]);
 
-      // Ensure the intent exists.
-      require(intent.staker == _stakers[i],
-        "INTENT_DOES_NOT_EXIST");
+        // Ensure the intent exists.
+        require(intent.staker == _stakers[i],
+          "INTENT_DOES_NOT_EXIST");
 
-      // Unset the intent on the market.
-      markets[_makerToken][_takerToken].unsetIntent(_stakers[i]);
+        // Unset the intent on the market.
+        markets[_makerToken][_takerToken].unsetIntent(_stakers[i]);
 
-      // Return the staked tokens.
-      stakeToken.transfer(_stakers[i], intent.amount);
-      emit Unstake(_stakers[i], _makerToken, _takerToken, intent.amount);
+        // Return the staked tokens.
+        stakeToken.transfer(_stakers[i], intent.amount);
+        emit Unstake(_stakers[i], _makerToken, _takerToken, intent.amount);
+      }
     }
   }
 

--- a/protocols/indexer/test/Indexer-unit.js
+++ b/protocols/indexer/test/Indexer-unit.js
@@ -13,8 +13,12 @@ const {
   getTimestampPlusDays,
   revertToSnapShot,
   takeSnapshot,
+  advanceTimeAndBlock,
 } = require('@airswap/test-utils').time
-const { EMPTY_ADDRESS } = require('@airswap/order-utils').constants
+const {
+  EMPTY_ADDRESS,
+  SECONDS_IN_DAY,
+} = require('@airswap/order-utils').constants
 const { padAddressToLocator } = require('@airswap/test-utils').padding
 
 contract('Indexer Unit Tests', async accounts => {
@@ -598,7 +602,12 @@ contract('Indexer Unit Tests', async accounts => {
       equal(marketBefore.length, 2, 'intents array should be size 2')
 
       // try to remove intents
-      let tx = await indexer.cleanExpiredIntents(tokenOne, tokenTwo, aliceAddress, 3)
+      let tx = await indexer.cleanExpiredIntents(
+        tokenOne,
+        tokenTwo,
+        aliceAddress,
+        3
+      )
 
       // check no intents were unstaked
       let marketAfter = await indexer.getIntents.call(tokenOne, tokenTwo, 100)
@@ -606,7 +615,54 @@ contract('Indexer Unit Tests', async accounts => {
       notEmitted(tx, 'Unstake')
     })
 
-    it("shouldn't remove intents if expired intents aren't in count")
+    it("shouldn't remove intents if expired intents aren't in count", async () => {
+      // create market
+      await indexer.createMarket(tokenOne, tokenTwo, {
+        from: aliceAddress,
+      })
+
+      // set two intents
+      await indexer.setIntent(
+        tokenOne,
+        tokenTwo,
+        50,
+        await getTimestampPlusDays(1),
+        aliceLocator,
+        {
+          from: aliceAddress,
+        }
+      )
+      await indexer.setIntent(
+        tokenOne,
+        tokenTwo,
+        100,
+        await getTimestampPlusDays(2),
+        bobLocator,
+        {
+          from: bobAddress,
+        }
+      )
+
+      // increase time so Alice's intent has expired
+      await advanceTimeAndBlock(SECONDS_IN_DAY * 1.1)
+
+      // get size of market
+      let marketBefore = await indexer.getIntents.call(tokenOne, tokenTwo, 100)
+      equal(marketBefore.length, 2, 'intents array should be size 2')
+
+      // try to remove intents but only consider Bob's
+      let tx = await indexer.cleanExpiredIntents(
+        tokenOne,
+        tokenTwo,
+        bobAddress,
+        1
+      )
+
+      // check no intents were unstaked
+      let marketAfter = await indexer.getIntents.call(tokenOne, tokenTwo, 100)
+      equal(marketAfter.length, 2, 'intents array should be size 2')
+      notEmitted(tx, 'Unstake')
+    })
 
     it('should remove expired intents in count')
   })

--- a/protocols/indexer/test/Indexer-unit.js
+++ b/protocols/indexer/test/Indexer-unit.js
@@ -556,4 +556,19 @@ contract('Indexer Unit Tests', async accounts => {
       equal(intents.length, 1, 'intents array should be size 1')
     })
   })
+
+  describe('Test cleanExpiredIntents', async () => {
+    it("should revert if the market doesn't exist", async () => {
+      await reverted(
+        indexer.cleanExpiredIntents(tokenOne, tokenTwo, aliceAddress, 3),
+        'MARKET_DOES_NOT_EXIST'
+      )
+    })
+
+    it("shouldn't remove intents if they not have expired")
+
+    it("shouldn't remove intents if expired intents aren't in count")
+
+    it('should remove expired intents in count')
+  })
 })

--- a/protocols/market/contracts/Market.sol
+++ b/protocols/market/contracts/Market.sol
@@ -192,10 +192,11 @@ contract Market is Ownable {
   }
 
   /**
-    * @notice Loops through _count stakers from _startingPoint and removes any expired intents
+    * @notice Loops through _count stakers from _startingPoint and returns expired stakers
     *
     * @param _startingPoint the staker to start at
     * @param _count the number of stakers to loop through
+    * @return address[] the expired stakers
     */
   function findExpiredIntents(address _startingPoint, uint256 _count) external view returns (address[] memory expiredIntents) {
     uint256 limit = _count;

--- a/protocols/market/contracts/Market.sol
+++ b/protocols/market/contracts/Market.sol
@@ -197,7 +197,7 @@ contract Market is Ownable {
     * @param _startingPoint the staker to start at
     * @param _count the number of stakers to loop through
     */
-  function cleanExpiredIntents(address _startingPoint, uint256 _count) external {
+  function cleanExpiredIntents(address _startingPoint, uint256 _count) external onlyOwner {
     uint256 limit = _count;
     address staker = _startingPoint;
     address previousStaker;

--- a/protocols/market/contracts/Market.sol
+++ b/protocols/market/contracts/Market.sol
@@ -197,23 +197,23 @@ contract Market is Ownable {
     * @param _startingPoint the staker to start at
     * @param _count the number of stakers to loop through
     */
-  function cleanExpiredIntents(address _startingPoint, uint256 _count) external onlyOwner {
+  function findExpiredIntents(address _startingPoint, uint256 _count) external returns (address[] memory expiredIntents) {
     uint256 limit = _count;
     address staker = _startingPoint;
-    address previousStaker;
 
     if (limit > length) {
       limit = length;
     }
 
+    expiredIntents = new address[](limit);
+    uint256 intentsIndex = 0;
+
     uint256 i = 0;
     while (i < limit) {
       if (staker != HEAD) {
         if (isIntentExpired(staker)) {
-          // we must track the neighbouring intent for when `staker` is removed
-          previousStaker = intentsLinkedList[staker][PREV].staker;
-          removeIntent(staker);
-          staker = previousStaker;
+          expiredIntents[intentsIndex] = staker;
+          intentsIndex++;
         }
         // only increase the count if it wasnt HEAD
         i++;

--- a/protocols/market/contracts/Market.sol
+++ b/protocols/market/contracts/Market.sol
@@ -197,7 +197,7 @@ contract Market is Ownable {
     * @param _startingPoint the staker to start at
     * @param _count the number of stakers to loop through
     */
-  function findExpiredIntents(address _startingPoint, uint256 _count) external returns (address[] memory expiredIntents) {
+  function findExpiredIntents(address _startingPoint, uint256 _count) external view returns (address[] memory expiredIntents) {
     uint256 limit = _count;
     address staker = _startingPoint;
 
@@ -229,7 +229,7 @@ contract Market is Ownable {
     * @param _staker the staker in question
     * @return bool has the staker's intent expired?
     */
-  function isIntentExpired(address _staker) public returns (bool) {
+  function isIntentExpired(address _staker) public view returns (bool) {
     return getIntent(_staker).expiry <= now;
   }
 

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -498,7 +498,9 @@ contract('Market Unit Tests', async accounts => {
       let listLength = await market.length()
       equal(listLength, 3, 'Link list length should be 3')
 
-      let expiredIntents = await market.findExpiredIntents.call(LIST_HEAD, 6, { from: owner })
+      let expiredIntents = await market.findExpiredIntents.call(LIST_HEAD, 6, {
+        from: owner,
+      })
 
       equal(expiredIntents.length, 3, 'Array length should be 3')
       equal(expiredIntents[0], EMPTY_ADDRESS, 'This element should be empty')
@@ -519,7 +521,9 @@ contract('Market Unit Tests', async accounts => {
       await advanceTimeAndBlock(SECONDS_IN_DAY * 1.1)
 
       // do not reach carols intent
-      let expiredIntents = await market.findExpiredIntents.call(bobAddress, 1, { from: owner })
+      let expiredIntents = await market.findExpiredIntents.call(bobAddress, 1, {
+        from: owner,
+      })
 
       equal(expiredIntents.length, 1, 'Array length should be 1')
       equal(expiredIntents[0], EMPTY_ADDRESS, 'This element should be empty')
@@ -538,7 +542,9 @@ contract('Market Unit Tests', async accounts => {
       await advanceTimeAndBlock(SECONDS_IN_DAY * 1.1)
 
       // now reach carols intent
-      let expiredIntents = await market.findExpiredIntents.call(bobAddress, 3, { from: owner })
+      let expiredIntents = await market.findExpiredIntents.call(bobAddress, 3, {
+        from: owner,
+      })
 
       equal(expiredIntents.length, 3, 'Array length should be 3')
       equal(expiredIntents[0], carolAddress, 'Carol should be listed')

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -489,6 +489,13 @@ contract('Market Unit Tests', async accounts => {
       })
     })
 
+    it('should not allow a non owner to call cleanExpiredIntents', async () => {
+      await reverted(
+        market.cleanExpiredIntents(LIST_HEAD, 3, { from: nonOwner }),
+        'Ownable: caller is not the owner'
+      )
+    })
+
     it('should make no changes if none have expired', async () => {
       let intents = await market.fetchIntents(7)
       equal(intents[0], aliceLocator, 'Alice should be first')
@@ -498,7 +505,7 @@ contract('Market Unit Tests', async accounts => {
       let listLength = await market.length()
       equal(listLength, 3, 'Link list length should be 3')
 
-      await market.cleanExpiredIntents(LIST_HEAD, 6)
+      await market.cleanExpiredIntents(LIST_HEAD, 6, { from: owner })
 
       intents = await market.fetchIntents(7)
       equal(intents[0], aliceLocator, 'Alice should be first')
@@ -522,7 +529,7 @@ contract('Market Unit Tests', async accounts => {
       await advanceTimeAndBlock(SECONDS_IN_DAY * 1.1)
 
       // do not reach carols intent
-      await market.cleanExpiredIntents(bobAddress, 1)
+      await market.cleanExpiredIntents(bobAddress, 1, { from: owner })
 
       // length is unchanged
       listLength = await market.length()
@@ -548,7 +555,7 @@ contract('Market Unit Tests', async accounts => {
       await advanceTimeAndBlock(SECONDS_IN_DAY * 1.1)
 
       // now reach carols intent
-      await market.cleanExpiredIntents(bobAddress, 3)
+      await market.cleanExpiredIntents(bobAddress, 3, { from: owner })
 
       // length is changed
       listLength = await market.length()

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -470,7 +470,7 @@ contract('Market Unit Tests', async accounts => {
     })
   })
 
-  describe('Test cleanExpiredIntents', async () => {
+  describe('Test findExpiredIntents', async () => {
     beforeEach('Setup intents again', async () => {
       await market.setIntent(
         aliceAddress,
@@ -489,14 +489,7 @@ contract('Market Unit Tests', async accounts => {
       })
     })
 
-    it('should not allow a non owner to call cleanExpiredIntents', async () => {
-      await reverted(
-        market.cleanExpiredIntents(LIST_HEAD, 3, { from: nonOwner }),
-        'Ownable: caller is not the owner'
-      )
-    })
-
-    it('should make no changes if none have expired', async () => {
+    it('should return empty array if none have expired', async () => {
       let intents = await market.fetchIntents(7)
       equal(intents[0], aliceLocator, 'Alice should be first')
       equal(intents[1], carolLocator, 'Carol should be second')
@@ -505,18 +498,15 @@ contract('Market Unit Tests', async accounts => {
       let listLength = await market.length()
       equal(listLength, 3, 'Link list length should be 3')
 
-      await market.cleanExpiredIntents(LIST_HEAD, 6, { from: owner })
+      let expiredIntents = await market.findExpiredIntents.call(LIST_HEAD, 6, { from: owner })
 
-      intents = await market.fetchIntents(7)
-      equal(intents[0], aliceLocator, 'Alice should be first')
-      equal(intents[1], carolLocator, 'Carol should be second')
-      equal(intents[2], bobLocator, 'Bob should be third')
-
-      listLength = await market.length()
-      equal(listLength, 3, 'Link list length should be 3')
+      equal(expiredIntents.length, 3, 'Array length should be 3')
+      equal(expiredIntents[0], EMPTY_ADDRESS, 'This element should be empty')
+      equal(expiredIntents[1], EMPTY_ADDRESS, 'This element should be empty')
+      equal(expiredIntents[2], EMPTY_ADDRESS, 'This element should be empty')
     })
 
-    it('should make not remove an expired intent if count doesnt reach it', async () => {
+    it('should make not return an expired intent if count doesnt reach it', async () => {
       let intents = await market.fetchIntents(7)
       equal(intents[0], aliceLocator, 'before: Alice should be first')
       equal(intents[1], carolLocator, 'before: Carol should be second')
@@ -529,20 +519,13 @@ contract('Market Unit Tests', async accounts => {
       await advanceTimeAndBlock(SECONDS_IN_DAY * 1.1)
 
       // do not reach carols intent
-      await market.cleanExpiredIntents(bobAddress, 1, { from: owner })
+      let expiredIntents = await market.findExpiredIntents.call(bobAddress, 1, { from: owner })
 
-      // length is unchanged
-      listLength = await market.length()
-      equal(listLength, 3, 'Link list length should be 3')
-
-      // fetch intents does not return carol as she is expired
-      intents = await market.fetchIntents(7)
-      equal(intents[0], aliceLocator, 'Alice should be first')
-      equal(intents[1], bobLocator, 'Bob should be second')
-      equal(intents[2], emptyLocator, 'Null should be third')
+      equal(expiredIntents.length, 1, 'Array length should be 1')
+      equal(expiredIntents[0], EMPTY_ADDRESS, 'This element should be empty')
     })
 
-    it('should make remove an expired intent if count does reach it', async () => {
+    it('should make return an expired intent if count does reach it', async () => {
       let intents = await market.fetchIntents(7)
       equal(intents[0], aliceLocator, 'before: Alice should be first')
       equal(intents[1], carolLocator, 'before: Carol should be second')
@@ -555,14 +538,12 @@ contract('Market Unit Tests', async accounts => {
       await advanceTimeAndBlock(SECONDS_IN_DAY * 1.1)
 
       // now reach carols intent
-      await market.cleanExpiredIntents(bobAddress, 3, { from: owner })
+      let expiredIntents = await market.findExpiredIntents.call(bobAddress, 3, { from: owner })
 
-      // length is changed
-      listLength = await market.length()
-      equal(listLength, 2, 'Link list length should be 2')
-      intents = await market.fetchIntents(7)
-      equal(intents[0], aliceLocator, 'Alice should be first')
-      equal(intents[1], bobLocator, 'Bob should be second')
+      equal(expiredIntents.length, 3, 'Array length should be 3')
+      equal(expiredIntents[0], carolAddress, 'Carol should be listed')
+      equal(expiredIntents[1], EMPTY_ADDRESS, 'This element should be empty')
+      equal(expiredIntents[2], EMPTY_ADDRESS, 'This element should be empty')
     })
   })
 })

--- a/protocols/market/test/Market.js
+++ b/protocols/market/test/Market.js
@@ -8,7 +8,7 @@ const {
   SECONDS_IN_DAY,
   EMPTY_ADDRESS,
 } = require('@airswap/order-utils').constants
-const { equal, passes } = require('@airswap/test-utils').assert
+const { equal } = require('@airswap/test-utils').assert
 const {
   getTimestampPlusDays,
   advanceTimeAndBlock,

--- a/protocols/market/test/Market.js
+++ b/protocols/market/test/Market.js
@@ -191,74 +191,52 @@ contract('Market', async accounts => {
   })
 
   describe('Garbage Collection', async () => {
-    it("Doesn't remove any intents that haven't expired", async () => {
+    it("Doesn't return any intents that haven't expired", async () => {
       let intents = await market.fetchIntents(7)
       // Returns all 6 intents
       assert(BN(intents.length).eq(6), 'Returned intents wrong length')
 
       // Tries to remove intents, looping from Bob, count 5
       // Bob -> Eve -> David -> Zara -> HEAD -> Alice (Carol is after Alice, before Bob)
-      await market.cleanExpiredIntents(bobAddress, 5)
+      let expiredIntents = await market.findExpiredIntents.call(bobAddress, 5)
 
-      intents = await market.fetchIntents(7)
-      assert(BN(intents.length).eq(6), 'Intents should be same length')
+      assert(BN(expiredIntents.length).eq(5), 'Array length should be 5')
 
-      // Ensure that the ordering is the same
-      assert(intents[0] == aliceLocator, 'Alice should be first')
-      assert(intents[1] == bobLocator, 'Bob should be second')
-      assert(intents[2] == eveLocator, 'Eve should be third')
-      assert(intents[3] == davidLocator, 'David should be fourth')
-      assert(intents[4] == zaraLocator, 'Zara should be fifth')
-      assert(intents[5] == emptyLocator, 'Null 6th location')
+      assert(expiredIntents[0] == EMPTY_ADDRESS, 'This element should be empty')
+      assert(expiredIntents[1] == EMPTY_ADDRESS, 'This element should be empty')
+      assert(expiredIntents[2] == EMPTY_ADDRESS, 'This element should be empty')
+      assert(expiredIntents[3] == EMPTY_ADDRESS, 'This element should be empty')
+      assert(expiredIntents[4] == EMPTY_ADDRESS, 'This element should be empty')
     })
 
-    it("Should remove Carol's intent if she's included in the loop", async () => {
+    it("Should return Carol's intent if she's included in the loop", async () => {
       let intents = await market.fetchIntents(7)
       // Returns all 6 intents
       assert(BN(intents.length).eq(6), 'Returned intents wrong length')
 
       // Try to remove Carol's intent (Zara -> HEAD -> Alice -> Carol -> Bob)
-      let tx = await market.cleanExpiredIntents(zaraAddress, 4)
-      passes(tx)
+      let expiredIntents = await market.findExpiredIntents.call(zaraAddress, 4)
 
-      // Returns just 5 intents this time - carol has been removed
-      intents = await market.fetchIntents(7)
-      assert(BN(intents.length).eq(5), 'Intents should be shorter')
+      assert(BN(expiredIntents.length).eq(4), 'Array length should be 4')
 
-      // Ensure that the ordering is the same, without a null 6th slot
-      assert(intents[0] == aliceLocator, 'Alice should be first')
-      assert(intents[1] == bobLocator, 'Bob should be second')
-      assert(intents[2] == eveLocator, 'Eve should be third')
-      assert(intents[3] == davidLocator, 'David should be fourth')
-      assert(intents[4] == zaraLocator, 'Zara should be fifth')
+      assert(expiredIntents[0] == carolAddress, 'Carol should be listed')
+      assert(expiredIntents[1] == EMPTY_ADDRESS, 'This element should be empty')
+      assert(expiredIntents[2] == EMPTY_ADDRESS, 'This element should be empty')
+      assert(expiredIntents[3] == EMPTY_ADDRESS, 'This element should be empty')
     })
 
     it('Remove more intents after more time', async () => {
       // Advance time another 0.6 days
       // This advances past the expiry of Bob's and Eve's intents
       await advanceTimeAndBlock(SECONDS_IN_DAY * 0.6)
-      let intents = await market.fetchIntents(7)
-      // Returns 5 intents as Bob and Eve have not been removed
-      assert(BN(intents.length).eq(5), 'Returned intents wrong length')
 
-      // Loop through, not including Bob and Eve
-      await market.cleanExpiredIntents(davidAddress, 3)
+      // Now loop through, both Bob and Eve should be returned
+      let expiredIntents = await market.findExpiredIntents.call(bobAddress, 2)
 
-      // no intents have been removed
-      intents = await market.fetchIntents(7)
-      assert(BN(intents.length).eq(5), 'Intents should be same length')
+      assert(BN(expiredIntents.length).eq(2), 'Array length should be 2')
 
-      // Now loop through, removing both in one go
-      await market.cleanExpiredIntents(bobAddress, 2)
-
-      intents = await market.fetchIntents(7)
-      // Returns just 3 intents this time
-      assert(BN(intents.length).eq(3), 'Intents should be shorter')
-
-      // Ensure that the ordering is the same
-      assert(intents[0] == aliceLocator, 'Alice should be first')
-      assert(intents[1] == davidLocator, 'David should be fourth')
-      assert(intents[2] == zaraLocator, 'Zara should be fifth')
+      assert(expiredIntents[0] == bobAddress, 'Bob should be listed')
+      assert(expiredIntents[1] == eveAddress, 'Eve should be listed')
     })
   })
 })


### PR DESCRIPTION
### Description

Cleaning expired intents wasn't returning staked tokens to stakers. The cleaning function has been moved to the indexer, so that such unstaking happens.

## Summary of changes:
- Market now has `findExpiredIntents` that returns an array of expired stakers
- Indexer has a `cleanExpiredIntents` function that calls `findExpiredIntents`, and then removes each of these staker's intents
- Pulled out common unstaking functionality from `unsetIntent` and `cleanExpiredIntents` into one function `removeIntent`

## Coverage
```
--------------|----------|----------|----------|----------|----------------|
File          |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------|----------|----------|----------|----------|----------------|
  Indexer.sol |      100 |      100 |      100 |      100 |
  Market.sol  |      100 |      100 |      100 |      100 |
```