### PR TITLE
Removing unnecessary payable keywords

### DIFF
--- a/protocols/peer/README.md
+++ b/protocols/peer/README.md
@@ -211,7 +211,7 @@ function provideOrder(
   uint8 v,
   bytes32 r,
   bytes32 s
-) public payable
+) public
 ```
 
 ### Params
@@ -249,7 +249,7 @@ function provideUnsignedOrder(
   address consumerToken,
   uint256 peerAmount,
   address peerToken
-) public payable
+) public
 ```
 
 ### Params

--- a/protocols/peer/contracts/Peer.sol
+++ b/protocols/peer/contracts/Peer.sol
@@ -227,9 +227,7 @@ contract Peer is IPeer, Ownable {
     uint8 v,
     bytes32 r,
     bytes32 s
-  ) public payable {
-
-    // TODO: Forward the message value (for ETH trades) and add tests.
+  ) public {
 
     Rule memory rule = rules[peerToken][consumerToken];
 
@@ -283,9 +281,7 @@ contract Peer is IPeer, Ownable {
     address consumerToken,
     uint256 peerAmount,
     address peerToken
-  ) public payable {
-
-    // TODO: Forward the message value (for ETH trades) and add tests.
+  ) public {
 
     provideOrder(
       nonce,

--- a/protocols/peer/interfaces/IPeer.sol
+++ b/protocols/peer/interfaces/IPeer.sol
@@ -89,7 +89,7 @@ interface IPeer {
     uint8 _v,
     bytes32 _r,
     bytes32 _s
-  ) external payable;
+  ) external;
 
   function provideUnsignedOrder(
     uint256 _nonce,
@@ -97,5 +97,5 @@ interface IPeer {
     address _consumerToken,
     uint256 _peerAmount,
     address _peerToken
-  ) external payable;
+  ) external;
 }

--- a/protocols/swap/MIGRATION.md
+++ b/protocols/swap/MIGRATION.md
@@ -110,7 +110,7 @@ function swapSimple(
   uint8 _v,
   bytes32 _r,
   bytes32 _s
-) external payable
+) external
 ```
 
 A successful `swapSimple` transaction will emit a `Swap` event.

--- a/protocols/swap/README.md
+++ b/protocols/swap/README.md
@@ -61,7 +61,7 @@ Swap between tokens (ERC-20 or ERC-721) or ETH with all features using typed dat
 function swap(
   Types.Order calldata _order,
   Types.Signature calldata _signature
-) external payable
+) external
 ```
 
 ### Params
@@ -102,19 +102,19 @@ struct Signature {
 
 ### Reverts
 
-| Reason                         | Scenario                                                                     |
-| :----------------------------- | :--------------------------------------------------------------------------- |
-| `SIGNER_UNAUTHORIZED`          | Order has been signed by an account that has not been authorized to sign it. |
-| `SIGNATURE_INVALID`            | Signature provided does not match the Order provided.                        |
-| `ORDER_ALREADY_TAKEN`          | Order has already been taken by its `nonce` value.                           |
-| `ORDER_ALREADY_CANCELED`       | Order has already been canceled by its `nonce` value.                        |
-| `ORDER_EXPIRED`                | Order has an `expiry` lower than the current block time.                     |
-| `NONCE_TOO_LOW`                | Nonce provided is below the minimum value set.                               |
-| `SENDER_UNAUTHORIZED`          | Order has been sent by an account that has not been authorized to send it.   |
-| `VALUE_MUST_BE_SENT`           | Order indicates an ether Swap but insufficient ether was sent.               |
-| `VALUE_MUST_BE_ZERO`           | Order indicates a token Swap but ether was sent.                             |
-| `INVALID_AUTH_DELEGATE`        | Delegate address is the same as the sender address.                          |
-| `INVALID_AUTH_EXPIRY`          | Authorization expiry time is in the past.                                    |
+| Reason                   | Scenario                                                                     |
+| :----------------------- | :--------------------------------------------------------------------------- |
+| `SIGNER_UNAUTHORIZED`    | Order has been signed by an account that has not been authorized to sign it. |
+| `SIGNATURE_INVALID`      | Signature provided does not match the Order provided.                        |
+| `ORDER_ALREADY_TAKEN`    | Order has already been taken by its `nonce` value.                           |
+| `ORDER_ALREADY_CANCELED` | Order has already been canceled by its `nonce` value.                        |
+| `ORDER_EXPIRED`          | Order has an `expiry` lower than the current block time.                     |
+| `NONCE_TOO_LOW`          | Nonce provided is below the minimum value set.                               |
+| `SENDER_UNAUTHORIZED`    | Order has been sent by an account that has not been authorized to send it.   |
+| `VALUE_MUST_BE_SENT`     | Order indicates an ether Swap but insufficient ether was sent.               |
+| `VALUE_MUST_BE_ZERO`     | Order indicates a token Swap but ether was sent.                             |
+| `INVALID_AUTH_DELEGATE`  | Delegate address is the same as the sender address.                          |
+| `INVALID_AUTH_EXPIRY`    | Authorization expiry time is in the past.                                    |
 
 ## Swap (Simple)
 
@@ -133,7 +133,7 @@ function swapSimple(
   uint8 _v,
   bytes32 _r,
   bytes32 _s
-) external payable
+) external
 ```
 
 ### Params


### PR DESCRIPTION
Peers are no longer payable because `Swap` is not payable.

Updating `Peer`, `IPeer`, and documentation.