### PR TITLE
Indexer Analysis

### DIFF
--- a/analysis_indexer/IERC20.sol
+++ b/analysis_indexer/IERC20.sol
@@ -1,0 +1,76 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP. Does not include
+ * the optional functions; to access them see `ERC20Detailed`.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a `Transfer` event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through `transferFrom`. This is
+     * zero by default.
+     *
+     * This value changes when `approve` or `transferFrom` are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * > Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an `Approval` event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a `Transfer` event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to `approve`. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/analysis_indexer/IIndexer.sol
+++ b/analysis_indexer/IIndexer.sol
@@ -1,0 +1,82 @@
+/*
+  Copyright 2019 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+pragma solidity 0.5.10;
+
+interface IIndexer {
+
+  event CreateMarket(
+    address makerToken,
+    address takerToken
+  );
+
+  event Stake(
+    address wallet,
+    address makerToken,
+    address takerToken,
+    uint256 amount
+  );
+
+  event Unstake(
+    address wallet,
+    address makerToken,
+    address takerToken,
+    uint256 amount
+  );
+
+  event AddToBlacklist(
+    address token
+  );
+
+  event RemoveFromBlacklist(
+    address token
+  );
+
+  function markets(address, address) external returns (address);
+  function blacklist(address) external returns (bool);
+
+  function createMarket(
+    address _makerToken,
+    address _takerToken
+  ) external returns (address);
+
+  function addToBlacklist(
+    address[] calldata _tokens
+  ) external;
+
+  function removeFromBlacklist(
+    address[] calldata _tokens
+  ) external;
+
+  function setIntent(
+    address _makerToken,
+    address _takerToken,
+    uint256 _amount,
+    bytes32 _locator
+  ) external;
+
+  function unsetIntent(
+    address _makerToken,
+    address _takerToken
+  ) external;
+
+  function getIntents(
+    address _makerToken,
+    address _takerToken,
+    uint256 _count
+  ) external returns (bytes32[] memory);
+
+}

--- a/analysis_indexer/ILocatorWhitelist.sol
+++ b/analysis_indexer/ILocatorWhitelist.sol
@@ -1,0 +1,25 @@
+/*
+  Copyright 2019 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+pragma solidity 0.5.10;
+
+interface ILocatorWhitelist {
+
+  function has(
+    bytes32 _locator
+  ) external returns (bool);
+
+}

--- a/analysis_indexer/Indexer.sol
+++ b/analysis_indexer/Indexer.sol
@@ -1,0 +1,219 @@
+/*
+  Copyright 2019 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+pragma solidity 0.5.10;
+pragma experimental ABIEncoderV2;
+
+import "./IIndexer.sol";
+import "./ILocatorWhitelist.sol";
+import "./Market.sol";
+import "./IERC20.sol";
+import "./Ownable.sol";
+
+/**
+  * @title Indexer: A Collection of Markets by Token Pair
+  */
+contract Indexer is IIndexer, Ownable {
+
+  // Token to be used for staking (ERC-20)
+  IERC20 public stakeToken;
+
+  // Mapping of maker token to taker token to market
+  mapping (address => mapping (address => Market)) public markets;
+
+  // Mapping of token address to boolean
+  mapping (address => bool) public blacklist;
+
+  // The whitelist contract for checking whether a peer is whitelisted
+  address public locatorWhitelist;
+
+  /**
+    * @notice Contract Constructor
+    *
+    * @param _stakeToken address
+    * @param _locatorWhitelist address
+    */
+  constructor(
+    address _stakeToken,
+    address _locatorWhitelist
+  ) public {
+    stakeToken = IERC20(_stakeToken);
+    locatorWhitelist = _locatorWhitelist;
+  }
+
+  /**
+    * @notice Create a Market (Collection of Intents to Trade)
+    * @dev Deploys a new Market contract and tracks the address
+    *
+    * @param _makerToken address
+    * @param _takerToken address
+    */
+  function createMarket(
+    address _makerToken,
+    address _takerToken
+  ) external returns (address) {
+
+    // If the Market does not exist, create it.
+    if (markets[_makerToken][_takerToken] == Market(0)) {
+      // Create a new Market contract for the token pair.
+      markets[_makerToken][_takerToken] = new Market(_makerToken, _takerToken);
+      emit CreateMarket(_makerToken, _takerToken);
+    }
+
+    // Return the address of the Market contract.
+    return address(markets[_makerToken][_takerToken]);
+  }
+
+  /**
+    * @notice Add a Token to the Blacklist
+    * @param _tokens address[]
+    */
+  function addToBlacklist(
+    address[] calldata _tokens
+  ) external onlyOwner {
+    for (uint256 i = 0; i < _tokens.length; i++) {
+      if (blacklist[_tokens[i]] == false) {
+        blacklist[_tokens[i]] = true;
+        emit AddToBlacklist(_tokens[i]);
+      }
+    }
+  }
+
+  /**
+    * @notice Remove a Token from the Blacklist
+    * @param _tokens address[]
+    */
+  function removeFromBlacklist(
+    address[] calldata _tokens
+  ) external onlyOwner {
+    for (uint256 i = 0; i < _tokens.length; i++) {
+      if (blacklist[_tokens[i]] == true) {
+        blacklist[_tokens[i]] = false;
+        emit RemoveFromBlacklist(_tokens[i]);
+      }
+    }
+  }
+
+  /**
+    * @notice Set an Intent to Trade
+    * @dev Requires approval to transfer staking token for sender
+    *
+    * @param _makerToken address
+    * @param _takerToken address
+    * @param _amount uint256
+    * @param _locator bytes32
+    */
+  function setIntent(
+    address _makerToken,
+    address _takerToken,
+    uint256 _amount,
+    bytes32 _locator
+  ) external {
+
+    // Ensure the locator is whitelisted, if relevant
+    if (locatorWhitelist != address(0)) {
+      require(ILocatorWhitelist(locatorWhitelist).has(_locator),
+      "LOCATOR_NOT_WHITELISTED");
+    }
+
+    // Ensure both of the tokens are not blacklisted.
+    require(!blacklist[_makerToken] && !blacklist[_takerToken],
+      "MARKET_IS_BLACKLISTED");
+
+    // Ensure the market exists.
+    require(markets[_makerToken][_takerToken] != Market(0),
+      "MARKET_DOES_NOT_EXIST");
+
+    // Only transfer for staking if amount is set.
+    if (_amount > 0) {
+
+      // Transfer the _amount for staking.
+      require(stakeToken.transferFrom(msg.sender, address(this), _amount),
+        "UNABLE_TO_STAKE");
+
+    }
+
+    require(!markets[_makerToken][_takerToken].hasIntent(msg.sender),
+      "USER_ALREADY_STAKED");
+
+    emit Stake(msg.sender, _makerToken, _takerToken, _amount);
+
+    // Set the intent on the market.
+    markets[_makerToken][_takerToken].setIntent(msg.sender, _amount, _locator);
+  }
+
+  /**
+    * @notice Unset an Intent to Trade
+    * @dev Users are allowed unstake from blacklisted markets
+    *
+    * @param _makerToken address
+    * @param _takerToken address
+    */
+  function unsetIntent(
+    address _makerToken,
+    address _takerToken
+  ) external {
+
+    // Ensure the market exists.
+    require(markets[_makerToken][_takerToken] != Market(0),
+      "MARKET_DOES_NOT_EXIST");
+
+    // Get the intent for the sender.
+    Market.Intent memory intent = markets[_makerToken][_takerToken].getIntent(msg.sender);
+
+    // Ensure the intent exists.
+    require(intent.staker == msg.sender,
+      "INTENT_DOES_NOT_EXIST");
+
+    // Unset the intent on the market.
+    require(markets[_makerToken][_takerToken].unsetIntent(msg.sender));
+
+    // Return the staked tokens.
+    require(stakeToken.transfer(msg.sender, intent.amount));
+    emit Unstake(msg.sender, _makerToken, _takerToken, intent.amount);
+  }
+
+  /**
+    * @notice Get the Intents to Trade for a Market
+    * @dev Users are allowed unstake from blacklisted markets
+    *
+    * @param _makerToken address
+    * @param _takerToken address
+    * @param _count uint256
+    * @return locators address[]
+    */
+  function getIntents(
+    address _makerToken,
+    address _takerToken,
+    uint256 _count
+  ) external returns (
+    bytes32[] memory locators
+  ) {
+
+    // Ensure neither token is blacklisted.
+    if (!blacklist[_makerToken] && !blacklist[_takerToken]) {
+
+      // Ensure the market exists.
+      if (markets[_makerToken][_takerToken] != Market(0)) {
+
+        // Return an array of locators for the market.
+        return markets[_makerToken][_takerToken].fetchIntents(_count);
+
+      }
+    }
+    return new bytes32[](0);
+  }
+}

--- a/analysis_indexer/Market.sol
+++ b/analysis_indexer/Market.sol
@@ -1,0 +1,273 @@
+/*
+  Copyright 2019 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+pragma solidity 0.5.10;
+pragma experimental ABIEncoderV2;
+
+import "./Ownable.sol";
+
+/**
+  * @title Market: A List of Intents to Trade
+  */
+contract Market is Ownable {
+
+  // Token pair of the market
+  address public makerToken;
+  address public takerToken;
+
+  // Length of the linked list
+  uint256 public length;
+
+  // Maximum address value to indicate the head
+  address private constant HEAD = address(uint160(2**160-1));
+
+  // Byte values to map to the previous and next
+  byte constant private PREV = 0x00;
+  byte constant private NEXT = 0x01;
+
+  // Mapping of staker address to its neighbors
+  mapping(address => mapping(byte => Intent)) public intentsLinkedList;
+
+  /**
+    * @notice Intent to Trade
+    *
+    * @param staker address
+    * @param amount uint256
+    * @param locator bytes32
+    */
+  struct Intent {
+    address staker;
+    uint256 amount;
+    bytes32 locator;
+  }
+
+  /**
+    * @notice Contract Events
+    * @dev Emitted with successful state changes
+    */
+
+  event SetIntent(
+    address staker,
+    uint256 amount,
+    bytes32 locator,
+    address makerToken,
+    address takerToken
+  );
+
+  event UnsetIntent(
+    address staker,
+    address makerToken,
+    address takerToken
+  );
+
+  /**
+    * @notice Contract Constructor
+    *
+    * @param _makerToken address
+    * @param _takerToken address
+    */
+  constructor(
+    address _makerToken,
+    address _takerToken
+  ) public {
+
+    // Set the token pair of the market.
+    makerToken = _makerToken;
+    takerToken = _takerToken;
+
+    // Initialize the linked list.
+    Intent memory head = Intent(HEAD, 0, bytes32(0));
+    intentsLinkedList[HEAD][PREV] = head;
+    intentsLinkedList[HEAD][NEXT] = head;
+  }
+
+  /**
+    * @notice Set an Intent to Trade
+    *
+    * @param _staker The account
+    * @param _amount uint256
+    * @param _locator bytes32
+    */
+  function setIntent(
+    address _staker,
+    uint256 _amount,
+    bytes32 _locator
+  ) external onlyOwner {
+    Intent memory newIntent = Intent(_staker, _amount, _locator);
+
+    // Insert after the next highest amount on the linked list.
+    insertIntent(newIntent, findPosition(_amount));
+      // Increment the length of the linked list if successful.
+    length = length + 1;
+
+    emit SetIntent(_staker, _amount, _locator, makerToken, takerToken);
+  }
+
+  /**
+    * @notice Unset an Intent to Trade
+    * @param _staker address
+    */
+  function unsetIntent(
+    address _staker
+  ) external onlyOwner returns (bool) {
+
+    // Ensure the _staker is in the linked list.
+    if (!hasIntent(_staker)) {
+      return false;
+    }
+
+    removeIntent(_staker);
+
+    emit UnsetIntent(_staker, makerToken, takerToken);
+    return true;
+  }
+
+  /**
+    * @notice Get the Intent for a Staker
+    * @param _staker address
+    */
+  function getIntent(
+    address _staker
+  ) external view returns (Intent memory) {
+
+    // Ensure the staker has a neighbor in the linked list.
+    if (intentsLinkedList[_staker][PREV].staker != address(0)) {
+
+      // Return the next intent from the previous neighbor.
+      return intentsLinkedList[intentsLinkedList[_staker][PREV].staker][NEXT];
+    }
+    return Intent(address(0), 0, bytes32(0));
+  }
+
+  /**
+    * @notice Get Valid Intents
+    * @param _count uint256
+    */
+  function fetchIntents(
+    uint256 _count
+  ) external view returns (bytes32[] memory result) {
+
+    // Limit results to list length or _count.
+    uint256 limit = length;
+    if (_count < length) {
+      limit = _count;
+    }
+    result = new bytes32[](limit);
+
+    // Get the first intent in the linked list after the HEAD
+    Intent storage intent = intentsLinkedList[HEAD][NEXT];
+
+    // Iterate over the list until the end or limit.
+    uint256 i = 0;
+    while (i < limit) {
+      if (intent.staker == HEAD) {
+        break;
+      }
+      result[i] = intent.locator;
+      i = i + 1;
+      intent = intentsLinkedList[intent.staker][NEXT];
+    }
+  }
+
+  /**
+    * @notice Determine Whether a Staker is in the Linked List
+    * @param _staker address
+    */
+  function hasIntent(
+    address _staker
+  ) public view returns (bool) {
+
+    if (intentsLinkedList[_staker][PREV].staker != address(0) &&
+      intentsLinkedList[intentsLinkedList[_staker][PREV].staker][NEXT].staker == _staker) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+    * @notice Returns the first intent smaller than _amount
+    * @param _amount uint256
+    */
+  function findPosition(
+    uint256 _amount
+  ) internal view returns (Intent memory) {
+
+    // Get the first intent in the linked list.
+    Intent storage intent = intentsLinkedList[HEAD][NEXT];
+
+    if (_amount == 0) {
+      // return the head of the linked list
+      return intentsLinkedList[intent.staker][PREV];
+    }
+
+    // Iterate through the list until a lower amount is found.
+    while (_amount <= intent.amount) {
+      intent = intentsLinkedList[intent.staker][NEXT];
+    }
+    return intent;
+  }
+
+  /**
+    * @notice Insert a new intent in the linked list, before the specified _nextIntent
+    *
+    * @param _newIntent Intent to be inserted
+    * @param _nextIntent Intent to follow _newIntent
+    */
+  function insertIntent(
+    Intent memory _newIntent,
+    Intent memory _nextIntent
+  ) internal {
+
+    // Get the intent before the _nextIntent.
+    Intent memory previousIntent = intentsLinkedList[_nextIntent.staker][PREV];
+
+    // Link the _newIntent into place.
+    link(previousIntent, _newIntent);
+    link(_newIntent, _nextIntent);
+  }
+
+  /**
+    * @notice Link Two Intents
+    *
+    * @param _left Intent
+    * @param _right Intent
+    */
+  function link(
+    Intent memory _left,
+    Intent memory _right
+  ) internal {
+    intentsLinkedList[_left.staker][NEXT] = _right;
+    intentsLinkedList[_right.staker][PREV] = _left;
+  }
+
+  /**
+    * @notice Removes a specified staker from the linked list
+    *
+    * @param _staker the staker in question
+    */
+  function removeIntent(address _staker) internal {
+    // Link its neighbors together.
+    link(intentsLinkedList[_staker][PREV], intentsLinkedList[_staker][NEXT]);
+
+    // Delete staker from the list.
+    delete intentsLinkedList[_staker][PREV];
+    delete intentsLinkedList[_staker][NEXT];
+
+    // Decrement the length of the linked list.
+    length = length - 1;
+  }
+
+}

--- a/analysis_indexer/Ownable.sol
+++ b/analysis_indexer/Ownable.sol
@@ -1,0 +1,75 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be aplied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor () internal {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), _owner);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Returns true if the caller is the current owner.
+     */
+    function isOwner() public view returns (bool) {
+        return msg.sender == _owner;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * > Note: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     */
+    function _transferOwnership(address newOwner) internal {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}


### PR DESCRIPTION
```
docker run -it -v `pwd`:/src trailofbits/eth-security-toolbox
cd /src
solc-select 0.5.10
```
### Slither
```javascript
slither Indexer.sol --exclude naming-convention
Compilation warnings/errors on Indexer.sol:
Market.sol:18:1: Warning: Experimental features are turned on. Do not use experimental features on live deployments.
pragma experimental ABIEncoderV2;
^-------------------------------^
Indexer.sol:18:1: Warning: Experimental features are turned on. Do not use experimental features on live deployments.
pragma experimental ABIEncoderV2;
^-------------------------------^

INFO:Detectors:
Different versions of Solidity is used in :
	- Version used: ['0.5.10', 'ABIEncoderV2', '^0.5.0']
	- IERC20.sol#1 declares pragma solidity^0.5.0
	- IIndexer.sol#17 declares pragma solidity0.5.10
	- ILocatorWhitelist.sol#17 declares pragma solidity0.5.10
	- Indexer.sol#17 declares pragma solidity0.5.10
	- Indexer.sol#18 declares pragma experimentalABIEncoderV2
	- Market.sol#17 declares pragma solidity0.5.10
	- Market.sol#18 declares pragma experimentalABIEncoderV2
	- Ownable.sol#1 declares pragma solidity^0.5.0
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#different-pragma-directives-are-used
INFO:Detectors:
Pragma version "^0.5.0" allows old versions (IERC20.sol#1)
Pragma version "0.5.10" necessitates versions too recent to be trusted. Consider deploying with 0.5.3 (IIndexer.sol#17)
Pragma version "0.5.10" necessitates versions too recent to be trusted. Consider deploying with 0.5.3 (ILocatorWhitelist.sol#17)
Pragma version "0.5.10" necessitates versions too recent to be trusted. Consider deploying with 0.5.3 (Indexer.sol#17)
Pragma version "0.5.10" necessitates versions too recent to be trusted. Consider deploying with 0.5.3 (Market.sol#17)
Pragma version "^0.5.0" allows old versions (Ownable.sol#1)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity
INFO:Detectors:
Ownable.owner() (Ownable.sol#28-30) should be declared external
Ownable.renounceOwnership() (Ownable.sol#54-57) should be declared external
Ownable.transferOwnership(address) (Ownable.sol#63-65) should be declared external
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#public-function-that-could-be-declared-as-external
INFO:Slither:Indexer.sol analyzed (6 contracts), 10 result(s) found
```