### PR TITLE
Remove 'Side' from method signatures

### DIFF
--- a/examples/consumer/contracts/Consumer.sol
+++ b/examples/consumer/contracts/Consumer.sol
@@ -81,7 +81,7 @@ contract Consumer {
 
       // Get a buy quote from the Peer.
       uint256 userSendAmount = IPeer(address(bytes20(untrustedProbablyPeers[i])))
-        .getMakerSideQuote(_userReceiveAmount, _userReceiveToken, _userSendToken);
+        .getMakerQuote(_userReceiveAmount, _userReceiveToken, _userSendToken);
 
       // Update the lowest cost.
       if (userSendAmount > 0 && userSendAmount < lowestCost) {

--- a/examples/consumer/test/Consumer-unit.js
+++ b/examples/consumer/test/Consumer-unit.js
@@ -45,12 +45,12 @@ contract('Consumer Unit Tests', async () => {
     mockPeerLow = await MockContract.new()
     mockPeerLowLocator = padAddressToLocator(mockPeerLow.address)
 
-    //mock peer getMakerSideQuote()
-    let peer_getMakerSideQuote = peerTemplate.contract.methods
-      .getMakerSideQuote(0, EMPTY_ADDRESS, EMPTY_ADDRESS)
+    //mock peer getMakerQuote()
+    let peer_getMakerQuote = peerTemplate.contract.methods
+      .getMakerQuote(0, EMPTY_ADDRESS, EMPTY_ADDRESS)
       .encodeABI()
-    await mockPeerHigh.givenMethodReturnUint(peer_getMakerSideQuote, highVal)
-    await mockPeerLow.givenMethodReturnUint(peer_getMakerSideQuote, lowVal)
+    await mockPeerHigh.givenMethodReturnUint(peer_getMakerQuote, highVal)
+    await mockPeerLow.givenMethodReturnUint(peer_getMakerQuote, lowVal)
 
     // mock peer has owner()
     let peer_owner = peerTemplate.contract.methods.owner().encodeABI()

--- a/helpers/peer-frontend/contracts/PeerFrontend.sol
+++ b/helpers/peer-frontend/contracts/PeerFrontend.sol
@@ -46,7 +46,7 @@ contract PeerFrontend {
     * @return peerAddress bytes32
     * @return lowestCost uint256
     */
-  function getBestTakerSideQuote(
+  function getBestTakerQuote(
     uint256 _takerAmount, //peer
     address _takerToken, //peers
     address _makerToken, // thiscontract
@@ -69,7 +69,7 @@ contract PeerFrontend {
 
       // Get a buy quote from the Peer.
       uint256 makerAmount = IPeer(address(bytes20(locators[i])))
-        .getMakerSideQuote(_takerAmount, _takerToken, _makerToken);
+        .getMakerQuote(_takerAmount, _takerToken, _makerToken);
 
       // Update the lowest cost.
       if (makerAmount > 0 && makerAmount < lowestCost) {
@@ -92,7 +92,7 @@ contract PeerFrontend {
     * @return peerLocator bytes32  The amount of ERC-20 token the consumer would send
     * @return lowestCost uint256 The amount of ERC-20 token the consumer would send
     */
-  function getBestMakerSideQuote(
+  function getBestMakerQuote(
     uint256 _makerAmount,
     address _makerToken,
     address _takerToken,
@@ -114,7 +114,7 @@ contract PeerFrontend {
 
       // Get a buy quote from the Peer.
       uint256 takerAmount = IPeer(address(bytes20(locators[i])))
-        .getTakerSideQuote(_makerAmount, _makerToken, _takerToken);
+        .getTakerQuote(_makerAmount, _makerToken, _takerToken);
 
       // Update the lowest cost.
       if (takerAmount > 0 && takerAmount < lowestCost) {
@@ -128,7 +128,7 @@ contract PeerFrontend {
 
   }
 
-  function fillBestTakerSideOrder(
+  function fillBestTakerOrder(
     uint256 _takerAmount,
     address _takerToken,
     address _makerToken,
@@ -136,7 +136,7 @@ contract PeerFrontend {
   ) external {
 
     // Find the best buy among Indexed Peers.
-    (bytes32 peerLocator, uint256 makerAmount) = getBestTakerSideQuote(
+    (bytes32 peerLocator, uint256 makerAmount) = getBestTakerQuote(
       _takerAmount,
       _takerToken,
       _makerToken,
@@ -184,7 +184,7 @@ contract PeerFrontend {
     IERC20(_takerToken).transfer(msg.sender, _takerAmount);
   }
 
-  function fillBestMakerSideOrder(
+  function fillBestMakerOrder(
     uint256 _makerAmount,
     address _makerToken,
     address _takerToken,
@@ -192,7 +192,7 @@ contract PeerFrontend {
   ) external {
 
     // Find the best buy among Indexed Peers.
-    (bytes32 peerLocator, uint256 takerAmount) = getBestMakerSideQuote(
+    (bytes32 peerLocator, uint256 takerAmount) = getBestMakerQuote(
       _makerAmount,
       _makerToken,
       _takerToken,

--- a/helpers/peer-frontend/test/PeerFrontend-unit.js
+++ b/helpers/peer-frontend/test/PeerFrontend-unit.js
@@ -45,19 +45,19 @@ contract('PeerFrontend Unit Tests', async () => {
     mockPeerLow = await MockContract.new()
     mockPeerLowLocator = padAddressToLocator(mockPeerLow.address)
 
-    //mock peer getMakerSideQuote()
-    let peer_getMakerSideQuote = peerTemplate.contract.methods
-      .getMakerSideQuote(0, EMPTY_ADDRESS, EMPTY_ADDRESS)
+    //mock peer getMakerQuote()
+    let peer_getMakerQuote = peerTemplate.contract.methods
+      .getMakerQuote(0, EMPTY_ADDRESS, EMPTY_ADDRESS)
       .encodeABI()
-    await mockPeerHigh.givenMethodReturnUint(peer_getMakerSideQuote, highVal)
-    await mockPeerLow.givenMethodReturnUint(peer_getMakerSideQuote, lowVal)
+    await mockPeerHigh.givenMethodReturnUint(peer_getMakerQuote, highVal)
+    await mockPeerLow.givenMethodReturnUint(peer_getMakerQuote, lowVal)
 
-    //mock peer getMakerSideQuote()
-    let peer_getTakerSideQuote = peerTemplate.contract.methods
-      .getTakerSideQuote(0, EMPTY_ADDRESS, EMPTY_ADDRESS)
+    //mock peer getMakerQuote()
+    let peer_getTakerQuote = peerTemplate.contract.methods
+      .getTakerQuote(0, EMPTY_ADDRESS, EMPTY_ADDRESS)
       .encodeABI()
-    await mockPeerHigh.givenMethodReturnUint(peer_getTakerSideQuote, highVal)
-    await mockPeerLow.givenMethodReturnUint(peer_getTakerSideQuote, lowVal)
+    await mockPeerHigh.givenMethodReturnUint(peer_getTakerQuote, highVal)
+    await mockPeerLow.givenMethodReturnUint(peer_getTakerQuote, lowVal)
 
     // mock peer has owner()
     let peer_owner = peerTemplate.contract.methods.owner().encodeABI()
@@ -114,7 +114,7 @@ contract('PeerFrontend Unit Tests', async () => {
     })
   })
 
-  describe('Test getBestTakerSideQuote()', async () => {
+  describe('Test getBestTakerQuote()', async () => {
     it('test default values are returned with an empty indexer', async () => {
       //mock indexer getIntents() where there are no locators
       await mockIndexer.givenMethodReturn(
@@ -122,7 +122,7 @@ contract('PeerFrontend Unit Tests', async () => {
         abi.rawEncode(['bytes32[]'], [[]])
       )
 
-      let val = await peerFrontend.getBestTakerSideQuote.call(
+      let val = await peerFrontend.getBestTakerQuote.call(
         180,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
@@ -145,7 +145,7 @@ contract('PeerFrontend Unit Tests', async () => {
       )
 
       //this should always select the lowest cost peer available
-      let val = await peerFrontend.getBestTakerSideQuote.call(
+      let val = await peerFrontend.getBestTakerQuote.call(
         180,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
@@ -167,7 +167,7 @@ contract('PeerFrontend Unit Tests', async () => {
       )
 
       //this should always select the lowest cost peer available
-      let val = await peerFrontend.getBestTakerSideQuote.call(
+      let val = await peerFrontend.getBestTakerQuote.call(
         180,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
@@ -178,7 +178,7 @@ contract('PeerFrontend Unit Tests', async () => {
     })
   })
 
-  describe('Test getBestMakerSideQuote()', async () => {
+  describe('Test getBestMakerQuote()', async () => {
     it('test default values are returned with an empty indexer', async () => {
       //mock indexer getIntents() where there are no locators
       await mockIndexer.givenMethodReturn(
@@ -186,7 +186,7 @@ contract('PeerFrontend Unit Tests', async () => {
         abi.rawEncode(['bytes32[]'], [[]])
       )
 
-      let val = await peerFrontend.getBestMakerSideQuote.call(
+      let val = await peerFrontend.getBestMakerQuote.call(
         180,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
@@ -209,7 +209,7 @@ contract('PeerFrontend Unit Tests', async () => {
       )
 
       //this should always select the lowest cost peer available
-      let val = await peerFrontend.getBestMakerSideQuote.call(
+      let val = await peerFrontend.getBestMakerQuote.call(
         180,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
@@ -231,7 +231,7 @@ contract('PeerFrontend Unit Tests', async () => {
       )
 
       //this should always select the lowest cost peer available
-      let val = await peerFrontend.getBestMakerSideQuote.call(
+      let val = await peerFrontend.getBestMakerQuote.call(
         180,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,

--- a/helpers/peer-frontend/test/PeerFrontend-unit.js
+++ b/helpers/peer-frontend/test/PeerFrontend-unit.js
@@ -243,7 +243,7 @@ contract('PeerFrontend Unit Tests', async () => {
     })
   })
 
-  describe('Test fillBestTakerSideOrder()', async () => {
+  describe('Test fillBestTakerOrder()', async () => {
     it('test by ensuring all internal methods are called', async () => {
       //mock indexer getIntents() where locators are ordered low to high
       await mockIndexer.givenMethodReturn(
@@ -254,7 +254,7 @@ contract('PeerFrontend Unit Tests', async () => {
         )
       )
 
-      let trx = await peerFrontend.fillBestTakerSideOrder(
+      let trx = await peerFrontend.fillBestTakerOrder(
         180,
         mockUserSendToken.address,
         mockUserReceiveToken.address,

--- a/helpers/peer-frontend/test/PeerFrontend.js
+++ b/helpers/peer-frontend/test/PeerFrontend.js
@@ -128,7 +128,7 @@ contract('PeerFrontend', async accounts => {
   describe('PeerFrontend - fills for non-existent quotes', async () => {
     it('Finds best price to buy 100 AST for DAI - reverts ', async () => {
       await reverted(
-        peerfrontend.fillBestMakerSideOrder.call(
+        peerfrontend.fillBestMakerOrder.call(
           100,
           tokenAST.address,
           tokenDAI.address,
@@ -140,7 +140,7 @@ contract('PeerFrontend', async accounts => {
 
     it('Finds best price to sell 100 AST for DAI - reverts', async () => {
       await reverted(
-        peerfrontend.fillBestTakerSideOrder.call(
+        peerfrontend.fillBestTakerOrder.call(
           100,
           tokenAST.address,
           tokenDAI.address,
@@ -187,7 +187,7 @@ contract('PeerFrontend', async accounts => {
     })
 
     it('Finds best price to buy 1 WETH for DAI', async () => {
-      const quote = await peerfrontend.getBestTakerSideQuote.call(
+      const quote = await peerfrontend.getBestTakerQuote.call(
         100,
         tokenWETH.address,
         tokenDAI.address,
@@ -198,7 +198,7 @@ contract('PeerFrontend', async accounts => {
     })
 
     it('Finds best price to very large WETH amount for DAI', async () => {
-      const quote = await peerfrontend.getBestTakerSideQuote.call(
+      const quote = await peerfrontend.getBestTakerQuote.call(
         10000000,
         tokenWETH.address,
         tokenDAI.address,
@@ -233,7 +233,7 @@ contract('PeerFrontend', async accounts => {
       )
 
       // Carol takes the best price for 100 DAI
-      await peerfrontend.fillBestTakerSideOrder(
+      await peerfrontend.fillBestTakerOrder(
         100,
         tokenWETH.address,
         tokenDAI.address,
@@ -260,7 +260,7 @@ contract('PeerFrontend', async accounts => {
 
   describe('PeerFrontend - MakerSide', async () => {
     it('Finds best price to buy 309 DAI for WETH', async () => {
-      const quote = await peerfrontend.getBestMakerSideQuote.call(
+      const quote = await peerfrontend.getBestMakerQuote.call(
         15476,
         tokenDAI.address,
         tokenWETH.address,
@@ -278,7 +278,7 @@ contract('PeerFrontend', async accounts => {
     it('Takes best price (Alice peer) - MakerSide', async () => {
       await advanceTimeAndBlock(10)
       // Carol takes the best price for 100 DAI
-      await peerfrontend.fillBestMakerSideOrder(
+      await peerfrontend.fillBestMakerOrder(
         15476,
         tokenDAI.address,
         tokenWETH.address,

--- a/protocols/peer/contracts/Peer.sol
+++ b/protocols/peer/contracts/Peer.sol
@@ -113,7 +113,7 @@ contract Peer is IPeer, Ownable {
     * @param _makerToken address The address of an ERC-20 token the consumer would send
     * @return uint256 makerParam The amount of ERC-20 token the consumer would send
     */
-  function getMakerSideQuote(
+  function getMakerQuote(
     uint256 _takerParam,
     address _takerToken,
     address _makerToken
@@ -147,7 +147,7 @@ contract Peer is IPeer, Ownable {
     * @param _takerToken address The address of an ERC-20 token the peer would send
     * @return uint256 takerParam The amount of ERC-20 token the peer would send
     */
-  function getTakerSideQuote(
+  function getTakerQuote(
     uint256 _makerParam,
     address _makerToken,
     address _takerToken

--- a/protocols/peer/contracts/interfaces/IPeer.sol
+++ b/protocols/peer/contracts/interfaces/IPeer.sol
@@ -55,7 +55,7 @@ interface IPeer {
     address _makerToken
   ) external;
 
-  function getMakerSideQuote(
+  function getMakerQuote(
     uint256 _takerParam,
     address _takerToken,
     address _makerToken
@@ -63,7 +63,7 @@ interface IPeer {
     uint256 makerParam
   );
 
-  function getTakerSideQuote(
+  function getTakerQuote(
     uint256 _makerParam,
     address _makerToken,
     address _takerToken

--- a/protocols/peer/test/Peer-unit.js
+++ b/protocols/peer/test/Peer-unit.js
@@ -169,10 +169,10 @@ contract('Peer Unit Tests', async accounts => {
     })
   })
 
-  describe('Test getMakerSideQuote', async () => {
+  describe('Test getMakerQuote', async () => {
     it('test when rule does not exist', async () => {
       const NON_EXISTENT_TAKER_TOKEN = accounts[7]
-      let val = await peer.getMakerSideQuote.call(
+      let val = await peer.getMakerQuote.call(
         1234,
         NON_EXISTENT_TAKER_TOKEN,
         MAKER_TOKEN
@@ -192,7 +192,7 @@ contract('Peer Unit Tests', async accounts => {
         PRICE_COEF,
         EXP
       )
-      let val = await peer.getMakerSideQuote.call(
+      let val = await peer.getMakerQuote.call(
         MAX_TAKER_AMOUNT + 1,
         TAKER_TOKEN,
         MAKER_TOKEN
@@ -212,7 +212,7 @@ contract('Peer Unit Tests', async accounts => {
         PRICE_COEF,
         EXP
       )
-      let val = await peer.getMakerSideQuote.call(0, TAKER_TOKEN, MAKER_TOKEN)
+      let val = await peer.getMakerQuote.call(0, TAKER_TOKEN, MAKER_TOKEN)
       equal(
         val.toNumber(),
         0,
@@ -220,7 +220,7 @@ contract('Peer Unit Tests', async accounts => {
       )
     })
 
-    it('test a successful call - getMakerSideQuote', async () => {
+    it('test a successful call - getMakerQuote', async () => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
@@ -229,7 +229,7 @@ contract('Peer Unit Tests', async accounts => {
         EXP
       )
 
-      let val = await peer.getMakerSideQuote.call(
+      let val = await peer.getMakerQuote.call(
         1234,
         TAKER_TOKEN,
         MAKER_TOKEN
@@ -239,9 +239,9 @@ contract('Peer Unit Tests', async accounts => {
     })
   })
 
-  describe('Test getTakerSideQuote', async () => {
+  describe('Test getTakerQuote', async () => {
     it('test when rule does not exist', async () => {
-      let val = await peer.getTakerSideQuote.call(
+      let val = await peer.getTakerQuote.call(
         4312,
         MAKER_TOKEN,
         TAKER_TOKEN
@@ -255,14 +255,14 @@ contract('Peer Unit Tests', async accounts => {
 
     it('test when peer amount is not within acceptable value bounds', async () => {
       await peer.setRule(TAKER_TOKEN, MAKER_TOKEN, 100, 1, 0)
-      let val = await peer.getTakerSideQuote.call(0, MAKER_TOKEN, TAKER_TOKEN)
+      let val = await peer.getTakerQuote.call(0, MAKER_TOKEN, TAKER_TOKEN)
       equal(
         val.toNumber(),
         0,
         'no quote should be available if returned peer amount is 0'
       )
 
-      val = await peer.getTakerSideQuote.call(
+      val = await peer.getTakerQuote.call(
         MAX_TAKER_AMOUNT + 1,
         MAKER_TOKEN,
         TAKER_TOKEN
@@ -274,7 +274,7 @@ contract('Peer Unit Tests', async accounts => {
       )
     })
 
-    it('test a successful call - getTakerSideQuote', async () => {
+    it('test a successful call - getTakerQuote', async () => {
       await peer.setRule(
         TAKER_TOKEN,
         MAKER_TOKEN,
@@ -283,7 +283,7 @@ contract('Peer Unit Tests', async accounts => {
         EXP
       )
 
-      let val = await peer.getTakerSideQuote.call(500, MAKER_TOKEN, TAKER_TOKEN)
+      let val = await peer.getTakerQuote.call(500, MAKER_TOKEN, TAKER_TOKEN)
       let expectedValue = Math.floor((500 * 10 ** EXP) / PRICE_COEF)
       equal(val.toNumber(), expectedValue, 'there should be a quote available')
     })

--- a/protocols/peer/test/Peer-unit.js
+++ b/protocols/peer/test/Peer-unit.js
@@ -229,11 +229,7 @@ contract('Peer Unit Tests', async accounts => {
         EXP
       )
 
-      let val = await peer.getMakerQuote.call(
-        1234,
-        TAKER_TOKEN,
-        MAKER_TOKEN
-      )
+      let val = await peer.getMakerQuote.call(1234, TAKER_TOKEN, MAKER_TOKEN)
       let expectedValue = Math.floor((1234 * PRICE_COEF) / 10 ** EXP)
       equal(val.toNumber(), expectedValue, 'there should be a quote available')
     })
@@ -241,11 +237,7 @@ contract('Peer Unit Tests', async accounts => {
 
   describe('Test getTakerQuote', async () => {
     it('test when rule does not exist', async () => {
-      let val = await peer.getTakerQuote.call(
-        4312,
-        MAKER_TOKEN,
-        TAKER_TOKEN
-      )
+      let val = await peer.getTakerQuote.call(4312, MAKER_TOKEN, TAKER_TOKEN)
       equal(
         val.toNumber(),
         0,

--- a/protocols/peer/test/Peer.js
+++ b/protocols/peer/test/Peer.js
@@ -67,7 +67,7 @@ contract('Peer', async accounts => {
         0
       )
       equal(
-        await alicePeer.getMakerSideQuote.call(
+        await alicePeer.getMakerQuote.call(
           1,
           tokenWETH.address,
           tokenDAI.address
@@ -76,7 +76,7 @@ contract('Peer', async accounts => {
       )
       await alicePeer.unsetRule(tokenWETH.address, tokenDAI.address)
       equal(
-        await alicePeer.getMakerSideQuote.call(
+        await alicePeer.getMakerQuote.call(
           1,
           tokenWETH.address,
           tokenDAI.address
@@ -96,7 +96,7 @@ contract('Peer', async accounts => {
         0
       )
       equal(
-        await alicePeer.getMakerSideQuote.call(
+        await alicePeer.getMakerQuote.call(
           1,
           tokenWETH.address,
           tokenDAI.address
@@ -113,7 +113,7 @@ contract('Peer', async accounts => {
         4
       )
       equal(
-        await alicePeer.getMakerSideQuote.call(
+        await alicePeer.getMakerQuote.call(
           100000,
           tokenDAI.address,
           tokenWETH.address
@@ -130,7 +130,7 @@ contract('Peer', async accounts => {
         3
       )
       equal(
-        await alicePeer.getMakerSideQuote.call(
+        await alicePeer.getMakerQuote.call(
           20000,
           tokenWETH.address,
           tokenDAI.address
@@ -158,7 +158,7 @@ contract('Peer', async accounts => {
     )
 
     it('Gets a quote to buy 20K DAI for WETH (Quote: 64 WETH)', async () => {
-      const quote = await alicePeer.getMakerSideQuote.call(
+      const quote = await alicePeer.getMakerQuote.call(
         20000,
         tokenDAI.address,
         tokenWETH.address
@@ -167,7 +167,7 @@ contract('Peer', async accounts => {
     })
 
     it('Gets a quote to sell 100K (Max) DAI for WETH (Quote: 320 WETH)', async () => {
-      const quote = await alicePeer.getMakerSideQuote.call(
+      const quote = await alicePeer.getMakerQuote.call(
         100000,
         tokenDAI.address,
         tokenWETH.address
@@ -176,7 +176,7 @@ contract('Peer', async accounts => {
     })
 
     it('Gets a quote to sell 1 WETH for DAI (Quote: 300 DAI)', async () => {
-      const quote = await alicePeer.getTakerSideQuote.call(
+      const quote = await alicePeer.getTakerQuote.call(
         1,
         tokenWETH.address,
         tokenDAI.address
@@ -185,7 +185,7 @@ contract('Peer', async accounts => {
     })
 
     it('Gets a quote to sell 5 WETH for DAI (False: No rule)', async () => {
-      const quote = await alicePeer.getTakerSideQuote.call(
+      const quote = await alicePeer.getTakerQuote.call(
         5,
         tokenDAI.address,
         tokenWETH.address
@@ -203,7 +203,7 @@ contract('Peer', async accounts => {
     })
 
     it('Gets a quote to buy 1500 WETH for DAI (False: Exceeds Max)', async () => {
-      const quote = await alicePeer.getMakerSideQuote.call(
+      const quote = await alicePeer.getMakerQuote.call(
         250000,
         tokenDAI.address,
         tokenWETH.address
@@ -215,7 +215,7 @@ contract('Peer', async accounts => {
   describe('Provide some orders to the Peer', async () => {
     let quote
     before('Gets a quote for 1 WETH', async () => {
-      quote = await alicePeer.getTakerSideQuote.call(
+      quote = await alicePeer.getTakerQuote.call(
         1,
         tokenWETH.address,
         tokenDAI.address


### PR DESCRIPTION
## Description
'side' is redundant if keywords `Maker` or `Taker` was already defined in the method signature.
Accidentally created off of https://github.com/airswap/airswap-protocols/pull/133
This PR removes 'side' keyword from method names

