### PR TITLE
Migrating Peer from swapSimple to swap

### DIFF
--- a/protocols/peer/README.md
+++ b/protocols/peer/README.md
@@ -19,13 +19,13 @@ Send up to a maximum amount of a token.
 
 ## Definitions
 
-| Term              | Definition                                                  |
-| :---------------- | :---------------------------------------------------------- |
-| Peer              | Smart contract that trades based on rules.                  |
-| Consumer          | A party that gets quotes from and sends orders to the Peer. |
-| Rule              | An amount of tokens to trade at a specific price.           |
-| Price Coefficient | The significant digits of the price.                        |
-| Price Exponent    | The location of the decimal on the price.                   |
+| Term              | Definition                                                                 |
+| :---------------- | :------------------------------------------------------------------------- |
+| Peer              | Smart contract that trades based on rules. Acts as taker.                  |
+| Consumer          | A party that gets quotes from and sends orders to the Peer. Acts as maker. |
+| Rule              | An amount of tokens to trade at a specific price.                          |
+| Price Coefficient | The significant digits of the price.                                       |
+| Price Exponent    | The location of the decimal on the price.                                  |
 
 ## Constructor
 
@@ -47,7 +47,7 @@ constructor(
 
 ## Price Calculations
 
-All amounts are in the smallest unit (e.g. wei), so all calculations based on price result in a whole number. For calculations that would result in a decimal, the amount is automatically floored by dropping the decimal. For example, a price of `5.25` and `peerAmount` of `2` results in `consumerAmount` of `10` rather than `10.5`. Tokens have many decimal places so these differences are very small.
+All amounts are in the smallest unit (e.g. wei), so all calculations based on price result in a whole number. For calculations that would result in a decimal, the amount is automatically floored by dropping the decimal. For example, a price of `5.25` and `takerAmount` of `2` results in `makerAmount` of `10` rather than `10.5`. Tokens have many decimal places so these differences are very small.
 
 ## Set a Rule
 
@@ -55,23 +55,23 @@ Set a trading rule for the Peer.
 
 ```Solidity
 function setRule(
-  address peerToken,
-  address consumerToken,
-  uint256 maxPeerAmount,
-  uint256 priceCoef,
-  uint256 priceExp
+  address _takerToken,
+  address _makerToken,
+  uint256 _maxTakerAmount,
+  uint256 _priceCoef,
+  uint256 _priceExp
 ) external onlyOwner
 ```
 
 ### Params
 
-| Name            | Type      | Description                                                    |
-| :-------------- | :-------- | :------------------------------------------------------------- |
-| `peerToken`     | `address` | The token that the peer would send in a trade.                 |
-| `consumerToken` | `address` | The token that the consumer would send in a trade.             |
-| `maxPeerAmount` | `uint256` | The maximum amount of token the peer would send.               |
-| `priceCoef`     | `uint256` | The coefficient of the price to indicate the whole number.     |
-| `priceExp`      | `uint256` | The exponent of the price to indicate location of the decimal. |
+| Name              | Type      | Description                                                    |
+| :---------------- | :-------- | :------------------------------------------------------------- |
+| `_takerToken`     | `address` | The token that the peer would send in a trade.                 |
+| `_makerToken`     | `address` | The token that the consumer would send in a trade.             |
+| `_maxTakerAmount` | `uint256` | The maximum amount of token the peer would send.               |
+| `_priceCoef`      | `uint256` | The coefficient of the price to indicate the whole number.     |
+| `_priceExp`       | `uint256` | The exponent of the price to indicate location of the decimal. |
 
 ### Example
 
@@ -99,17 +99,17 @@ Unset a trading rule for the Peer.
 
 ```Solidity
 function unsetRule(
-  address peerToken,
-  address consumerToken
+  address _takerToken,
+  address _makerToken
 ) external onlyOwner
 ```
 
 ### Params
 
-| Name            | Type      | Description                                        |
-| :-------------- | :-------- | :------------------------------------------------- |
-| `peerToken`     | `address` | The token that the Peer would send in a trade.     |
-| `consumerToken` | `address` | The token that the Consumer would send in a trade. |
+| Name          | Type      | Description                                        |
+| :------------ | :-------- | :------------------------------------------------- |
+| `_takerToken` | `address` | The token that the Peer would send in a trade.     |
+| `_makerToken` | `address` | The token that the Consumer would send in a trade. |
 
 ## Get a Buy Quote
 
@@ -117,21 +117,21 @@ Get a quote to buy from the Peer.
 
 ```Solidity
 function getBuyQuote(
-  uint256 peerAmount,
-  address peerToken,
-  address consumerToken
+  uint256 _takerAmount,
+  address _takerToken,
+  address _makerToken
 ) external view returns (
-  uint256 consumerAmount
+  uint256 _makerAmount
 )
 ```
 
 ### Params
 
-| Name            | Type      | Description                             |
-| :-------------- | :-------- | :-------------------------------------- |
-| `peerAmount`    | `uint256` | The amount the Peer would send.         |
-| `peerToken`     | `address` | The token that the Peer would send.     |
-| `consumerToken` | `address` | The token that the Consumer would send. |
+| Name           | Type      | Description                             |
+| :------------- | :-------- | :-------------------------------------- |
+| `_takerAmount` | `uint256` | The amount the Peer would send.         |
+| `_takerToken`  | `address` | The token that the Peer would send.     |
+| `_makerToken`  | `address` | The token that the Consumer would send. |
 
 ### Reverts
 
@@ -146,19 +146,19 @@ Get a quote to sell from the Peer.
 
 ```Solidity
 function getSellQuote(
-  uint256 consumerAmount,
-  address consumerToken,
-  address peerToken
+  uint256 _makerAmount,
+  address _makerToken,
+  address _takerToken
 ) external view returns (uint256)
 ```
 
 ### Params
 
-| Name             | Type      | Description                            |
-| :--------------- | :-------- | :------------------------------------- |
-| `consumerAmount` | `uint256` | The amount the Consumer would send.    |
-| `consumerToken`  | `address` | The token that the Consumer will send. |
-| `peerToken`      | `address` | The token that the Peer will send.     |
+| Name           | Type      | Description                            |
+| :------------- | :-------- | :------------------------------------- |
+| `_makerAmount` | `uint256` | The amount the Consumer would send.    |
+| `_makerToken`  | `address` | The token that the Consumer will send. |
+| `_takerToken`  | `address` | The token that the Peer will send.     |
 
 ### Reverts
 
@@ -173,20 +173,20 @@ Get the maximum quote from the Peer.
 
 ```Solidity
 function getMaxQuote(
-  address peerToken,
-  address consumerToken
+  address _takerToken,
+  address _makerToken
 ) external view returns (
-  uint256 peerAmount,
-  uint256 consumerAmount
+  uint256 _takerAmount,
+  uint256 _makerAmount
 )
 ```
 
 ### Params
 
-| Name            | Type      | Description                            |
-| :-------------- | :-------- | :------------------------------------- |
-| `peerToken`     | `address` | The token that the Peer will send.     |
-| `consumerToken` | `address` | The token that the Consumer will send. |
+| Name          | Type      | Description                            |
+| :------------ | :-------- | :------------------------------------- |
+| `_takerToken` | `address` | The token that the Peer will send.     |
+| `_makerToken` | `address` | The token that the Consumer will send. |
 
 ### Reverts
 
@@ -200,35 +200,17 @@ Provide an order to the Peer for taking.
 
 ```Solidity
 function provideOrder(
-  uint256 nonce,
-  uint256 expiry,
-  address consumerWallet,
-  uint256 consumerAmount,
-  address consumerToken,
-  address peerWallet,
-  uint256 peerAmount,
-  address peerToken,
-  uint8 v,
-  bytes32 r,
-  bytes32 s
+  Types.Order memory _order,
+  Types.Signature memory _signature
 ) public
 ```
 
 ### Params
 
-| Name             | Type      | Description                                            |
-| :--------------- | :-------- | :----------------------------------------------------- |
-| `nonce`          | `uint256` | A single use identifier for the Order.                 |
-| `expiry`         | `uint256` | The expiry in seconds since unix epoch.                |
-| `consumerWallet` | `address` | The Maker of the Order who sets price.                 |
-| `consumerAmount` | `uint256` | The amount or identifier of the token the Maker sends. |
-| `consumerToken`  | `address` | The address of the token the Maker sends.              |
-| `peerWallet`     | `address` | The Taker of the Order who takes price.                |
-| `peerAmount`     | `uint256` | The amount or identifier of the token the Taker sends. |
-| `peerToken`      | `address` | The address of the token the Taker sends.              |
-| `v`              | `uint8`   | The `v` value of an ECDSA signature.                   |
-| `r`              | `bytes32` | The `r` value of an ECDSA signature.                   |
-| `s`              | `bytes32` | The `s` value of an ECDSA signature.                   |
+| Name        | Type        | Description                                                    |
+| :---------- | :---------- | :------------------------------------------------------------- |
+| `order`     | `Order`     | Order struct as specified in the `@airswap/types` package.     |
+| `signature` | `Signature` | Signature struct as specified in the `@airswap/types` package. |
 
 ### Reverts
 
@@ -244,24 +226,23 @@ Provide an unsigned order to the Peer. Requires that the Consumer has authorized
 
 ```Solidity
 function provideUnsignedOrder(
-  uint256 nonce,
-  uint256 consumerAmount,
-  address consumerToken,
-  uint256 peerAmount,
-  address peerToken
+  uint256 _nonce,
+  uint256 _makerAmount,
+  address _makerToken,
+  uint256 _takerAmount,
+  address _takerToken
 ) public
 ```
 
 ### Params
 
-| Name             | Type      | Description                                            |
-| :--------------- | :-------- | :----------------------------------------------------- |
-| `nonce`          | `uint256` | A single use identifier for the Order.                 |
-| `expiry`         | `uint256` | The expiry in seconds since unix epoch.                |
-| `consumerAmount` | `uint256` | The amount or identifier of the token the Maker sends. |
-| `consumerToken`  | `address` | The address of the token the Maker sends.              |
-| `peerAmount`     | `uint256` | The amount or identifier of the token the Taker sends. |
-| `peerToken`      | `address` | The address of the token the Taker sends.              |
+| Name           | Type      | Description                                            |
+| :------------- | :-------- | :----------------------------------------------------- |
+| `_nonce`       | `uint256` | A single use identifier for the Order.                 |
+| `_makerAmount` | `uint256` | The amount or identifier of the token the Maker sends. |
+| `_makerToken`  | `address` | The address of the token the Maker sends.              |
+| `_takerAmount` | `uint256` | The amount or identifier of the token the Taker sends. |
+| `_takerToken`  | `address` | The address of the token the Taker sends.              |
 
 ### Reverts
 

--- a/protocols/peer/README.md
+++ b/protocols/peer/README.md
@@ -223,26 +223,21 @@ function provideOrder(
 ## Provide an Unsigned Order
 
 Provide an unsigned order to the Peer. Requires that the Consumer has authorized the Peer on the Swap contract.
+The Signature should be an empty Signature struct to support the unsigned order.
 
 ```Solidity
-function provideUnsignedOrder(
-  uint256 _nonce,
-  uint256 _makerAmount,
-  address _makerToken,
-  uint256 _takerAmount,
-  address _takerToken
+function provideOrder(
+  Types.Order memory _order,
+  Types.Signature memory _signature
 ) public
 ```
 
 ### Params
 
-| Name           | Type      | Description                                            |
-| :------------- | :-------- | :----------------------------------------------------- |
-| `_nonce`       | `uint256` | A single use identifier for the Order.                 |
-| `_makerAmount` | `uint256` | The amount or identifier of the token the Maker sends. |
-| `_makerToken`  | `address` | The address of the token the Maker sends.              |
-| `_takerAmount` | `uint256` | The amount or identifier of the token the Taker sends. |
-| `_takerToken`  | `address` | The address of the token the Taker sends.              |
+| Name        | Type        | Description                                                    |
+| :---------- | :---------- | :------------------------------------------------------------- |
+| `order`     | `Order`     | Order struct as specified in the `@airswap/types` package.     |
+| `signature` | `Signature` | Signature struct as specified in the `@airswap/types` package. |
 
 ### Reverts
 

--- a/protocols/peer/contracts/Peer.sol
+++ b/protocols/peer/contracts/Peer.sol
@@ -235,41 +235,4 @@ contract Peer is IPeer, Ownable {
     swapContract.swap(_order, _signature);
 
   }
-
-  /**
-    * @notice Provide an Unsigned Order
-    * @dev Requires that sender has authorized the peer (Swap)
-    * @param _nonce uint256 A single use identifier for the order
-    * @param _makerAmount uint256 The amount or identifier of the token the Maker sends
-    * @param _makerToken address The address of the token the Maker sends
-    * @param _takerAmount uint256 The amount or identifier of the token the Taker sends
-    * @param _takerToken address The address of the token the Taker sends
-    */
-  function provideUnsignedOrder(
-    uint256 _nonce,
-    uint256 _makerAmount,
-    address _makerToken,
-    uint256 _takerAmount,
-    address _takerToken
-  ) public {
-
-    provideOrder(Types.Order(
-      _nonce,
-      block.timestamp + 1,
-      Types.Party(
-        msg.sender,
-        _makerToken,
-        _makerAmount,
-        0x277f8169
-      ),
-      Types.Party(
-        owner(),
-        _takerToken,
-        _takerAmount,
-        0x277f8169
-      ),
-      Types.Party(address(0), address(0), 0, bytes4(0))
-    ), Types.Signature(address(0), 0, 0, 0, 0));
-
-  }
 }

--- a/protocols/peer/contracts/Peer.sol
+++ b/protocols/peer/contracts/Peer.sol
@@ -33,7 +33,7 @@ contract Peer is IPeer, Ownable {
   // Swap contract to be used to settle trades
   ISwap public swapContract;
 
-  // Mapping of peerToken to consumerToken for rule lookup
+  // Mapping of takerToken to makerToken for rule lookup
   mapping (address => mapping (address => Rule)) public rules;
 
   /**
@@ -54,86 +54,84 @@ contract Peer is IPeer, Ownable {
   /**
     * @notice Set a Trading Rule
     * @dev only callable by the owner of the contract
-    * @param peerToken address The token address that the peer would send in a trade
-    * @param consumerToken address The token address that the consumer would send in a trade
-    * @param maxPeerAmount uint256 The maximum amount of token the peer would send
-    * @param priceCoef uint256 The whole number that will be multiplied by 10^(-priceExp) - the price coefficient
-    * @param priceExp uint256 The exponent of the price to indicate location of the decimal priceCoef * 10^(-priceExp)
+    * @param _takerToken address The token address that the Peer would send in a trade
+    * @param _makerToken address The token address that the Consumer would send in a trade
+    * @param _maxTakerAmount uint256 The maximum amount of token the Peer would send
+    * @param _priceCoef uint256 The whole number that will be multiplied by 10^(-priceExp) - the price coefficient
+    * @param _priceExp uint256 The exponent of the price to indicate location of the decimal priceCoef * 10^(-priceExp)
     */
   function setRule(
-    address peerToken,
-    address consumerToken,
-    uint256 maxPeerAmount,
-    uint256 priceCoef,
-    uint256 priceExp
+    address _takerToken,
+    address _makerToken,
+    uint256 _maxTakerAmount,
+    uint256 _priceCoef,
+    uint256 _priceExp
   ) external onlyOwner {
 
-    rules[peerToken][consumerToken] = Rule({
-      maxPeerAmount: maxPeerAmount,
-      priceCoef: priceCoef,
-      priceExp: priceExp
+    rules[_takerToken][_makerToken] = Rule({
+      maxTakerAmount: _maxTakerAmount,
+      priceCoef: _priceCoef,
+      priceExp: _priceExp
     });
 
     emit SetRule(
-      peerToken,
-      consumerToken,
-      maxPeerAmount,
-      priceCoef,
-      priceExp
+      _takerToken,
+      _makerToken,
+      _maxTakerAmount,
+      _priceCoef,
+      _priceExp
     );
   }
 
   /**
     * @notice Unset a Trading Rule
     * @dev only callable by the owner of the contract, removes from a mapping
-    * @param peerToken address The token address that the peer would send in a trade
-    * @param consumerToken address The token address that the consumer would send in a trade
+    * @param _takerToken address The token address that the peer would send in a trade
+    * @param _makerToken address The token address that the consumer would send in a trade
     */
   function unsetRule(
-    address peerToken,
-    address consumerToken
+    address _takerToken,
+    address _makerToken
   ) external onlyOwner {
 
     // Delete the rule.
-    delete rules[peerToken][consumerToken];
+    delete rules[_takerToken][_makerToken];
 
     emit UnsetRule(
-      peerToken,
-      consumerToken
+      _takerToken,
+      _makerToken
     );
   }
 
   /**
     * @notice Get a Buy Quote from the Peer
-    * @param peerAmount uint256 The amount the Peer would send
-    * @param peerToken address The token that the Peer would send
-    * @param consumerToken address The token that the Consumer would send
-    * @return uint256 consumerAmount The amount the Consumer would send
+    * @param _takerAmount uint256 The amount the Peer would send
+    * @param _takerToken address The token that the Peer would send
+    * @param _makerToken address The token that the Consumer would send
+    * @return uint256 _makerAmount The amount the Consumer would send
     */
   function getBuyQuote(
-    uint256 peerAmount,
-    address peerToken,
-    address consumerToken
+    uint256 _takerAmount,
+    address _takerToken,
+    address _makerToken
   ) external returns (
-    uint256 consumerAmount
+    uint256 _makerAmount
   ) {
 
-    Rule memory rule = rules[peerToken][consumerToken];
+    Rule memory rule = rules[_takerToken][_makerToken];
 
     // Ensure that a rule exists.
-    if(rule.maxPeerAmount > 0) {
+    if(rule.maxTakerAmount > 0) {
 
-      // Ensure the peerAmount does not exceed maximum for the rule.
-      if(peerAmount <= rule.maxPeerAmount) {
+      // Ensure the _takerAmount does not exceed maximum for the rule.
+      if(_takerAmount <= rule.maxTakerAmount) {
 
-        consumerAmount = peerAmount
+        _makerAmount = _takerAmount
             .mul(rule.priceCoef)
             .div(10 ** rule.priceExp);
 
-        // Ensure that the quoted amount is greater than zero.
-        if (consumerAmount > 0) {
-          return consumerAmount;
-        }
+        // Return the quote.
+        return _makerAmount;
       }
     }
     return 0;
@@ -141,31 +139,31 @@ contract Peer is IPeer, Ownable {
 
   /**
     * @notice Get a Sell Quote from the Peer
-    * @param consumerAmount uint256 The amount the Consumer would send
-    * @param consumerToken address The token that the Consumer will send
-    * @param peerToken address The token that the Peer will send
-    * @return uint256 peerAmount The amount the Peer would send
+    * @param _makerAmount uint256 The amount the Consumer would send
+    * @param _makerToken address The token that the Consumer will send
+    * @param _takerToken address The token that the Peer will send
+    * @return uint256 _takerAmount The amount the Peer would send
     */
   function getSellQuote(
-    uint256 consumerAmount,
-    address consumerToken,
-    address peerToken
+    uint256 _makerAmount,
+    address _makerToken,
+    address _takerToken
   ) external returns (
-    uint256 peerAmount
+    uint256 _takerAmount
   ) {
 
-    Rule memory rule = rules[peerToken][consumerToken];
+    Rule memory rule = rules[_takerToken][_makerToken];
 
     // Ensure that a rule exists.
-    if(rule.maxPeerAmount > 0) {
+    if(rule.maxTakerAmount > 0) {
 
-      // Calculate the peerAmount.
-      peerAmount = consumerAmount
+      // Calculate the _takerAmount.
+      _takerAmount = _makerAmount
         .mul(10 ** rule.priceExp).div(rule.priceCoef);
 
-      // Ensure the peerAmount does not exceed maximum and is greater than zero.
-      if(peerAmount <= rule.maxPeerAmount && peerAmount > 0) {
-        return peerAmount;
+      // Ensure the _takerAmount does not exceed maximum and is greater than zero.
+      if(_takerAmount <= rule.maxTakerAmount && _takerAmount > 0) {
+        return _takerAmount;
       }
     }
     return 0;
@@ -173,127 +171,105 @@ contract Peer is IPeer, Ownable {
 
   /**
     * @notice Get a Maximum Quote from the Peer
-    * @param peerToken address The token that the Peer will send
-    * @param consumerToken address The token that the Consumer will send
+    * @param _takerToken address The token that the Peer will send
+    * @param _makerToken address The token that the Consumer will send
     * @return uint 256 The amount the Peer would send
     * @return uint 256 The amount the Consumer would send
     */
   function getMaxQuote(
-    address peerToken,
-    address consumerToken
+    address _takerToken,
+    address _makerToken
   ) external returns (
-    uint256 peerAmount,
-    uint256 consumerAmount
+    uint256 _takerAmount,
+    uint256 _makerAmount
   ) {
 
-    Rule memory rule = rules[peerToken][consumerToken];
+    Rule memory rule = rules[_takerToken][_makerToken];
 
     // Ensure that a rule exists.
-    if(rule.maxPeerAmount > 0) {
+    if(rule.maxTakerAmount > 0) {
 
-      // Return the maxPeerAmount and calculated consumerAmount.
+      // Return the maxTakerAmount and calculated _makerAmount.
       return (
-        rule.maxPeerAmount,
-        rule.maxPeerAmount.mul(rule.priceCoef).div(10 ** rule.priceExp)
+        rule.maxTakerAmount,
+        rule.maxTakerAmount.mul(rule.priceCoef).div(10 ** rule.priceExp)
       );
     }
     return (0, 0);
   }
 
   /**
-    * @notice Provide an Order (Simple)
-    * @dev Rules get reset with new maxPeerAmount
-    * @param nonce uint256  A single use identifier for the Order.
-    * @param expiry uint256 The expiry in seconds since unix epoch.
-    * @param consumerWallet address The Maker of the Order who sets price.
-    * @param consumerAmount uint256 The amount or identifier of the token the Maker sends.
-    * @param consumerToken address The address of the token the Maker sends.
-    * @param peerWallet address The Taker of the Order who takes price.
-    * @param peerAmount uint256  The amount or identifier of the token the Taker sends.
-    * @param peerToken address The address of the token the Taker sends.
-    * @param v uint8 The `v` value of an ECDSA signature.
-    * @param r bytes32 The `r` value of an ECDSA signature.
-    * @param s bytes32 The `s` value of an ECDSA signature.
+    * @notice Provide an Order
+    * @dev Rules get reset with new maxTakerAmount
+    * @param _order Types.Order
+    * @param _signature Types.Signature
     */
   function provideOrder(
-    uint256 nonce,
-    uint256 expiry,
-    address consumerWallet,
-    uint256 consumerAmount,
-    address consumerToken,
-    address peerWallet,
-    uint256 peerAmount,
-    address peerToken,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
+    Types.Order memory _order,
+    Types.Signature memory _signature
   ) public {
 
-    Rule memory rule = rules[peerToken][consumerToken];
+    Rule memory rule = rules[_order.taker.token][_order.maker.token];
 
     // Ensure that a rule exists.
-    require(rule.maxPeerAmount != 0,
+    require(rule.maxTakerAmount != 0,
       "TOKEN_PAIR_INACTIVE");
 
     // Ensure the order does not exceed the maximum amount.
-    require(peerAmount <= rule.maxPeerAmount,
+    require(_order.taker.param <= rule.maxTakerAmount,
       "AMOUNT_EXCEEDS_MAX");
 
     // Ensure the order is priced according to the rule.
-    require(peerAmount == consumerAmount
+    require(_order.taker.param == _order.maker.param
       .mul(10 ** rule.priceExp).div(rule.priceCoef),
       "PRICE_INCORRECT");
 
-    // Overwrite the rule with a decremented maxPeerAmount.
-    rules[peerToken][consumerToken] = Rule({
-      maxPeerAmount: rule.maxPeerAmount - peerAmount,
+    // Overwrite the rule with a decremented maxTakerAmount.
+    rules[_order.taker.token][_order.maker.token] = Rule({
+      maxTakerAmount: rule.maxTakerAmount - _order.taker.param,
       priceCoef: rule.priceCoef,
       priceExp: rule.priceExp
     });
 
     // Perform the swap.
-    swapContract.swapSimple(
-      nonce,
-      expiry,
-      consumerWallet,
-      consumerAmount,
-      consumerToken,
-      peerWallet,
-      peerAmount,
-      peerToken,
-      v, r, s
-    );
+    swapContract.swap(_order, _signature);
 
   }
 
   /**
-    * @notice Provide an Unsigned Order (Simple)
+    * @notice Provide an Unsigned Order
     * @dev Requires that sender has authorized the peer (Swap)
-    * @param nonce uint256 A single use identifier for the order
-    * @param consumerAmount uint256 The amount or identifier of the token the Maker sends
-    * @param consumerToken address The address of the token the Maker sends
-    * @param peerAmount uint256 The amount or identifier of the token the Taker sends
-    * @param peerToken address The address of the token the Taker sends
+    * @param _nonce uint256 A single use identifier for the order
+    * @param _makerAmount uint256 The amount or identifier of the token the Maker sends
+    * @param _makerToken address The address of the token the Maker sends
+    * @param _takerAmount uint256 The amount or identifier of the token the Taker sends
+    * @param _takerToken address The address of the token the Taker sends
     */
   function provideUnsignedOrder(
-    uint256 nonce,
-    uint256 consumerAmount,
-    address consumerToken,
-    uint256 peerAmount,
-    address peerToken
+    uint256 _nonce,
+    uint256 _makerAmount,
+    address _makerToken,
+    uint256 _takerAmount,
+    address _takerToken
   ) public {
 
-    provideOrder(
-      nonce,
+    provideOrder(Types.Order(
+      _nonce,
       block.timestamp + 1,
-      msg.sender,
-      consumerAmount,
-      consumerToken,
-      owner(),
-      peerAmount,
-      peerToken,
-      0, 0, 0
-    );
+      Types.Party(
+        msg.sender,
+        _makerToken,
+        _makerAmount,
+        0x277f8169
+      ),
+      Types.Party(
+        owner(),
+        _takerToken,
+        _takerAmount,
+        0x277f8169
+      ),
+      Types.Party(address(0), address(0), 0, bytes4(0))
+    ), Types.Signature(address(0), 0, 0, 0, 0));
 
   }
 }

--- a/protocols/peer/contracts/Peer.sol
+++ b/protocols/peer/contracts/Peer.sol
@@ -173,8 +173,8 @@ contract Peer is IPeer, Ownable {
     * @notice Get a Maximum Quote from the Peer
     * @param _takerToken address The token that the Peer will send
     * @param _makerToken address The token that the Consumer will send
-    * @return uint 256 The amount the Peer would send
-    * @return uint 256 The amount the Consumer would send
+    * @return uint256 The amount the Peer would send
+    * @return uint256 The amount the Consumer would send
     */
   function getMaxQuote(
     address _takerToken,

--- a/protocols/peer/contracts/interfaces/IPeer.sol
+++ b/protocols/peer/contracts/interfaces/IPeer.sol
@@ -84,11 +84,6 @@ interface IPeer {
     Types.Signature calldata signature
   ) external;
 
-  function provideUnsignedOrder(
-    uint256 _nonce,
-    uint256 _makerAmount,
-    address _makerToken,
-    uint256 _takerAmount,
-    address _takerToken
-  ) external;
+  function owner()
+    external view returns (address);
 }

--- a/protocols/peer/contracts/interfaces/IPeer.sol
+++ b/protocols/peer/contracts/interfaces/IPeer.sol
@@ -17,23 +17,25 @@
 pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
+import "@airswap/types/contracts/Types.sol";
+
 interface IPeer {
 
   event SetRule(
-    address peerToken,
-    address consumerToken,
-    uint256 maxPeerAmount,
+    address takerToken,
+    address makerToken,
+    uint256 maxTakerAmount,
     uint256 priceCoef,
     uint256 priceExp
   );
 
   event UnsetRule(
-    address peerToken,
-    address consumerToken
+    address takerToken,
+    address makerToken
   );
 
   struct Rule {
-    uint256 maxPeerAmount;
+    uint256 maxTakerAmount;
     uint256 priceCoef;
     uint256 priceExp;
   }
@@ -41,61 +43,52 @@ interface IPeer {
   function rules(address, address) external returns (Rule memory);
 
   function setRule(
-    address _peerToken,
-    address _consumerToken,
-    uint256 _maxPeerAmount,
+    address _takerToken,
+    address _makerToken,
+    uint256 _maxTakerAmount,
     uint256 _priceCoef,
     uint256 _priceExp
   ) external;
 
   function unsetRule(
-    address _peerToken,
-    address _consumerToken
+    address _takerToken,
+    address _makerToken
   ) external;
 
   function getBuyQuote(
-    uint256 _peerAmount,
-    address _peerToken,
-    address _consumerToken
+    uint256 _takerAmount,
+    address _takerToken,
+    address _makerToken
   ) external returns (
-    uint256 consumerAmount
+    uint256 makerAmount
   );
 
   function getSellQuote(
-    uint256 _consumerAmount,
-    address _consumerToken,
-    address _peerToken
+    uint256 _makerAmount,
+    address _makerToken,
+    address _takerToken
   ) external returns (
-    uint256 peerAmount
+    uint256 takerAmount
   );
 
   function getMaxQuote(
-    address _peerToken,
-    address _consumerToken
+    address _takerToken,
+    address _makerToken
   ) external returns (
-    uint256 peerAmount,
-    uint256 consumerAmount
+    uint256 takerAmount,
+    uint256 makerAmount
   );
 
   function provideOrder(
-    uint256 _nonce,
-    uint256 _expiry,
-    address _consumerWallet,
-    uint256 _consumerAmount,
-    address _consumerToken,
-    address _peerWallet,
-    uint256 _peerAmount,
-    address _peerToken,
-    uint8 _v,
-    bytes32 _r,
-    bytes32 _s
+    Types.Order calldata order,
+    Types.Signature calldata signature
   ) external;
 
   function provideUnsignedOrder(
     uint256 _nonce,
-    uint256 _consumerAmount,
-    address _consumerToken,
-    uint256 _peerAmount,
-    address _peerToken
+    uint256 _makerAmount,
+    address _makerToken,
+    uint256 _takerAmount,
+    address _takerToken
   ) external;
 }

--- a/protocols/peer/test/Peer-unit.js
+++ b/protocols/peer/test/Peer-unit.js
@@ -327,6 +327,7 @@ contract('Peer Unit Tests', async accounts => {
     it('test if a rule does not exist', async () => {
       const { order } = await orders.getOrder({
         maker: {
+          wallet: notOwner,
           param: 555,
           token: MAKER_TOKEN,
         },
@@ -335,8 +336,11 @@ contract('Peer Unit Tests', async accounts => {
           token: TAKER_TOKEN,
         },
       })
+
       await reverted(
-        peer.provideOrder(order, signatures.getEmptySignature()),
+        peer.provideOrder(order, signatures.getEmptySignature(), {
+          from: notOwner
+        }),
         'TOKEN_PAIR_INACTIVE'
       )
     })
@@ -352,8 +356,9 @@ contract('Peer Unit Tests', async accounts => {
 
       const { order } = await orders.getOrder({
         maker: {
+          wallet: notOwner,
           param: 555,
-          token: MAKER_TOKEN,
+          token: MAKER_TOKEN
         },
         taker: {
           param: MAX_TAKER_AMOUNT + 1,
@@ -362,7 +367,9 @@ contract('Peer Unit Tests', async accounts => {
       })
 
       await reverted(
-        peer.provideOrder(order, signatures.getEmptySignature()),
+        peer.provideOrder(order, signatures.getEmptySignature(), {
+          from: notOwner,
+        }),
         'AMOUNT_EXCEEDS_MAX'
       )
     })
@@ -387,7 +394,11 @@ contract('Peer Unit Tests', async accounts => {
         },
       })
 
-      await reverted(peer.provideOrder(order, signatures.getEmptySignature()))
+      await reverted(
+        peer.provideOrder(order, signatures.getEmptySignature(), {
+          from: notOwner,
+        })
+      )
     })
 
     it('test a successful transaction with integer values', async () => {
@@ -399,6 +410,7 @@ contract('Peer Unit Tests', async accounts => {
 
       const { order } = await orders.getOrder({
         maker: {
+          wallet: notOwner,
           param: makerAmount,
           token: MAKER_TOKEN,
         },
@@ -411,7 +423,9 @@ contract('Peer Unit Tests', async accounts => {
       await passes(
         //mock swapContract
         //test rule decrement
-        peer.provideOrder(order, signatures.getEmptySignature())
+        peer.provideOrder(order, signatures.getEmptySignature(), {
+          from: notOwner
+        })
       )
 
       let ruleAfter = await peer.rules.call(TAKER_TOKEN, MAKER_TOKEN)
@@ -448,6 +462,7 @@ contract('Peer Unit Tests', async accounts => {
 
       const { order } = await orders.getOrder({
         maker: {
+          wallet: notOwner,
           param: makerAmount,
           token: MAKER_TOKEN,
         },
@@ -460,7 +475,9 @@ contract('Peer Unit Tests', async accounts => {
       await passes(
         //mock swapContract
         //test rule decrement
-        peer.provideOrder(order, signatures.getEmptySignature())
+        peer.provideOrder(order, signatures.getEmptySignature(), {
+          from: notOwner,
+        })
       )
 
       let ruleAfter = await peer.rules.call(TAKER_TOKEN, MAKER_TOKEN)

--- a/protocols/peer/test/Peer-unit.js
+++ b/protocols/peer/test/Peer-unit.js
@@ -471,33 +471,4 @@ contract('Peer Unit Tests', async accounts => {
       )
     })
   })
-
-  describe('Test provideUnsignedOrder', async () => {
-    it('test provideUnsignedOrder call', async () => {
-      await peer.setRule(TAKER_TOKEN, MAKER_TOKEN, MAX_TAKER_AMOUNT, 100, EXP)
-
-      let makerAmount = 100
-      await passes(
-        //mock swapContract
-        //test rule decrement
-        peer.provideUnsignedOrder(
-          1, //nonce
-          makerAmount, //makerAmount
-          MAKER_TOKEN, //makerToken
-          100, //takerAmount
-          TAKER_TOKEN //takerToken
-        )
-      )
-
-      //check if swap() was called
-      let invocationCount = await mockSwap.invocationCountForMethod.call(
-        swapFunction
-      )
-      equal(
-        invocationCount.toNumber(),
-        1,
-        'swap function was not called the expected number of times'
-      )
-    })
-  })
 })

--- a/protocols/peer/test/Peer-unit.js
+++ b/protocols/peer/test/Peer-unit.js
@@ -21,7 +21,7 @@ contract('Peer Unit Tests', async accounts => {
   let swapFunction
   const TAKER_TOKEN = accounts[9]
   const MAKER_TOKEN = accounts[8]
-  const MAX_PEER_AMOUNT = 12345
+  const MAX_TAKER_AMOUNT = 12345
   const PRICE_COEF = 4321
   const EXP = 2
 
@@ -76,7 +76,7 @@ contract('Peer Unit Tests', async accounts => {
         peer.setRule(
           TAKER_TOKEN,
           MAKER_TOKEN,
-          MAX_PEER_AMOUNT,
+          MAX_TAKER_AMOUNT,
           PRICE_COEF,
           EXP,
           { from: notOwner }
@@ -87,7 +87,7 @@ contract('Peer Unit Tests', async accounts => {
         peer.setRule(
           TAKER_TOKEN,
           MAKER_TOKEN,
-          MAX_PEER_AMOUNT,
+          MAX_TAKER_AMOUNT,
           PRICE_COEF,
           EXP,
           { from: owner }
@@ -99,7 +99,7 @@ contract('Peer Unit Tests', async accounts => {
       let trx = await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
@@ -108,7 +108,7 @@ contract('Peer Unit Tests', async accounts => {
       let rule = await peer.rules.call(TAKER_TOKEN, MAKER_TOKEN)
       equal(
         rule[0].toNumber(),
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         'max peer amount is incorrectly saved'
       )
       equal(rule[1].toNumber(), PRICE_COEF, 'price coef is incorrectly saved')
@@ -119,7 +119,7 @@ contract('Peer Unit Tests', async accounts => {
         return (
           e.takerToken === TAKER_TOKEN &&
           e.makerToken === MAKER_TOKEN &&
-          e.maxTakerAmount.toNumber() === MAX_PEER_AMOUNT &&
+          e.maxTakerAmount.toNumber() === MAX_TAKER_AMOUNT &&
           e.priceCoef.toNumber() === PRICE_COEF &&
           e.priceExp.toNumber() === EXP
         )
@@ -137,7 +137,7 @@ contract('Peer Unit Tests', async accounts => {
       let trx = await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
@@ -146,7 +146,7 @@ contract('Peer Unit Tests', async accounts => {
       let ruleBefore = await peer.rules.call(TAKER_TOKEN, MAKER_TOKEN)
       equal(
         ruleBefore[0].toNumber(),
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         'max peer amount is incorrectly saved'
       )
 
@@ -188,12 +188,12 @@ contract('Peer Unit Tests', async accounts => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
       let val = await peer.getBuyQuote.call(
-        MAX_PEER_AMOUNT + 1,
+        MAX_TAKER_AMOUNT + 1,
         TAKER_TOKEN,
         MAKER_TOKEN
       )
@@ -208,7 +208,7 @@ contract('Peer Unit Tests', async accounts => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
@@ -224,7 +224,7 @@ contract('Peer Unit Tests', async accounts => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
@@ -255,7 +255,7 @@ contract('Peer Unit Tests', async accounts => {
       )
 
       val = await peer.getSellQuote.call(
-        MAX_PEER_AMOUNT + 1,
+        MAX_TAKER_AMOUNT + 1,
         MAKER_TOKEN,
         TAKER_TOKEN
       )
@@ -270,7 +270,7 @@ contract('Peer Unit Tests', async accounts => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
@@ -300,7 +300,7 @@ contract('Peer Unit Tests', async accounts => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
@@ -308,11 +308,13 @@ contract('Peer Unit Tests', async accounts => {
 
       equal(
         val[0].toNumber(),
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         'no quote should be available if a peer does not exist'
       )
 
-      let expectedValue = Math.floor((MAX_PEER_AMOUNT * PRICE_COEF) / 10 ** EXP)
+      let expectedValue = Math.floor(
+        (MAX_TAKER_AMOUNT * PRICE_COEF) / 10 ** EXP
+      )
       equal(
         val[1].toNumber(),
         expectedValue,
@@ -343,7 +345,7 @@ contract('Peer Unit Tests', async accounts => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
@@ -354,7 +356,7 @@ contract('Peer Unit Tests', async accounts => {
           token: MAKER_TOKEN,
         },
         taker: {
-          param: MAX_PEER_AMOUNT + 1,
+          param: MAX_TAKER_AMOUNT + 1,
           token: TAKER_TOKEN,
         },
       })
@@ -369,7 +371,7 @@ contract('Peer Unit Tests', async accounts => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
@@ -380,7 +382,7 @@ contract('Peer Unit Tests', async accounts => {
           token: MAKER_TOKEN,
         },
         taker: {
-          param: MAX_PEER_AMOUNT,
+          param: MAX_TAKER_AMOUNT,
           token: TAKER_TOKEN,
         },
       })
@@ -389,7 +391,7 @@ contract('Peer Unit Tests', async accounts => {
     })
 
     it('test a successful transaction with integer values', async () => {
-      await peer.setRule(TAKER_TOKEN, MAKER_TOKEN, MAX_PEER_AMOUNT, 100, EXP)
+      await peer.setRule(TAKER_TOKEN, MAKER_TOKEN, MAX_TAKER_AMOUNT, 100, EXP)
 
       let ruleBefore = await peer.rules.call(TAKER_TOKEN, MAKER_TOKEN)
 
@@ -434,7 +436,7 @@ contract('Peer Unit Tests', async accounts => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
-        MAX_PEER_AMOUNT,
+        MAX_TAKER_AMOUNT,
         PRICE_COEF,
         EXP
       )
@@ -472,7 +474,7 @@ contract('Peer Unit Tests', async accounts => {
 
   describe('Test provideUnsignedOrder', async () => {
     it('test provideUnsignedOrder call', async () => {
-      await peer.setRule(TAKER_TOKEN, MAKER_TOKEN, MAX_PEER_AMOUNT, 100, EXP)
+      await peer.setRule(TAKER_TOKEN, MAKER_TOKEN, MAX_TAKER_AMOUNT, 100, EXP)
 
       let makerAmount = 100
       await passes(

--- a/protocols/peer/test/Peer-unit.js
+++ b/protocols/peer/test/Peer-unit.js
@@ -339,7 +339,7 @@ contract('Peer Unit Tests', async accounts => {
 
       await reverted(
         peer.provideOrder(order, signatures.getEmptySignature(), {
-          from: notOwner
+          from: notOwner,
         }),
         'TOKEN_PAIR_INACTIVE'
       )
@@ -358,7 +358,7 @@ contract('Peer Unit Tests', async accounts => {
         maker: {
           wallet: notOwner,
           param: 555,
-          token: MAKER_TOKEN
+          token: MAKER_TOKEN,
         },
         taker: {
           param: MAX_TAKER_AMOUNT + 1,
@@ -424,7 +424,7 @@ contract('Peer Unit Tests', async accounts => {
         //mock swapContract
         //test rule decrement
         peer.provideOrder(order, signatures.getEmptySignature(), {
-          from: notOwner
+          from: notOwner,
         })
       )
 

--- a/protocols/peer/test/Peer-unit.js
+++ b/protocols/peer/test/Peer-unit.js
@@ -42,6 +42,8 @@ contract('Peer Unit Tests', async accounts => {
       .encodeABI()
 
     mockSwap = await MockContract.new()
+
+    orders.setVerifyingContract(mockSwap.address)
   }
 
   before('deploy Peer', async () => {
@@ -325,7 +327,7 @@ contract('Peer Unit Tests', async accounts => {
 
   describe('Test provideOrder', async () => {
     it('test if a rule does not exist', async () => {
-      const { order } = await orders.getOrder({
+      const { order, signature } = await orders.getOrder({
         maker: {
           wallet: notOwner,
           param: 555,
@@ -338,7 +340,7 @@ contract('Peer Unit Tests', async accounts => {
       })
 
       await reverted(
-        peer.provideOrder(order, signatures.getEmptySignature(), {
+        peer.provideOrder(order, signature, {
           from: notOwner,
         }),
         'TOKEN_PAIR_INACTIVE'

--- a/protocols/peer/test/Peer.js
+++ b/protocols/peer/test/Peer.js
@@ -233,26 +233,13 @@ contract('Peer', async accounts => {
         taker: {
           wallet: aliceAddress,
           token: tokenDAI.address,
-          param: quote,
+          param: quote.toNumber(),
         },
       })
 
       // Succeeds on the Peer, fails on the Swap.
       await reverted(
-        alicePeer.provideOrder(
-          order.nonce,
-          order.expiry,
-          order.maker.wallet,
-          order.maker.param,
-          order.maker.token,
-          order.taker.wallet,
-          order.taker.param,
-          order.taker.token,
-          signature.v,
-          signature.r,
-          signature.s,
-          { from: bobAddress }
-        ),
+        alicePeer.provideOrder(order, signature),
         'SENDER_UNAUTHORIZED'
       )
     })

--- a/protocols/peer/test/Peer.js
+++ b/protocols/peer/test/Peer.js
@@ -239,7 +239,7 @@ contract('Peer', async accounts => {
 
       // Succeeds on the Peer, fails on the Swap.
       await reverted(
-        alicePeer.provideOrder(order, signature),
+        alicePeer.provideOrder(order, signature, { from: bobAddress }),
         'SENDER_UNAUTHORIZED'
       )
     })


### PR DESCRIPTION
## Description
- rename peerToken and consumerToken -> takerToken and makerToken 
- With the migration to swap, Peer needs to use swap instead.
- remove provideUnsignedOrder as now the function signatures are the same, the difference is whether Signature is populated or not 
- add require to ensure that order.maker.wallet is always msg.sender
- order.maker.kind and order.taker.kind are 0x277f8169 (ERC-20)