### PR TITLE
Update Market and Indexer Logic

### DIFF
--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -143,11 +143,7 @@ contract Indexer is IIndexer, Ownable {
       // Transfer the _amount for staking.
       require(stakeToken.transferFrom(msg.sender, address(this), _amount),
         "UNABLE_TO_STAKE");
-
     }
-
-    require(!markets[_makerToken][_takerToken].hasIntent(msg.sender),
-      "USER_ALREADY_STAKED");
 
     emit Stake(msg.sender, _makerToken, _takerToken, _amount);
 

--- a/protocols/indexer/test/Indexer-unit.js
+++ b/protocols/indexer/test/Indexer-unit.js
@@ -358,7 +358,7 @@ contract('Indexer Unit Tests', async accounts => {
         indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
         }),
-        'USER_ALREADY_STAKED'
+        'USER_HAS_INTENT'
       )
     })
   })

--- a/protocols/market/contracts/Market.sol
+++ b/protocols/market/contracts/Market.sol
@@ -107,7 +107,7 @@ contract Market is Ownable {
     bytes32 _locator
   ) external onlyOwner {
 
-    require(!hasIntent(_staker), "USER_ALREADY_STAKED");
+    require(!hasIntent(_staker), "USER_HAS_INTENT");
 
     Intent memory newIntent = Intent(_staker, _amount, _locator);
 

--- a/protocols/market/contracts/Market.sol
+++ b/protocols/market/contracts/Market.sol
@@ -176,9 +176,6 @@ contract Market is Ownable {
     // Iterate over the list until the end or limit.
     uint256 i = 0;
     while (i < limit) {
-      if (intent.staker == HEAD) {
-        break;
-      }
       result[i] = intent.locator;
       i = i + 1;
       intent = intentsLinkedList[intent.staker][NEXT];

--- a/protocols/market/contracts/Market.sol
+++ b/protocols/market/contracts/Market.sol
@@ -106,6 +106,9 @@ contract Market is Ownable {
     uint256 _amount,
     bytes32 _locator
   ) external onlyOwner {
+
+    require(!hasIntent(_staker), "USER_ALREADY_STAKED");
+
     Intent memory newIntent = Intent(_staker, _amount, _locator);
 
     // Insert after the next highest amount on the linked list.
@@ -188,7 +191,7 @@ contract Market is Ownable {
     */
   function hasIntent(
     address _staker
-  ) public view returns (bool) {
+  ) internal view returns (bool) {
 
     if (intentsLinkedList[_staker][PREV].staker != address(0) &&
       intentsLinkedList[intentsLinkedList[_staker][PREV].staker][NEXT].staker == _staker) {

--- a/protocols/market/contracts/Market.sol
+++ b/protocols/market/contracts/Market.sol
@@ -191,7 +191,7 @@ contract Market is Ownable {
     */
   function hasIntent(
     address _staker
-  ) internal view returns (bool) {
+  ) public view returns (bool) {
 
     if (intentsLinkedList[_staker][PREV].staker != address(0) &&
       intentsLinkedList[intentsLinkedList[_staker][PREV].staker][NEXT].staker == _staker) {

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -358,4 +358,18 @@ contract('Market Unit Tests', async accounts => {
       equal(hasIntent, true, 'hasIntent should have returned true')
     })
   })
+
+  describe('Test multiple setting of intents from same addres', async () => {
+      it('should not increase the total number of intents', async () => {
+        await market.setIntent(aliceAddress, 2000, aliceLocator, {
+          from: owner,
+        })
+        await market.setIntent(aliceAddress, 5000, aliceLocator, {
+          from: owner,
+        })
+
+        let length = await market.length.call()
+        equal(length.toNumber(), 1, "length increased, but total stakers has not")
+      })
+  })
 })

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -170,7 +170,7 @@ contract('Market Unit Tests', async accounts => {
       trx = market.setIntent(aliceAddress, 5000, aliceLocator, {
         from: owner,
       })
-      await reverted(trx, 'USER_ALREADY_HAS_INTENT')
+      await reverted(trx, 'USER_HAS_INTENT')
 
       let length = await market.length.call()
       equal(length.toNumber(), 1, 'length increased, but total stakers has not')
@@ -248,6 +248,20 @@ contract('Market Unit Tests', async accounts => {
       await checkLinking(LIST_HEAD, LIST_HEAD, LIST_HEAD)
       listLength = await market.length()
       equal(listLength, 0, 'Link list length should be 0')
+    })
+
+    it('unsetting intent twice in a row for an address has no effect', async () => {
+      let trx = market.unsetIntent(bobAddress, { from: owner })
+      await passes(trx)
+      let size = await market.length.call()
+      equal(size, 2, "Intent was improperly removed")
+      trx = market.unsetIntent(bobAddress, { from: owner })
+      await passes(trx)
+      equal(size, 2, "Intent was improperly removed")
+
+      let intents = await market.fetchIntents(7)
+      equal(intents[0], aliceLocator, 'Alice should be first')
+      equal(intents[1], carolLocator, 'Carol should be second')
     })
   })
 
@@ -367,7 +381,7 @@ contract('Market Unit Tests', async accounts => {
       equal(hasIntent, false, 'hasIntent should have returned false')
     })
 
-    it('should return false if the address has no intent', async () => {
+    it('should return true if the address has an intent', async () => {
       // give alice an intent
       await market.setIntent(aliceAddress, 2000, aliceLocator, {
         from: owner,

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -161,6 +161,20 @@ contract('Market Unit Tests', async accounts => {
       equal(intents[1], carolLocator, 'Carol should be second')
       equal(intents[2], bobLocator, 'Bob should be third')
     })
+
+    it('user should not be able to set a second intent if one already exists', async () => {
+      let trx = market.setIntent(aliceAddress, 2000, aliceLocator, {
+        from: owner,
+      })
+      await passes(trx)
+      trx = market.setIntent(aliceAddress, 5000, aliceLocator, {
+        from: owner,
+      })
+      await reverted(trx, 'USER_ALREADY_HAS_INTENT')
+
+      let length = await market.length.call()
+      equal(length.toNumber(), 1, 'length increased, but total stakers has not')
+    })
   })
 
   describe('Test unsetIntent', async () => {
@@ -361,22 +375,6 @@ contract('Market Unit Tests', async accounts => {
       // now test again
       let hasIntent = await market.hasIntent(aliceAddress)
       equal(hasIntent, true, 'hasIntent should have returned true')
-    })
-  })
-
-  describe('Test multiple setting of intents from same address', async () => {
-    it('should not increase the total number of intents', async () => {
-      let trx = market.setIntent(aliceAddress, 2000, aliceLocator, {
-        from: owner,
-      })
-      await passes(trx)
-      trx = market.setIntent(aliceAddress, 5000, aliceLocator, {
-        from: owner,
-      })
-      await reverted(trx, 'USER_ALREADY_HAS_INTENT')
-
-      let length = await market.length.call()
-      equal(length.toNumber(), 1, 'length increased, but total stakers has not')
     })
   })
 })

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -254,10 +254,10 @@ contract('Market Unit Tests', async accounts => {
       let trx = market.unsetIntent(bobAddress, { from: owner })
       await passes(trx)
       let size = await market.length.call()
-      equal(size, 2, "Intent was improperly removed")
+      equal(size, 2, 'Intent was improperly removed')
       trx = market.unsetIntent(bobAddress, { from: owner })
       await passes(trx)
-      equal(size, 2, "Intent was improperly removed")
+      equal(size, 2, 'Intent was improperly removed')
 
       let intents = await market.fetchIntents(7)
       equal(intents[0], aliceLocator, 'Alice should be first')

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -1,6 +1,11 @@
 const Market = artifacts.require('Market')
 
-const { passes, equal, reverted, emitted } = require('@airswap/test-utils').assert
+const {
+  passes,
+  equal,
+  reverted,
+  emitted,
+} = require('@airswap/test-utils').assert
 const { takeSnapshot, revertToSnapShot } = require('@airswap/test-utils').time
 const { padAddressToLocator } = require('@airswap/test-utils').padding
 const { EMPTY_ADDRESS } = require('@airswap/order-utils').constants
@@ -360,18 +365,18 @@ contract('Market Unit Tests', async accounts => {
   })
 
   describe('Test multiple setting of intents from same addres', async () => {
-      it('should not increase the total number of intents', async () => {
-        let trx = market.setIntent(aliceAddress, 2000, aliceLocator, {
-          from: owner,
-        })
-        await passes(trx)
-        trx = market.setIntent(aliceAddress, 5000, aliceLocator, {
-          from: owner,
-        })
-        await reverted(trx, "USER_ALREADY_STAKED")
-
-        let length = await market.length.call()
-        equal(length.toNumber(), 1, "length increased, but total stakers has not")
+    it('should not increase the total number of intents', async () => {
+      let trx = market.setIntent(aliceAddress, 2000, aliceLocator, {
+        from: owner,
       })
+      await passes(trx)
+      trx = market.setIntent(aliceAddress, 5000, aliceLocator, {
+        from: owner,
+      })
+      await reverted(trx, 'USER_ALREADY_STAKED')
+
+      let length = await market.length.call()
+      equal(length.toNumber(), 1, 'length increased, but total stakers has not')
+    })
   })
 })

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -162,7 +162,7 @@ contract('Market Unit Tests', async accounts => {
       equal(intents[2], bobLocator, 'Bob should be third')
     })
 
-    it('user should not be able to set a second intent if one already exists', async () => {
+    it('should not be able to set a second intent if one already exists for an address', async () => {
       let trx = market.setIntent(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -364,7 +364,7 @@ contract('Market Unit Tests', async accounts => {
     })
   })
 
-  describe('Test multiple setting of intents from same addres', async () => {
+  describe('Test multiple setting of intents from same address', async () => {
     it('should not increase the total number of intents', async () => {
       let trx = market.setIntent(aliceAddress, 2000, aliceLocator, {
         from: owner,

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -1,6 +1,6 @@
 const Market = artifacts.require('Market')
 
-const { equal, reverted, emitted } = require('@airswap/test-utils').assert
+const { passes, equal, reverted, emitted } = require('@airswap/test-utils').assert
 const { takeSnapshot, revertToSnapShot } = require('@airswap/test-utils').time
 const { padAddressToLocator } = require('@airswap/test-utils').padding
 const { EMPTY_ADDRESS } = require('@airswap/order-utils').constants
@@ -361,12 +361,14 @@ contract('Market Unit Tests', async accounts => {
 
   describe('Test multiple setting of intents from same addres', async () => {
       it('should not increase the total number of intents', async () => {
-        await market.setIntent(aliceAddress, 2000, aliceLocator, {
+        let trx = market.setIntent(aliceAddress, 2000, aliceLocator, {
           from: owner,
         })
-        await market.setIntent(aliceAddress, 5000, aliceLocator, {
+        await passes(trx)
+        trx = market.setIntent(aliceAddress, 5000, aliceLocator, {
           from: owner,
         })
+        await reverted(trx, "USER_ALREADY_STAKED")
 
         let length = await market.length.call()
         equal(length.toNumber(), 1, "length increased, but total stakers has not")

--- a/protocols/market/test/Market-unit.js
+++ b/protocols/market/test/Market-unit.js
@@ -373,7 +373,7 @@ contract('Market Unit Tests', async accounts => {
       trx = market.setIntent(aliceAddress, 5000, aliceLocator, {
         from: owner,
       })
-      await reverted(trx, 'USER_ALREADY_STAKED')
+      await reverted(trx, 'USER_ALREADY_HAS_INTENT')
 
       let length = await market.length.call()
       equal(length.toNumber(), 1, 'length increased, but total stakers has not')


### PR DESCRIPTION
## Description
- Market is coupled to Indexer and intended to be used by the indexer. It is a specialized LL.
- The conditional check in Indexer that check if an intent exists and reverts should be placed into Market.
- Market will continue to sets intents by staker address. Additional logic will now exist if a staker tries to provide another intent, the staking will revert. This keeps with the old design.
- In order to update their intent a stake will need to first remove their old intent and then set a new intent

## Changes
- Update the market so that if a sender were to stake another intent that it will fail. This logic is being moved out of indexer
- Update market and indexer tests to reflect these changes
- Write tests that ensure that the underlying linked list structure has not been compromised. 