### PR TITLE
Quick fix for order-util

### DIFF
--- a/examples/consumer/package.json
+++ b/examples/consumer/package.json
@@ -22,7 +22,7 @@
     "solidity-coverage": "^0.6.3"
   },
   "dependencies": {
-    "@airswap/order-utils": "0.3.0",
+    "@airswap/order-utils": "0.3.1",
     "@airswap/test-utils": "0.1.0",
     "truffle": "^5.0.24"
   }

--- a/helpers/wrapper/package.json
+++ b/helpers/wrapper/package.json
@@ -16,7 +16,7 @@
     "test": "truffle test"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.0",
+    "@airswap/order-utils": "0.3.1",
     "@airswap/test-utils": "0.1.0",
     "solidity-coverage": "^0.6.3"
   },

--- a/packages/order-utils/package.json
+++ b/packages/order-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/order-utils",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "JavaScript utilities for orders, hashes, and signatures in the Swap Protocol",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/order-utils/src/orders.js
+++ b/packages/order-utils/src/orders.js
@@ -62,14 +62,16 @@ module.exports = {
       affiliate: { ...defaults.Party, ...affiliate },
     }
     const wallet = signer !== NULL_ADDRESS ? signer : order.maker.wallet
-    if (!noSignature && this._knownAccounts.indexOf(wallet) !== -1) {
-      order.signature = await signatures.getWeb3Signature(
-        order,
-        wallet,
-        this._verifyingContract
-      )
-    } else {
-      order.signature = signatures.getEmptySignature()
+    if (!noSignature) {
+      if (this._knownAccounts.indexOf(wallet) !== -1) {
+        order.signature = await signatures.getWeb3Signature(
+          order,
+          wallet,
+          this._verifyingContract
+        )
+      } else {
+        order.signature = signatures.getEmptySignature()
+      }
     }
     return order
   },

--- a/protocols/market/package.json
+++ b/protocols/market/package.json
@@ -15,7 +15,7 @@
     "test": "truffle test"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.0",
+    "@airswap/order-utils": "0.3.1",
     "@airswap/test-utils": "0.1.0",
     "@airswap/tokens": "0.1.0",
     "truffle": "^5.0.24",

--- a/protocols/peer/package.json
+++ b/protocols/peer/package.json
@@ -16,7 +16,7 @@
     "test": "truffle test"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.0",
+    "@airswap/order-utils": "0.3.1",
     "@airswap/test-utils": "0.1.0"
   },
   "dependencies": {

--- a/protocols/swap/package.json
+++ b/protocols/swap/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@airswap/tokens": "0.1.0",
-    "@airswap/order-utils": "0.3.0",
+    "@airswap/order-utils": "0.3.1",
     "@airswap/test-utils": "0.1.0",
     "truffle": "^5.0.32",
     "@gnosis.pm/mock-contract": "^3.0.7"


### PR DESCRIPTION
getOrder was adding an empty `signature` every time.