### PR TITLE
Terminology update for Index and Signal

### DIFF
--- a/examples/consumer/test/Consumer.js
+++ b/examples/consumer/test/Consumer.js
@@ -83,7 +83,7 @@ contract('Consumer', async accounts => {
       )
     })
 
-    it('Bob creates a market (collection of intents) for WETH/DAI', async () => {
+    it('Bob creates an index for WETH/DAI', async () => {
       emitted(
         await indexer.createIndex(tokenWETH.address, tokenDAI.address, {
           from: bobAddress,

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -109,6 +109,7 @@ contract Index is Ownable {
   /**
     * @notice Unset an Locator to Trade
     * @param _user address
+    * @return bool return true on success
     */
   function unsetLocator(
     address _user
@@ -136,6 +137,7 @@ contract Index is Ownable {
   /**
     * @notice Get the Locator for a user
     * @param _user address
+    * @return Locator
     */
   function getLocator(
     address _user
@@ -181,6 +183,7 @@ contract Index is Ownable {
   /**
     * @notice Determine Whether a user is in the Linked List
     * @param _user address
+    * @return bool return true when user exists
     */
   function hasLocator(
     address _user
@@ -196,6 +199,7 @@ contract Index is Ownable {
   /**
     * @notice Returns the first Locator smaller than _score
     * @param _score uint256
+    * @return Locator
     */
   function findPosition(
     uint256 _score
@@ -218,7 +222,7 @@ contract Index is Ownable {
 
   /**
     * @notice Link Two Locators
-    * @dev helper function for linkedlist
+    * @dev helper function for linked list
     * @param _left Locator
     * @param _right Locator
     */

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -88,7 +88,7 @@ contract Index is Ownable {
     bytes32 _locator
   ) external onlyOwner {
 
-    require(!hasSignal(_user), "USER_HAS_ENTRY");
+    require(!hasSignal(_user), "SIGNAL_ALREADY_SET");
 
     Signal memory newSignal = Signal(_user, _score, _locator);
 
@@ -143,7 +143,7 @@ contract Index is Ownable {
     // Ensure the user has a neighbor in the linked list.
     if (signalsLinkedList[_user][PREV].user != address(0)) {
 
-      // Return the next intent from the previous neighbor.
+      // Return the next signal from the previous neighbor.
       return signalsLinkedList[signalsLinkedList[_user][PREV].user][NEXT];
     }
     return Signal(address(0), 0, bytes32(0));
@@ -164,15 +164,15 @@ contract Index is Ownable {
     }
     result = new bytes32[](limit);
 
-    // Get the first intent in the linked list after the HEAD
-    Signal storage intent = signalsLinkedList[HEAD][NEXT];
+    // Get the first signal in the linked list after the HEAD
+    Signal storage signal = signalsLinkedList[HEAD][NEXT];
 
     // Iterate over the list until the end or limit.
     uint256 i = 0;
     while (i < limit) {
-      result[i] = intent.locator;
+      result[i] = signal.locator;
       i = i + 1;
-      intent = signalsLinkedList[intent.user][NEXT];
+      signal = signalsLinkedList[signal.user][NEXT];
     }
   }
 
@@ -192,26 +192,26 @@ contract Index is Ownable {
   }
 
   /**
-    * @notice Returns the first intent smaller than _score
+    * @notice Returns the first signal smaller than _score
     * @param _score uint256
     */
   function findPosition(
     uint256 _score
   ) internal view returns (Signal memory) {
 
-    // Get the first intent in the linked list.
-    Signal storage intent = signalsLinkedList[HEAD][NEXT];
+    // Get the first signal in the linked list.
+    Signal storage signal = signalsLinkedList[HEAD][NEXT];
 
     if (_score == 0) {
       // return the head of the linked list
-      return signalsLinkedList[intent.user][PREV];
+      return signalsLinkedList[signal.user][PREV];
     }
 
     // Iterate through the list until a lower score is found.
-    while (_score <= intent.score) {
-      intent = signalsLinkedList[intent.user][NEXT];
+    while (_score <= signal.score) {
+      signal = signalsLinkedList[signal.user][NEXT];
     }
-    return intent;
+    return signal;
   }
 
   /**

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -182,7 +182,7 @@ contract Index is Ownable {
     */
   function hasSignal(
     address _user
-  ) public view returns (bool) {
+  ) internal view returns (bool) {
 
     if (signalsLinkedList[_user][PREV].user != address(0) &&
       signalsLinkedList[signalsLinkedList[_user][PREV].user][NEXT].user == _user) {

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -20,7 +20,7 @@ pragma experimental ABIEncoderV2;
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 /**
-  * @title Index: A List of Signals to Trade
+  * @title Index: A List of Locators
   */
 contract Index is Ownable {
 
@@ -35,19 +35,20 @@ contract Index is Ownable {
   byte constant private NEXT = 0x01;
 
   // Mapping of user address to its neighbors
-  mapping(address => mapping(byte => Signal)) private signalsLinkedList;
+  mapping(address => mapping(byte => Locator)) private LocatorsLinkedList;
 
   /**
-    * @notice Signal to Trade
+    * @notice Locator for a Peer
+    * @dev data is arbitrary e.g. may include an address
     *
     * @param user address
     * @param score uint256
-    * @param locator bytes32
+    * @param data bytes32
     */
-  struct Signal {
+  struct Locator {
     address user;
     uint256 score;
-    bytes32 locator;
+    bytes32 data;
   }
 
   /**
@@ -55,13 +56,13 @@ contract Index is Ownable {
     * @dev Emitted with successful state changes
     */
 
-  event SetSignal(
+  event SetLocator(
     uint256 score,
     address indexed user,
-    bytes32 indexed locator
+    bytes32 indexed data
   );
 
-  event UnsetSignal(
+  event UnsetLocator(
     address indexed user
   );
 
@@ -70,90 +71,90 @@ contract Index is Ownable {
     */
   constructor() public {
     // Initialize the linked list.
-    Signal memory head = Signal(HEAD, 0, bytes32(0));
-    signalsLinkedList[HEAD][PREV] = head;
-    signalsLinkedList[HEAD][NEXT] = head;
+    Locator memory head = Locator(HEAD, 0, bytes32(0));
+    LocatorsLinkedList[HEAD][PREV] = head;
+    LocatorsLinkedList[HEAD][NEXT] = head;
   }
 
   /**
-    * @notice Set an Signal to Trade
+    * @notice Set an Locator to Trade
     *
     * @param _user The account
     * @param _score uint256
-    * @param _locator bytes32
+    * @param _data bytes32
     */
-  function setSignal(
+  function setLocator(
     address _user,
     uint256 _score,
-    bytes32 _locator
+    bytes32 _data
   ) external onlyOwner {
 
-    require(!hasSignal(_user), "SIGNAL_ALREADY_SET");
+    require(!hasLocator(_user), "LOCATOR_ALREADY_SET");
 
-    Signal memory newSignal = Signal(_user, _score, _locator);
+    Locator memory newLocator = Locator(_user, _score, _data);
 
     // Insert after the next highest score on the linked list.
-    Signal memory nextSignal = findPosition(_score);
+    Locator memory nextLocator = findPosition(_score);
 
-    // Link the newSignal into place.
-    link(signalsLinkedList[nextSignal.user][PREV], newSignal);
-    link(newSignal, nextSignal);
+    // Link the newLocator into place.
+    link(LocatorsLinkedList[nextLocator.user][PREV], newLocator);
+    link(newLocator, nextLocator);
 
     // Increment the length of the linked list if successful.
     length = length + 1;
 
-    emit SetSignal(_score, _user, _locator);
+    emit SetLocator(_score, _user, _data);
   }
 
   /**
-    * @notice Unset an Signal to Trade
+    * @notice Unset an Locator to Trade
     * @param _user address
     */
-  function unsetSignal(
+  function unsetLocator(
     address _user
   ) external onlyOwner returns (bool) {
 
     // Ensure the _user is in the linked list.
-    if (!hasSignal(_user)) {
+    if (!hasLocator(_user)) {
       return false;
     }
 
     // Link its neighbors together.
-    link(signalsLinkedList[_user][PREV], signalsLinkedList[_user][NEXT]);
+    link(LocatorsLinkedList[_user][PREV], LocatorsLinkedList[_user][NEXT]);
 
     // Delete user from the list.
-    delete signalsLinkedList[_user][PREV];
-    delete signalsLinkedList[_user][NEXT];
+    delete LocatorsLinkedList[_user][PREV];
+    delete LocatorsLinkedList[_user][NEXT];
 
     // Decrement the length of the linked list.
     length = length - 1;
 
-    emit UnsetSignal(_user);
+    emit UnsetLocator(_user);
     return true;
   }
 
   /**
-    * @notice Get the Signal for a user
+    * @notice Get the Locator for a user
     * @param _user address
     */
-  function getSignal(
+  function getLocator(
     address _user
-  ) external view returns (Signal memory) {
+  ) external view returns (Locator memory) {
 
     // Ensure the user has a neighbor in the linked list.
-    if (signalsLinkedList[_user][PREV].user != address(0)) {
+    if (LocatorsLinkedList[_user][PREV].user != address(0)) {
 
-      // Return the next signal from the previous neighbor.
-      return signalsLinkedList[signalsLinkedList[_user][PREV].user][NEXT];
+      // Return the next Locator from the previous neighbor.
+      return LocatorsLinkedList[LocatorsLinkedList[_user][PREV].user][NEXT];
     }
-    return Signal(address(0), 0, bytes32(0));
+    return Locator(address(0), 0, bytes32(0));
   }
 
   /**
-    * @notice Get Valid Signals
+    * @notice Get Valid Locators
     * @param _count uint256
     */
-  function fetchSignals(
+  function fetchLocators(
     uint256 _count
   ) external view returns (bytes32[] memory result) {
 
@@ -164,15 +165,15 @@ contract Index is Ownable {
     }
     result = new bytes32[](limit);
 
-    // Get the first signal in the linked list after the HEAD
-    Signal storage signal = signalsLinkedList[HEAD][NEXT];
+    // Get the first Locator in the linked list after the HEAD
+    Locator storage Locator = LocatorsLinkedList[HEAD][NEXT];
 
     // Iterate over the list until the end or limit.
     uint256 i = 0;
     while (i < limit) {
-      result[i] = signal.locator;
+      result[i] = Locator.data;
       i = i + 1;
-      signal = signalsLinkedList[signal.user][NEXT];
+      Locator = LocatorsLinkedList[Locator.user][NEXT];
     }
   }
 
@@ -180,51 +181,51 @@ contract Index is Ownable {
     * @notice Determine Whether a user is in the Linked List
     * @param _user address
     */
-  function hasSignal(
+  function hasLocator(
     address _user
   ) internal view returns (bool) {
 
-    if (signalsLinkedList[_user][PREV].user != address(0) &&
-      signalsLinkedList[signalsLinkedList[_user][PREV].user][NEXT].user == _user) {
+    if (LocatorsLinkedList[_user][PREV].user != address(0) &&
+      LocatorsLinkedList[LocatorsLinkedList[_user][PREV].user][NEXT].user == _user) {
       return true;
     }
     return false;
   }
 
   /**
-    * @notice Returns the first signal smaller than _score
+    * @notice Returns the first Locator smaller than _score
     * @param _score uint256
     */
   function findPosition(
     uint256 _score
-  ) internal view returns (Signal memory) {
+  ) internal view returns (Locator memory) {
 
-    // Get the first signal in the linked list.
-    Signal storage signal = signalsLinkedList[HEAD][NEXT];
+    // Get the first Locator in the linked list.
+    Locator storage Locator = LocatorsLinkedList[HEAD][NEXT];
 
     if (_score == 0) {
       // return the head of the linked list
-      return signalsLinkedList[signal.user][PREV];
+      return LocatorsLinkedList[Locator.user][PREV];
     }
 
     // Iterate through the list until a lower score is found.
-    while (_score <= signal.score) {
-      signal = signalsLinkedList[signal.user][NEXT];
+    while (_score <= Locator.score) {
+      Locator = LocatorsLinkedList[Locator.user][NEXT];
     }
-    return signal;
+    return Locator;
   }
 
   /**
-    * @notice Link Two Signals
+    * @notice Link Two Locators
     *
-    * @param _left Signal
-    * @param _right Signal
+    * @param _left Locator
+    * @param _right Locator
     */
   function link(
-    Signal memory _left,
-    Signal memory _right
+    Locator memory _left,
+    Locator memory _right
   ) internal {
-    signalsLinkedList[_left.user][NEXT] = _right;
-    signalsLinkedList[_right.user][PREV] = _left;
+    LocatorsLinkedList[_left.user][NEXT] = _right;
+    LocatorsLinkedList[_right.user][PREV] = _left;
   }
 }

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -153,6 +153,7 @@ contract Index is Ownable {
   /**
     * @notice Get Valid Locators
     * @param _count uint256
+    * @return result bytes32[]
     */
   function fetchLocators(
     uint256 _count
@@ -217,7 +218,7 @@ contract Index is Ownable {
 
   /**
     * @notice Link Two Locators
-    *
+    * @dev helper function for linkedlist
     * @param _left Locator
     * @param _right Locator
     */

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -35,7 +35,7 @@ contract Index is Ownable {
   byte constant private NEXT = 0x01;
 
   // Mapping of user address to its neighbors
-  mapping(address => mapping(byte => Locator)) private LocatorsLinkedList;
+  mapping(address => mapping(byte => Locator)) private locatorsLinkedList;
 
   /**
     * @notice Locator for a Peer
@@ -72,8 +72,8 @@ contract Index is Ownable {
   constructor() public {
     // Initialize the linked list.
     Locator memory head = Locator(HEAD, 0, bytes32(0));
-    LocatorsLinkedList[HEAD][PREV] = head;
-    LocatorsLinkedList[HEAD][NEXT] = head;
+    locatorsLinkedList[HEAD][PREV] = head;
+    locatorsLinkedList[HEAD][NEXT] = head;
   }
 
   /**
@@ -97,7 +97,7 @@ contract Index is Ownable {
     Locator memory nextLocator = findPosition(_score);
 
     // Link the newLocator into place.
-    link(LocatorsLinkedList[nextLocator.user][PREV], newLocator);
+    link(locatorsLinkedList[nextLocator.user][PREV], newLocator);
     link(newLocator, nextLocator);
 
     // Increment the length of the linked list if successful.
@@ -120,11 +120,11 @@ contract Index is Ownable {
     }
 
     // Link its neighbors together.
-    link(LocatorsLinkedList[_user][PREV], LocatorsLinkedList[_user][NEXT]);
+    link(locatorsLinkedList[_user][PREV], locatorsLinkedList[_user][NEXT]);
 
     // Delete user from the list.
-    delete LocatorsLinkedList[_user][PREV];
-    delete LocatorsLinkedList[_user][NEXT];
+    delete locatorsLinkedList[_user][PREV];
+    delete locatorsLinkedList[_user][NEXT];
 
     // Decrement the length of the linked list.
     length = length - 1;
@@ -142,10 +142,10 @@ contract Index is Ownable {
   ) external view returns (Locator memory) {
 
     // Ensure the user has a neighbor in the linked list.
-    if (LocatorsLinkedList[_user][PREV].user != address(0)) {
+    if (locatorsLinkedList[_user][PREV].user != address(0)) {
 
       // Return the next Locator from the previous neighbor.
-      return LocatorsLinkedList[LocatorsLinkedList[_user][PREV].user][NEXT];
+      return locatorsLinkedList[locatorsLinkedList[_user][PREV].user][NEXT];
     }
     return Locator(address(0), 0, bytes32(0));
   }
@@ -166,14 +166,14 @@ contract Index is Ownable {
     result = new bytes32[](limit);
 
     // Get the first Locator in the linked list after the HEAD
-    Locator storage Locator = LocatorsLinkedList[HEAD][NEXT];
+    Locator storage Locator = locatorsLinkedList[HEAD][NEXT];
 
     // Iterate over the list until the end or limit.
     uint256 i = 0;
     while (i < limit) {
       result[i] = Locator.data;
       i = i + 1;
-      Locator = LocatorsLinkedList[Locator.user][NEXT];
+      Locator = locatorsLinkedList[Locator.user][NEXT];
     }
   }
 
@@ -185,8 +185,8 @@ contract Index is Ownable {
     address _user
   ) internal view returns (bool) {
 
-    if (LocatorsLinkedList[_user][PREV].user != address(0) &&
-      LocatorsLinkedList[LocatorsLinkedList[_user][PREV].user][NEXT].user == _user) {
+    if (locatorsLinkedList[_user][PREV].user != address(0) &&
+      locatorsLinkedList[locatorsLinkedList[_user][PREV].user][NEXT].user == _user) {
       return true;
     }
     return false;
@@ -201,16 +201,16 @@ contract Index is Ownable {
   ) internal view returns (Locator memory) {
 
     // Get the first Locator in the linked list.
-    Locator storage Locator = LocatorsLinkedList[HEAD][NEXT];
+    Locator storage Locator = locatorsLinkedList[HEAD][NEXT];
 
     if (_score == 0) {
       // return the head of the linked list
-      return LocatorsLinkedList[Locator.user][PREV];
+      return locatorsLinkedList[Locator.user][PREV];
     }
 
     // Iterate through the list until a lower score is found.
     while (_score <= Locator.score) {
-      Locator = LocatorsLinkedList[Locator.user][NEXT];
+      Locator = locatorsLinkedList[Locator.user][NEXT];
     }
     return Locator;
   }
@@ -225,7 +225,7 @@ contract Index is Ownable {
     Locator memory _left,
     Locator memory _right
   ) internal {
-    LocatorsLinkedList[_left.user][NEXT] = _right;
-    LocatorsLinkedList[_right.user][PREV] = _left;
+    locatorsLinkedList[_left.user][NEXT] = _right;
+    locatorsLinkedList[_right.user][PREV] = _left;
   }
 }

--- a/protocols/index/test/Index-test.js
+++ b/protocols/index/test/Index-test.js
@@ -45,83 +45,83 @@ contract('Index', async accounts => {
   })
 
   describe('Set', async () => {
-    it('Sets a signal for Alice', async () => {
-      await index.setSignal(aliceAddress, 2000, aliceAddress)
+    it('Sets a locator for Alice', async () => {
+      await index.setLocator(aliceAddress, 2000, aliceAddress)
     })
 
-    it('Sets a signal for Bob', async () => {
-      await index.setSignal(bobAddress, 500, bobAddress)
+    it('Sets a locator for Bob', async () => {
+      await index.setLocator(bobAddress, 500, bobAddress)
     })
 
-    it('Sets a signal for Carol', async () => {
-      await index.setSignal(carolAddress, 1500, carolAddress)
+    it('Sets a locator for Carol', async () => {
+      await index.setLocator(carolAddress, 1500, carolAddress)
     })
 
-    it('Sets a signal for David', async () => {
-      await index.setSignal(davidAddress, 100, davidAddress)
+    it('Sets a locator for David', async () => {
+      await index.setLocator(davidAddress, 100, davidAddress)
     })
 
-    it('Sets a signal of 0 for zara', async () => {
-      await index.setSignal(zaraAddress, 0, zaraAddress)
+    it('Sets a locator of 0 for zara', async () => {
+      await index.setLocator(zaraAddress, 0, zaraAddress)
     })
 
-    it("Sets a signal for Eve equal to Bob's signal", async () => {
-      await index.setSignal(eveAddress, 500, eveAddress)
+    it("Sets a locator for Eve equal to Bob's locator", async () => {
+      await index.setLocator(eveAddress, 500, eveAddress)
     })
 
     it('Ensure ordering is correct', async () => {
-      const signals = await index.fetchSignals(7)
-      assert(signals[0] == aliceLocator, 'Alice should be first')
-      assert(signals[1] == carolLocator, 'Carol should be second')
-      assert(signals[2] == bobLocator, 'Bob should be third')
-      assert(signals[3] == eveLocator, 'Eve should be fourth')
-      assert(signals[4] == davidLocator, 'David should be fifth')
-      assert(signals[5] == zaraLocator, 'Zara should be last')
+      const locators = await index.fetchLocators(7)
+      assert(locators[0] == aliceLocator, 'Alice should be first')
+      assert(locators[1] == carolLocator, 'Carol should be second')
+      assert(locators[2] == bobLocator, 'Bob should be third')
+      assert(locators[3] == eveLocator, 'Eve should be fourth')
+      assert(locators[4] == davidLocator, 'David should be fifth')
+      assert(locators[5] == zaraLocator, 'Zara should be last')
     })
   })
 
   describe('Get', async () => {
-    it('Gets the signal for Alice', async () => {
-      equal((await index.getSignal(aliceAddress)).locator, aliceLocator)
+    it('Gets the locator for Alice', async () => {
+      equal((await index.getLocator(aliceAddress)).data, aliceLocator)
     })
 
-    it('Gets the signal for Bob', async () => {
-      equal((await index.getSignal(bobAddress)).locator, bobLocator)
+    it('Gets the locator for Bob', async () => {
+      equal((await index.getLocator(bobAddress)).data, bobLocator)
     })
 
-    it('Gets the signal for Carol', async () => {
-      equal((await index.getSignal(carolAddress)).locator, carolLocator)
+    it('Gets the locator for Carol', async () => {
+      equal((await index.getLocator(carolAddress)).data, carolLocator)
     })
 
-    it('Gets the signal for David', async () => {
-      equal((await index.getSignal(davidAddress)).locator, davidLocator)
+    it('Gets the locator for David', async () => {
+      equal((await index.getLocator(davidAddress)).data, davidLocator)
     })
 
-    it('Gets the signal for Eve', async () => {
-      equal((await index.getSignal(eveAddress)).locator, eveLocator)
+    it('Gets the locator for Eve', async () => {
+      equal((await index.getLocator(eveAddress)).data, eveLocator)
     })
 
-    it('Gets the signal for Zara', async () => {
-      let zaraSignal = await index.getSignal(zaraAddress)
-      equal(zaraSignal.locator, zaraLocator)
-      equal(zaraSignal.score, 0)
+    it('Gets the locator for Zara', async () => {
+      let zaraLocator = await index.getLocator(zaraAddress)
+      equal(zaraLocator.data, zaraLocator.data)
+      equal(zaraLocator.score, 0)
     })
 
-    it('Gets a non existent signal', async () => {
-      let fredSignal = await index.getSignal(fredAddress)
-      equal(fredSignal.locator, emptyLocator)
+    it('Gets a non existent locator', async () => {
+      let fredLocator = await index.getLocator(fredAddress)
+      equal(fredLocator.data, emptyLocator)
     })
   })
 
   describe('Fetch', async () => {
-    it('Fetches signals', async () => {
-      const signals = await index.fetchSignals(7)
-      assert(signals[0] == aliceLocator, 'Alice should be first')
-      assert(signals[1] == carolLocator, 'Carol should be second')
-      assert(signals[2] == bobLocator, 'Bob should be third')
-      assert(signals[3] == eveLocator, 'Eve should be fourth')
-      assert(signals[4] == davidLocator, 'David should be fifth')
-      assert(signals[5] == zaraLocator, 'Zara should be last')
+    it('Fetches locators', async () => {
+      const locators = await index.fetchLocators(7)
+      assert(locators[0] == aliceLocator, 'Alice should be first')
+      assert(locators[1] == carolLocator, 'Carol should be second')
+      assert(locators[2] == bobLocator, 'Bob should be third')
+      assert(locators[3] == eveLocator, 'Eve should be fourth')
+      assert(locators[4] == davidLocator, 'David should be fifth')
+      assert(locators[5] == zaraLocator, 'Zara should be last')
       assert(BN(await index.length()).eq(6), 'Index length is incorrect')
     })
   })

--- a/protocols/index/test/Index-unit.js
+++ b/protocols/index/test/Index-unit.js
@@ -21,15 +21,15 @@ contract('Index Unit Tests', async accounts => {
   let snapshotId
   let index
 
-  let aliceLocator = padAddressToLocator(aliceAddress)
-  let bobLocator = padAddressToLocator(bobAddress)
-  let carolLocator = padAddressToLocator(carolAddress)
-  let emptyLocator = padAddressToLocator(EMPTY_ADDRESS)
+  let aliceLocatorData = padAddressToLocator(aliceAddress)
+  let bobLocatorData = padAddressToLocator(bobAddress)
+  let carolLocatorData = padAddressToLocator(carolAddress)
+  let emptyLocatorData = padAddressToLocator(EMPTY_ADDRESS)
 
   // helpers
   const USER = 'user'
   const SCORE = 'score'
-  const LOCATOR = 'locator'
+  const DATA = 'data'
 
   beforeEach(async () => {
     let snapShot = await takeSnapshot()
@@ -49,281 +49,286 @@ contract('Index Unit Tests', async accounts => {
       let listLength = await index.length()
       equal(listLength, 0, 'Link list length should be 0')
 
-      let signals = await index.fetchSignals(10)
-      equal(signals.length, 0, 'list should have 0 signals')
+      let locators = await index.fetchLocators(10)
+      equal(locators.length, 0, 'list should have 0 locators')
     })
   })
 
-  describe('Test setSignal', async () => {
-    it('should not allow a non owner to call setSignal', async () => {
+  describe('Test setLocator', async () => {
+    it('should not allow a non owner to call setLocator', async () => {
       await reverted(
-        index.setSignal(aliceAddress, 2000, aliceAddress, { from: nonOwner }),
+        index.setLocator(aliceAddress, 2000, aliceAddress, { from: nonOwner }),
         'Ownable: caller is not the owner'
       )
     })
 
-    it('should allow a signal to be inserted by the owner', async () => {
-      // set a signal from the owner
-      let result = await index.setSignal(aliceAddress, 2000, aliceLocator, {
-        from: owner,
-      })
+    it('should allow a locator to be inserted by the owner', async () => {
+      // set a locator from the owner
+      let result = await index.setLocator(
+        aliceAddress,
+        2000,
+        aliceLocatorData,
+        {
+          from: owner,
+        }
+      )
 
-      // check the SetSignal event was emitted
-      emitted(result, 'SetSignal', event => {
+      // check the SetLocator event was emitted
+      emitted(result, 'SetLocator', event => {
         return (
           event.user === aliceAddress &&
           event.score.toNumber() === 2000 &&
-          event.locator === aliceLocator
+          event.data === aliceLocatorData
         )
       })
 
       // check it has been inserted into the linked list correctly
-      let signals = await index.fetchSignals(10)
-      equal(signals.length, 1, 'list should have 1 signal')
-      equal(signals[0], aliceLocator, 'Alice should be in list')
+      let locators = await index.fetchLocators(10)
+      equal(locators.length, 1, 'list should have 1 locator')
+      equal(locators[0], aliceLocatorData, 'Alice should be in list')
 
       // check the length has increased
       let listLength = await index.length()
       equal(listLength, 1, 'Link list length should be 1')
     })
 
-    it('should insert subsequent signals in the correct order', async () => {
+    it('should insert subsequent locators in the correct order', async () => {
       // insert alice
-      await index.setSignal(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocatorData, {
         from: owner,
       })
 
       // now add more
-      let result = await index.setSignal(bobAddress, 500, bobLocator, {
+      let result = await index.setLocator(bobAddress, 500, bobLocatorData, {
         from: owner,
       })
 
-      // check the SetSignal event was emitted
-      emitted(result, 'SetSignal', event => {
+      // check the SetLocator event was emitted
+      emitted(result, 'SetLocator', event => {
         return (
           event.user === bobAddress &&
           event.score.toNumber() === 500 &&
-          event.locator === bobLocator
+          event.data === bobLocatorData
         )
       })
 
-      await index.setSignal(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocatorData, {
         from: owner,
       })
 
       let listLength = await index.length()
       equal(listLength, 3, 'Link list length should be 3')
 
-      const signals = await index.fetchSignals(7)
-      equal(signals[0], aliceLocator, 'Alice should be first')
-      equal(signals[1], carolLocator, 'Carol should be second')
-      equal(signals[2], bobLocator, 'Bob should be third')
+      const locators = await index.fetchLocators(7)
+      equal(locators[0], aliceLocatorData, 'Alice should be first')
+      equal(locators[1], carolLocatorData, 'Carol should be second')
+      equal(locators[2], bobLocatorData, 'Bob should be third')
     })
 
-    it('should not be able to set a second signal if one already exists for an address', async () => {
-      let trx = index.setSignal(aliceAddress, 2000, aliceLocator, {
+    it('should not be able to set a second locator if one already exists for an address', async () => {
+      let trx = index.setLocator(aliceAddress, 2000, aliceLocatorData, {
         from: owner,
       })
       await passes(trx)
-      trx = index.setSignal(aliceAddress, 5000, aliceLocator, {
+      trx = index.setLocator(aliceAddress, 5000, aliceLocatorData, {
         from: owner,
       })
-      await reverted(trx, 'SIGNAL_ALREADY_SET')
+      await reverted(trx, 'LOCATOR_ALREADY_SET')
 
       let length = await index.length.call()
       equal(length.toNumber(), 1, 'length increased, but total users has not')
     })
   })
 
-  describe('Test unsetSignal', async () => {
-    beforeEach('Setup signals', async () => {
-      await index.setSignal(aliceAddress, 2000, aliceLocator, {
+  describe('Test unsetLocator', async () => {
+    beforeEach('Setup locators', async () => {
+      await index.setLocator(aliceAddress, 2000, aliceLocatorData, {
         from: owner,
       })
-      await index.setSignal(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocatorData, {
         from: owner,
       })
-      await index.setSignal(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocatorData, {
         from: owner,
       })
     })
 
-    it('should not allow a non owner to call unsetSignal', async () => {
+    it('should not allow a non owner to call unsetLocator', async () => {
       await reverted(
-        index.unsetSignal(aliceAddress, { from: nonOwner }),
+        index.unsetLocator(aliceAddress, { from: nonOwner }),
         'Ownable: caller is not the owner'
       )
     })
 
     it('should leave state unchanged for someone who hasnt staked', async () => {
-      let returnValue = await index.unsetSignal.call(davidAddress, {
+      let returnValue = await index.unsetLocator.call(davidAddress, {
         from: owner,
       })
-      equal(returnValue, false, 'unsetSignal should have returned false')
+      equal(returnValue, false, 'unsetLocator should have returned false')
 
-      await index.unsetSignal(davidAddress, { from: owner })
+      await index.unsetLocator(davidAddress, { from: owner })
 
       let listLength = await index.length()
       equal(listLength, 3, 'Link list length should be 3')
 
-      const signals = await index.fetchSignals(7)
-      equal(signals[0], aliceLocator, 'Alice should be first')
-      equal(signals[1], carolLocator, 'Carol should be second')
-      equal(signals[2], bobLocator, 'Bob should be third')
+      const locators = await index.fetchLocators(7)
+      equal(locators[0], aliceLocatorData, 'Alice should be first')
+      equal(locators[1], carolLocatorData, 'Carol should be second')
+      equal(locators[2], bobLocatorData, 'Bob should be third')
     })
 
-    it('should unset the signal for a valid user', async () => {
+    it('should unset the locator for a valid user', async () => {
       // check it returns true
-      let returnValue = await index.unsetSignal.call(bobAddress, {
+      let returnValue = await index.unsetLocator.call(bobAddress, {
         from: owner,
       })
-      equal(returnValue, true, 'unsetSignal should have returned true')
+      equal(returnValue, true, 'unsetLocator should have returned true')
 
       // check it emits an event correctly
-      let result = await index.unsetSignal(bobAddress, { from: owner })
-      emitted(result, 'UnsetSignal', event => {
+      let result = await index.unsetLocator(bobAddress, { from: owner })
+      emitted(result, 'UnsetLocator', event => {
         return event.user === bobAddress
       })
 
       let listLength = await index.length()
       equal(listLength, 2, 'Link list length should be 2')
 
-      let signals = await index.fetchSignals(7)
-      equal(signals[0], aliceLocator, 'Alice should be first')
-      equal(signals[1], carolLocator, 'Carol should be second')
+      let locators = await index.fetchLocators(7)
+      equal(locators[0], aliceLocatorData, 'Alice should be first')
+      equal(locators[1], carolLocatorData, 'Carol should be second')
 
-      await index.unsetSignal(aliceAddress, { from: owner })
-      await index.unsetSignal(carolAddress, { from: owner })
+      await index.unsetLocator(aliceAddress, { from: owner })
+      await index.unsetLocator(carolAddress, { from: owner })
 
       listLength = await index.length()
       equal(listLength, 0, 'Link list length should be 0')
 
-      signals = await index.fetchSignals(10)
-      equal(signals.length, 0, 'list should have 0 signals')
+      locators = await index.fetchLocators(10)
+      equal(locators.length, 0, 'list should have 0 locators')
     })
 
-    it('unsetting signal twice in a row for an address has no effect', async () => {
-      let trx = index.unsetSignal(bobAddress, { from: owner })
+    it('unsetting locator twice in a row for an address has no effect', async () => {
+      let trx = index.unsetLocator(bobAddress, { from: owner })
       await passes(trx)
       let size = await index.length.call()
-      equal(size, 2, 'Signal was improperly removed')
-      trx = index.unsetSignal(bobAddress, { from: owner })
+      equal(size, 2, 'Locator was improperly removed')
+      trx = index.unsetLocator(bobAddress, { from: owner })
       await passes(trx)
-      equal(size, 2, 'Signal was improperly removed')
+      equal(size, 2, 'Locator was improperly removed')
 
-      let signals = await index.fetchSignals(7)
-      equal(signals[0], aliceLocator, 'Alice should be first')
-      equal(signals[1], carolLocator, 'Carol should be second')
+      let locators = await index.fetchLocators(7)
+      equal(locators[0], aliceLocatorData, 'Alice should be first')
+      equal(locators[1], carolLocatorData, 'Carol should be second')
     })
   })
 
-  describe('Test getSignal', async () => {
-    beforeEach('Setup signals again', async () => {
-      await index.setSignal(aliceAddress, 2000, aliceLocator, {
+  describe('Test getLocator', async () => {
+    beforeEach('Setup locators again', async () => {
+      await index.setLocator(aliceAddress, 2000, aliceLocatorData, {
         from: owner,
       })
-      await index.setSignal(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocatorData, {
         from: owner,
       })
-      await index.setSignal(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocatorData, {
         from: owner,
       })
     })
 
-    it('should return empty signal for a non-user', async () => {
-      let davidSignal = await index.getSignal(davidAddress)
+    it('should return empty locator for a non-user', async () => {
+      let davidLocator = await index.getLocator(davidAddress)
       equal(
-        davidSignal[USER],
+        davidLocator[USER],
         EMPTY_ADDRESS,
-        'David: Signal address not correct'
+        'David: Locator address not correct'
       )
-      equal(davidSignal[SCORE], 0, 'David: Signal score not correct')
-      equal(
-        davidSignal[LOCATOR],
-        emptyLocator,
-        'David: Signal locator not correct'
-      )
+      equal(davidLocator[SCORE], 0, 'David: Locator score not correct')
+      equal(davidLocator[DATA], emptyLocatorData, 'David: Locator not correct')
 
-      // now for a recently unset signal
-      await index.unsetSignal(carolAddress, { from: owner })
-      let carolSignal = await index.getSignal(carolAddress)
+      // now for a recently unset locator
+      await index.unsetLocator(carolAddress, { from: owner })
+      let testLocator = await index.getLocator(carolAddress)
       equal(
-        carolSignal[USER],
+        testLocator[USER],
         EMPTY_ADDRESS,
-        'Carol: Signal address not correct'
+        'Carol: Locator address not correct'
       )
-      equal(carolSignal[SCORE], 0, 'Carol: Signal score not correct')
+      equal(testLocator[SCORE], 0, 'Carol: Locator score not correct')
       equal(
-        carolSignal[LOCATOR],
-        emptyLocator,
-        'Carol: Signal locator not correct'
+        testLocator[DATA],
+        emptyLocatorData,
+        'Carol: Locator data not correct'
       )
     })
 
-    it('should return the correct signal for a valid user', async () => {
-      let aliceSignal = await index.getSignal(aliceAddress)
+    it('should return the correct locator for a valid user', async () => {
+      let aliceLocator = await index.getLocator(aliceAddress)
       equal(
-        aliceSignal[USER],
+        aliceLocator[USER],
         aliceAddress,
-        'Alice: Signal address not correct'
+        'Alice: Locator address not correct'
       )
-      equal(aliceSignal[SCORE], 2000, 'Alice: Signal score not correct')
+      equal(aliceLocator[SCORE], 2000, 'Alice: Locator score not correct')
       equal(
-        aliceSignal[LOCATOR],
-        aliceLocator,
-        'Alice: Signal locator not correct'
+        aliceLocator[DATA],
+        aliceLocatorData,
+        'Alice: Locator data not correct'
       )
 
-      let bobSignal = await index.getSignal(bobAddress)
-      equal(bobSignal[USER], bobAddress, 'Bob: signal address not correct')
-      equal(bobSignal[SCORE], 500, 'Bob: Signal score not correct')
-      equal(bobSignal[LOCATOR], bobLocator, 'Bob: Signal locator not correct')
+      let bobLocator = await index.getLocator(bobAddress)
+      equal(bobLocator[USER], bobAddress, 'Bob: locator address not correct')
+      equal(bobLocator[SCORE], 500, 'Bob: Locator score not correct')
+      equal(
+        bobLocator[DATA],
+        bobLocatorData,
+        'Bob: Locator locator data not correct'
+      )
     })
   })
 
-  describe('Test fetchSignals', async () => {
-    it('returns an empty array with no signals', async () => {
-      const signals = await index.fetchSignals(7)
-      equal(signals.length, 0, 'there should be no signals')
+  describe('Test fetchLocators', async () => {
+    it('returns an empty array with no locators', async () => {
+      const locators = await index.fetchLocators(7)
+      equal(locators.length, 0, 'there should be no locators')
     })
 
     it('returns specified number of elements if < length', async () => {
-      // add 3 signals
-      await index.setSignal(aliceAddress, 2000, aliceLocator, {
+      // add 3 locators
+      await index.setLocator(aliceAddress, 2000, aliceLocatorData, {
         from: owner,
       })
-      await index.setSignal(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocatorData, {
         from: owner,
       })
-      await index.setSignal(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocatorData, {
         from: owner,
       })
 
-      const signals = await index.fetchSignals(2)
-      equal(signals.length, 2, 'there should only be 2 signals returned')
+      const locators = await index.fetchLocators(2)
+      equal(locators.length, 2, 'there should only be 2 locators returned')
 
-      equal(signals[0], aliceLocator, 'Alice should be first')
-      equal(signals[1], carolLocator, 'Carol should be second')
+      equal(locators[0], aliceLocatorData, 'Alice should be first')
+      equal(locators[1], carolLocatorData, 'Carol should be second')
     })
 
     it('returns only length if requested number if larger', async () => {
-      // add 3 signals
-      await index.setSignal(aliceAddress, 2000, aliceLocator, {
+      // add 3 locators
+      await index.setLocator(aliceAddress, 2000, aliceLocatorData, {
         from: owner,
       })
-      await index.setSignal(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocatorData, {
         from: owner,
       })
-      await index.setSignal(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocatorData, {
         from: owner,
       })
 
-      const signals = await index.fetchSignals(10)
-      equal(signals.length, 3, 'there should only be 3 signals returned')
+      const locators = await index.fetchLocators(10)
+      equal(locators.length, 3, 'there should only be 3 locators returned')
 
-      equal(signals[0], aliceLocator, 'Alice should be first')
-      equal(signals[1], carolLocator, 'Carol should be second')
-      equal(signals[2], bobLocator, 'Bob should be third')
+      equal(locators[0], aliceLocatorData, 'Alice should be first')
+      equal(locators[1], carolLocatorData, 'Carol should be second')
+      equal(locators[2], bobLocatorData, 'Bob should be third')
     })
   })
 })

--- a/protocols/index/test/Index-unit.js
+++ b/protocols/index/test/Index-unit.js
@@ -326,21 +326,4 @@ contract('Index Unit Tests', async accounts => {
       equal(signals[2], bobLocator, 'Bob should be third')
     })
   })
-
-  describe('Test hasSignal', async () => {
-    it('should return false if the address has no signal', async () => {
-      let hasSignal = await index.hasSignal(aliceAddress)
-      equal(hasSignal, false, 'hasSignal should have returned false')
-    })
-
-    it('should return true if the address has a signal', async () => {
-      // give alice a signal
-      await index.setSignal(aliceAddress, 2000, aliceLocator, {
-        from: owner,
-      })
-      // now test again
-      let hasSignal = await index.hasSignal(aliceAddress)
-      equal(hasSignal, true, 'hasSignal should have returned true')
-    })
-  })
 })

--- a/protocols/index/test/Index-unit.js
+++ b/protocols/index/test/Index-unit.js
@@ -128,7 +128,7 @@ contract('Index Unit Tests', async accounts => {
       trx = index.setSignal(aliceAddress, 5000, aliceLocator, {
         from: owner,
       })
-      await reverted(trx, 'USER_HAS_ENTRY')
+      await reverted(trx, 'SIGNAL_ALREADY_SET')
 
       let length = await index.length.call()
       equal(length.toNumber(), 1, 'length increased, but total users has not')

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -133,7 +133,7 @@ contract Indexer is IIndexer, Ownable {
     require(!blacklist[_makerToken] && !blacklist[_takerToken],
       "INDEX_IS_BLACKLISTED");
 
-    // Ensure the market exists.
+    // Ensure the index exists.
     require(indexes[_makerToken][_takerToken] != Index(0),
       "INDEX_DOES_NOT_EXIST");
 
@@ -147,7 +147,7 @@ contract Indexer is IIndexer, Ownable {
 
     emit Stake(msg.sender, _makerToken, _takerToken, _amount);
 
-    // Set the signal on the market.
+    // Set the signal on the index.
     indexes[_makerToken][_takerToken].setSignal(msg.sender, _amount, _locator);
   }
 
@@ -163,7 +163,7 @@ contract Indexer is IIndexer, Ownable {
     address _takerToken
   ) external {
 
-    // Ensure the market exists.
+    // Ensure the index exists.
     require(indexes[_makerToken][_takerToken] != Index(0),
       "INDEX_DOES_NOT_EXIST");
 
@@ -172,9 +172,9 @@ contract Indexer is IIndexer, Ownable {
 
     // Ensure the signal exists.
     require(signal.user == msg.sender,
-      "ENTRY_DOES_NOT_EXIST");
+      "SIGNAL_DOES_NOT_EXIST");
 
-    // Unset the signal on the market.
+    // Unset the signal on the index.
     //No need to require() because a check is done above that reverts if there are no signals
     indexes[_makerToken][_takerToken].unsetSignal(msg.sender);
 
@@ -207,10 +207,10 @@ contract Indexer is IIndexer, Ownable {
     // Ensure neither token is blacklisted.
     if (!blacklist[_makerToken] && !blacklist[_takerToken]) {
 
-      // Ensure the market exists.
+      // Ensure the index exists.
       if (indexes[_makerToken][_takerToken] != Index(0)) {
 
-        // Return an array of locators for the market.
+        // Return an array of locators for the index.
         return indexes[_makerToken][_takerToken].fetchSignals(_count);
 
       }

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -55,7 +55,7 @@ contract Indexer is IIndexer, Ownable {
   }
 
   /**
-    * @notice Create an Index (List of Signals for a Token Pair)
+    * @notice Create an Index (List of Locators for a Token Pair)
     * @dev Deploys a new Index contract and stores the address
     *
     * @param _makerToken address
@@ -147,8 +147,8 @@ contract Indexer is IIndexer, Ownable {
 
     emit Stake(msg.sender, _makerToken, _takerToken, _amount);
 
-    // Set the signal on the index.
-    indexes[_makerToken][_takerToken].setSignal(msg.sender, _amount, _locator);
+    // Set the locator on the index.
+    indexes[_makerToken][_takerToken].setLocator(msg.sender, _amount, _locator);
   }
 
   /**
@@ -167,24 +167,24 @@ contract Indexer is IIndexer, Ownable {
     require(indexes[_makerToken][_takerToken] != Index(0),
       "INDEX_DOES_NOT_EXIST");
 
-    // Get the signal for the sender.
-    Index.Signal memory signal = indexes[_makerToken][_takerToken].getSignal(msg.sender);
+    // Get the locator for the sender.
+    Index.Locator memory locator = indexes[_makerToken][_takerToken].getLocator(msg.sender);
 
-    // Ensure the signal exists.
-    require(signal.user == msg.sender,
+    // Ensure the locator exists.
+    require(locator.user == msg.sender,
       "SIGNAL_DOES_NOT_EXIST");
 
-    // Unset the signal on the index.
-    //No need to require() because a check is done above that reverts if there are no signals
-    indexes[_makerToken][_takerToken].unsetSignal(msg.sender);
+    // Unset the locator on the index.
+    //No need to require() because a check is done above that reverts if there are no locators
+    indexes[_makerToken][_takerToken].unsetLocator(msg.sender);
 
-    if (signal.score > 0) {
+    if (locator.score > 0) {
       // Return the staked tokens. IERC20 returns boolean this contract may not be ours.
       // Need to revert when false is returned
-      require(stakeToken.transfer(msg.sender, signal.score));
+      require(stakeToken.transfer(msg.sender, locator.score));
     }
 
-    emit Unstake(msg.sender, _makerToken, _takerToken, signal.score);
+    emit Unstake(msg.sender, _makerToken, _takerToken, locator.score);
   }
 
   /**
@@ -211,7 +211,7 @@ contract Indexer is IIndexer, Ownable {
       if (indexes[_makerToken][_takerToken] != Index(0)) {
 
         // Return an array of locators for the index.
-        return indexes[_makerToken][_takerToken].fetchSignals(_count);
+        return indexes[_makerToken][_takerToken].fetchLocators(_count);
 
       }
     }

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -172,7 +172,7 @@ contract Indexer is IIndexer, Ownable {
 
     // Ensure the locator exists.
     require(locator.user == msg.sender,
-      "SIGNAL_DOES_NOT_EXIST");
+      "LOCATOR_DOES_NOT_EXIST");
 
     // Unset the locator on the index.
     //No need to require() because a check is done above that reverts if there are no locators

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -131,7 +131,7 @@ contract Indexer is IIndexer, Ownable {
 
     // Ensure both of the tokens are not blacklisted.
     require(!blacklist[_makerToken] && !blacklist[_takerToken],
-      "INDEX_IS_BLACKLISTED");
+      "TOKEN_IS_BLACKLISTED");
 
     // Ensure the index exists.
     require(indexes[_makerToken][_takerToken] != Index(0),

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -131,7 +131,7 @@ contract Indexer is IIndexer, Ownable {
 
     // Ensure both of the tokens are not blacklisted.
     require(!blacklist[_makerToken] && !blacklist[_takerToken],
-      "TOKEN_IS_BLACKLISTED");
+      "PAIR_IS_BLACKLISTED");
 
     // Ensure the index exists.
     require(indexes[_makerToken][_takerToken] != Index(0),

--- a/protocols/indexer/test/Indexer-unit.js
+++ b/protocols/indexer/test/Indexer-unit.js
@@ -326,7 +326,7 @@ contract('Indexer Unit Tests', async accounts => {
         indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
         }),
-        'USER_HAS_ENTRY'
+        'SIGNAL_ALREADY_SET'
       )
     })
   })
@@ -352,7 +352,7 @@ contract('Indexer Unit Tests', async accounts => {
         indexer.unsetIntent(tokenOne, tokenTwo, {
           from: aliceAddress,
         }),
-        'ENTRY_DOES_NOT_EXIST'
+        'SIGNAL_DOES_NOT_EXIST'
       )
     })
 

--- a/protocols/indexer/test/Indexer-unit.js
+++ b/protocols/indexer/test/Indexer-unit.js
@@ -207,12 +207,12 @@ contract('Indexer Unit Tests', async accounts => {
         from: owner,
       })
 
-      // now try to stake with an amount less than 250
+      // now try to stake with a blacklisted tokenOne
       await reverted(
         indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
         }),
-        'TOKEN_IS_BLACKLISTED'
+        'PAIR_IS_BLACKLISTED'
       )
 
       await indexer.removeFromBlacklist([tokenOne], {
@@ -224,12 +224,12 @@ contract('Indexer Unit Tests', async accounts => {
         from: owner,
       })
 
-      // now try to stake with an amount less than 250
+      // now try to stake with a blacklisted tokenTwo
       await reverted(
         indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
         }),
-        'TOKEN_IS_BLACKLISTED'
+        'PAIR_IS_BLACKLISTED'
       )
     })
 

--- a/protocols/indexer/test/Indexer-unit.js
+++ b/protocols/indexer/test/Indexer-unit.js
@@ -183,7 +183,7 @@ contract('Indexer Unit Tests', async accounts => {
   })
 
   describe('Test setIntent', async () => {
-    it('should not set a signal if the index doesnt exist', async () => {
+    it('should not set an intent if the index doesnt exist', async () => {
       await reverted(
         indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
@@ -192,7 +192,7 @@ contract('Indexer Unit Tests', async accounts => {
       )
     })
 
-    it('should not set a signal if the locator is not whitelisted', async () => {
+    it('should not set an intent if the locator is not whitelisted', async () => {
       await reverted(
         whitelistedIndexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
@@ -201,7 +201,7 @@ contract('Indexer Unit Tests', async accounts => {
       )
     })
 
-    it('should not set a signal if a token is blacklisted', async () => {
+    it('should not set an intent if a token is blacklisted', async () => {
       // blacklist tokenOne
       await indexer.addToBlacklist([tokenOne], {
         from: owner,
@@ -233,7 +233,7 @@ contract('Indexer Unit Tests', async accounts => {
       )
     })
 
-    it('should not set a signal if the staking tokens arent approved', async () => {
+    it('should not set an intent if the staking tokens arent approved', async () => {
       // make the index first
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
@@ -242,7 +242,7 @@ contract('Indexer Unit Tests', async accounts => {
       // The transfer is not approved
       await stakingTokenMock.givenAnyReturnBool(false)
 
-      // now try to set a signal
+      // now try to set an intent
       await reverted(
         indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
@@ -251,13 +251,13 @@ contract('Indexer Unit Tests', async accounts => {
       )
     })
 
-    it('should set a valid signal on a non-whitelisted indexer', async () => {
+    it('should set a valid intent on a non-whitelisted indexer', async () => {
       // make the index first
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
       })
 
-      // now set a signal
+      // now set an intent
       let result = await indexer.setIntent(
         tokenOne,
         tokenTwo,
@@ -279,7 +279,7 @@ contract('Indexer Unit Tests', async accounts => {
       })
     })
 
-    it('should set a valid signal on a whitelisted indexer', async () => {
+    it('should set a valid intent on a whitelisted indexer', async () => {
       // make the index first
       await whitelistedIndexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
@@ -288,7 +288,7 @@ contract('Indexer Unit Tests', async accounts => {
       // whitelist the locator
       await whitelistMock.givenAnyReturnBool(true)
 
-      // now set a signal
+      // now set an intent
       let result = await whitelistedIndexer.setIntent(
         tokenOne,
         tokenTwo,
@@ -310,13 +310,13 @@ contract('Indexer Unit Tests', async accounts => {
       })
     })
 
-    it('should not set a signal if the user has already staked', async () => {
+    it('should not set an intent if the user has already staked', async () => {
       // make the index first
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
       })
 
-      // set one signal
+      // set one intent
       await indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
         from: aliceAddress,
       })
@@ -332,7 +332,7 @@ contract('Indexer Unit Tests', async accounts => {
   })
 
   describe('Test unsetIntent', async () => {
-    it('should not unset a signal if the index doesnt exist', async () => {
+    it('should not unset an intent if the index doesnt exist', async () => {
       await reverted(
         indexer.unsetIntent(tokenOne, tokenTwo, {
           from: aliceAddress,
@@ -341,33 +341,33 @@ contract('Indexer Unit Tests', async accounts => {
       )
     })
 
-    it('should not unset a signal if the signal doesnt exist', async () => {
+    it('should not unset an intent if the intent does not exist', async () => {
       // create the index
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
       })
 
-      // now try to unset a non-existent signal
+      // now try to unset a non-existent intent
       await reverted(
         indexer.unsetIntent(tokenOne, tokenTwo, {
           from: aliceAddress,
         }),
-        'SIGNAL_DOES_NOT_EXIST'
+        'LOCATOR_DOES_NOT_EXIST'
       )
     })
 
-    it('should successfully unset a signal', async () => {
+    it('should successfully unset an intent', async () => {
       // create the index
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
       })
 
-      // create the signal
+      // create the intent
       await indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
         from: aliceAddress,
       })
 
-      // now try to unset the signal
+      // now try to unset the intent
       let tx = await indexer.unsetIntent(tokenOne, tokenTwo, {
         from: aliceAddress,
       })
@@ -384,13 +384,13 @@ contract('Indexer Unit Tests', async accounts => {
       })
     })
 
-    it('should revert if unset a signal failed in token transfer', async () => {
+    it('should revert if unset an intent failed in token transfer', async () => {
       // create the index
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
       })
 
-      // create the signal
+      // create the intent
       await indexer.setIntent(tokenOne, tokenTwo, 10, aliceLocator, {
         from: aliceAddress,
       })
@@ -414,8 +414,8 @@ contract('Indexer Unit Tests', async accounts => {
 
   describe('Test getIntents', async () => {
     it('should return an empty array if the index doesnt exist', async () => {
-      let signals = await indexer.getIntents.call(tokenOne, tokenTwo, 4)
-      equal(signals.length, 0, 'signals array should be empty')
+      let intents = await indexer.getIntents.call(tokenOne, tokenTwo, 4)
+      equal(intents.length, 0, 'intents array should be empty')
     })
 
     it('should return an empty array if a token is blacklisted', async () => {
@@ -424,7 +424,7 @@ contract('Indexer Unit Tests', async accounts => {
         from: aliceAddress,
       })
 
-      // set a signal staking 0
+      // set an intent staking 0
       await indexer.setIntent(tokenOne, tokenTwo, 0, aliceLocator, {
         from: aliceAddress,
       })
@@ -434,18 +434,18 @@ contract('Indexer Unit Tests', async accounts => {
         from: owner,
       })
 
-      // now try to get the signals
-      let signals = await indexer.getIntents.call(tokenOne, tokenTwo, 4)
-      equal(signals.length, 0, 'signals array should be empty')
+      // now try to get the intents
+      let intents = await indexer.getIntents.call(tokenOne, tokenTwo, 4)
+      equal(intents.length, 0, 'intents array should be empty')
     })
 
-    it('should otherwise return the signals', async () => {
+    it('should otherwise return the intents', async () => {
       // create index
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
       })
 
-      // set two signals
+      // set two intents
       await indexer.setIntent(tokenOne, tokenTwo, 50, aliceLocator, {
         from: aliceAddress,
       })
@@ -453,13 +453,13 @@ contract('Indexer Unit Tests', async accounts => {
         from: bobAddress,
       })
 
-      // now try to get the signals
-      let signals = await indexer.getIntents.call(tokenOne, tokenTwo, 4)
-      equal(signals.length, 2, 'signals array should be size 2')
+      // now try to get the intents
+      let intents = await indexer.getIntents.call(tokenOne, tokenTwo, 4)
+      equal(intents.length, 2, 'intents array should be size 2')
 
       // should only get the number specified
-      signals = await indexer.getIntents.call(tokenOne, tokenTwo, 1)
-      equal(signals.length, 1, 'signals array should be size 1')
+      intents = await indexer.getIntents.call(tokenOne, tokenTwo, 1)
+      equal(intents.length, 1, 'intents array should be size 1')
     })
   })
 })

--- a/protocols/indexer/test/Indexer-unit.js
+++ b/protocols/indexer/test/Indexer-unit.js
@@ -212,7 +212,7 @@ contract('Indexer Unit Tests', async accounts => {
         indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
         }),
-        'INDEX_IS_BLACKLISTED'
+        'TOKEN_IS_BLACKLISTED'
       )
 
       await indexer.removeFromBlacklist([tokenOne], {
@@ -229,7 +229,7 @@ contract('Indexer Unit Tests', async accounts => {
         indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
         }),
-        'INDEX_IS_BLACKLISTED'
+        'TOKEN_IS_BLACKLISTED'
       )
     })
 
@@ -326,7 +326,7 @@ contract('Indexer Unit Tests', async accounts => {
         indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
         }),
-        'SIGNAL_ALREADY_SET'
+        'LOCATOR_ALREADY_SET'
       )
     })
   })

--- a/protocols/indexer/test/Indexer.js
+++ b/protocols/indexer/test/Indexer.js
@@ -340,7 +340,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
             from: aliceAddress,
           }
         ),
-        'INDEX_IS_BLACKLISTED'
+        'TOKEN_IS_BLACKLISTED'
       )
     })
 

--- a/protocols/indexer/test/Indexer.js
+++ b/protocols/indexer/test/Indexer.js
@@ -340,7 +340,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
             from: aliceAddress,
           }
         ),
-        'TOKEN_IS_BLACKLISTED'
+        'PAIR_IS_BLACKLISTED'
       )
     })
 

--- a/protocols/indexer/test/Indexer.js
+++ b/protocols/indexer/test/Indexer.js
@@ -97,7 +97,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       equal(intents.length, 0)
     })
 
-    it('Alice attempts to stake and set a signal but fails due to no index', async () => {
+    it('Alice attempts to stake and set an intent but fails due to no index', async () => {
       await reverted(
         indexer.setIntent(
           tokenDAI.address,
@@ -114,7 +114,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
   })
 
   describe('Staking', async () => {
-    it('Alice attempts to stake with 0 and set a signal succeeds', async () => {
+    it('Alice attempts to stake with 0 and set an intent succeeds', async () => {
       emitted(
         await indexer.setIntent(
           tokenWETH.address,
@@ -129,7 +129,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       )
     })
 
-    it('Alice attempts to unset a signal and succeeds', async () => {
+    it('Alice attempts to unset an intent and succeeds', async () => {
       emitted(
         await indexer.unsetIntent(tokenWETH.address, tokenDAI.address, {
           from: aliceAddress,
@@ -184,7 +184,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       ok(await balances(indexerAddress, [[tokenAST, 0]]))
     })
 
-    it('Alice attempts to stake and set a signal succeeds', async () => {
+    it('Alice attempts to stake and set an intent succeeds', async () => {
       emitted(
         await indexer.setIntent(
           tokenWETH.address,
@@ -206,7 +206,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
   })
 
   describe('Intent integrity', async () => {
-    it('Bob ensures only one signal is on the Indexer', async () => {
+    it('Bob ensures only one intent is on the Indexer', async () => {
       const intents = await indexer.getIntents.call(
         tokenWETH.address,
         tokenDAI.address,
@@ -218,7 +218,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       equal(intents.length, 1)
     })
 
-    it('Bob ensures that Alice signal is on the Indexer', async () => {
+    it('Bob ensures that Alice intent is on the Indexer', async () => {
       const intents = await indexer.getIntents.call(
         tokenWETH.address,
         tokenDAI.address,
@@ -239,7 +239,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       )
     })
 
-    it('Alice attempts to unset a signal and succeeds', async () => {
+    it('Alice attempts to unset an intent and succeeds', async () => {
       emitted(
         await indexer.unsetIntent(tokenWETH.address, tokenDAI.address, {
           from: aliceAddress,
@@ -248,12 +248,12 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       )
     })
 
-    it('Alice attempts to unset an non-existent signal and reverts', async () => {
+    it('Alice attempts to unset a non-existent intent and reverts', async () => {
       await reverted(
         indexer.unsetIntent(tokenWETH.address, tokenDAI.address, {
           from: aliceAddress,
         }),
-        'SIGNAL_DOES_NOT_EXIST'
+        'LOCATOR_DOES_NOT_EXIST'
       )
     })
 
@@ -274,7 +274,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       equal(intents.length, 0)
     })
 
-    it('Alice attempts to set a signal and succeeds', async () => {
+    it('Alice attempts to set an intent and succeeds', async () => {
       emitted(
         await indexer.setIntent(
           tokenWETH.address,
@@ -308,7 +308,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       )
     })
 
-    it('Bob tries to fetch signal on blacklisted token which returns 0', async () => {
+    it('Bob tries to fetch intent on blacklisted token which returns 0', async () => {
       const intents = await indexer.getIntents.call(
         tokenWETH.address,
         tokenDAI.address,
@@ -329,7 +329,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       )
     })
 
-    it('Alice attempts to stake and set a signal and fails due to blacklist', async () => {
+    it('Alice attempts to stake and set an intent and fails due to blacklist', async () => {
       await reverted(
         indexer.setIntent(
           tokenWETH.address,
@@ -344,7 +344,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       )
     })
 
-    it('Alice attempts to unset a signal and succeeds regardless of blacklist', async () => {
+    it('Alice attempts to unset an intent and succeeds regardless of blacklist', async () => {
       emitted(
         await indexer.unsetIntent(tokenWETH.address, tokenDAI.address, {
           from: aliceAddress,
@@ -380,7 +380,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       )
     })
 
-    it('Alice attempts to stake and set a signal and succeeds', async () => {
+    it('Alice attempts to stake and set an intent and succeeds', async () => {
       emitted(
         await indexer.setIntent(
           tokenWETH.address,

--- a/protocols/indexer/test/Indexer.js
+++ b/protocols/indexer/test/Indexer.js
@@ -253,7 +253,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
         indexer.unsetIntent(tokenWETH.address, tokenDAI.address, {
           from: aliceAddress,
         }),
-        'ENTRY_DOES_NOT_EXIST'
+        'SIGNAL_DOES_NOT_EXIST'
       )
     })
 


### PR DESCRIPTION
## Description

Remove use of intent and instead use locator
From the viewpoint of the indexer, it should work with intents
Only the internal contract index works with locators
Locators are the name of the struct but the actual locator address/bytes32 is stored in the data field
Make sure REVERT_REASON use SIGNAL and not ENTRY

#Test 
Tests all pass with 100% coverage