### PR TITLE
Reduce Indexer Code

### DIFF
--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -171,7 +171,19 @@ contract Indexer is IIndexer, Ownable {
     require(markets[_makerToken][_takerToken] != Market(0),
       "MARKET_DOES_NOT_EXIST");
 
-    removeIntent(_makerToken, _takerToken, msg.sender);
+    // Get the intent for the sender.
+    Market.Intent memory intent = markets[_makerToken][_takerToken].getIntent(_staker);
+
+    // Ensure the intent exists.
+    require(intent.staker == _staker,
+      "INTENT_DOES_NOT_EXIST");
+
+    // Unset the intent on the market.
+    markets[_makerToken][_takerToken].unsetIntent(_staker);
+
+    // Return the staked tokens.
+    stakeToken.transfer(_staker, intent.amount);
+    emit Unstake(_staker, _makerToken, _takerToken, intent.amount);
   }
 
   /**
@@ -204,32 +216,4 @@ contract Indexer is IIndexer, Ownable {
     }
     return new bytes32[](0);
   }
-
-  /**
-    * @notice Removes stakers' intents from a market
-    *
-    * @param _makerToken address
-    * @param _takerToken address
-    * @param _staker address
-    */
-  function removeIntent(
-    address _makerToken,
-    address _takerToken,
-    address _staker
-  ) internal {
-    // Get the intent for the sender.
-    Market.Intent memory intent = markets[_makerToken][_takerToken].getIntent(_staker);
-
-    // Ensure the intent exists.
-    require(intent.staker == _staker,
-      "INTENT_DOES_NOT_EXIST");
-
-    // Unset the intent on the market.
-    markets[_makerToken][_takerToken].unsetIntent(_staker);
-
-    // Return the staked tokens.
-    stakeToken.transfer(_staker, intent.amount);
-    emit Unstake(_staker, _makerToken, _takerToken, intent.amount);
-  }
-
 }

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -172,18 +172,18 @@ contract Indexer is IIndexer, Ownable {
       "MARKET_DOES_NOT_EXIST");
 
     // Get the intent for the sender.
-    Market.Intent memory intent = markets[_makerToken][_takerToken].getIntent(_staker);
+    Market.Intent memory intent = markets[_makerToken][_takerToken].getIntent(msg.sender);
 
     // Ensure the intent exists.
-    require(intent.staker == _staker,
+    require(intent.staker == msg.sender,
       "INTENT_DOES_NOT_EXIST");
 
     // Unset the intent on the market.
-    markets[_makerToken][_takerToken].unsetIntent(_staker);
+    markets[_makerToken][_takerToken].unsetIntent(msg.sender);
 
     // Return the staked tokens.
-    stakeToken.transfer(_staker, intent.amount);
-    emit Unstake(_staker, _makerToken, _takerToken, intent.amount);
+    stakeToken.transfer(msg.sender, intent.amount);
+    emit Unstake(msg.sender, _makerToken, _takerToken, intent.amount);
   }
 
   /**


### PR DESCRIPTION
![Screen Shot 2019-08-15 at 5 08 03 PM](https://user-images.githubusercontent.com/3590816/63127430-4d976f80-bf80-11e9-9136-e85331593e86.png)

`removeIntent` was only called by `unsetIntent` within `Indexer`. This removes the extraneous internal method 