### PR TITLE
Update Pragma Float to strict 0.5.10

### DIFF
--- a/examples/consumer/contracts/Consumer.sol
+++ b/examples/consumer/contracts/Consumer.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/swap/contracts/interfaces/ISwap.sol";

--- a/helpers/tokens/contracts/interfaces/IWETH.sol
+++ b/helpers/tokens/contracts/interfaces/IWETH.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 interface IWETH {
 

--- a/helpers/wrapper/contracts/Wrapper.sol
+++ b/helpers/wrapper/contracts/Wrapper.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/swap/contracts/interfaces/ISwap.sol";


### PR DESCRIPTION
replaces all `^0.5.10` to `0.5.10`

```
grep -rl $(find * -name '*.sol') -e "\^0.5.10" | xargs sed -i ".bak" -e "s/\^0.5.10/0.5.10/g"
```