### PR TITLE
Separate approvals

### DIFF
--- a/helpers/delegate-frontend/contracts/DelegateFrontend.sol
+++ b/helpers/delegate-frontend/contracts/DelegateFrontend.sol
@@ -166,7 +166,7 @@ contract DelegateFrontend {
     IERC20(_signerToken).approve(address(swapContract), signerAmount);
 
     // DelegateFrontend authorizes the Delegate.
-    swapContract.authorize(delegateContract, block.timestamp + 1);
+    swapContract.authorizeSigner(delegateContract, block.timestamp + 1);
 
     // DelegateFrontend provides unsigned order to Delegate.
     IDelegate(delegateContract).provideOrder(Types.Order(
@@ -194,7 +194,7 @@ contract DelegateFrontend {
     ));
 
     // DelegateFrontend revokes the authorization of the Delegate.
-    swapContract.revoke(delegateContract);
+    swapContract.revokeSigner(delegateContract);
 
     // DelegateFrontend transfers received amount to the User.
     IERC20(_senderToken).transfer(msg.sender, _senderAmount);
@@ -236,7 +236,7 @@ contract DelegateFrontend {
     IERC20(_signerToken).approve(address(swapContract), _signerAmount);
 
     // DelegateFrontend authorizes the Delegate.
-    swapContract.authorize(delegateContract, block.timestamp + 1);
+    swapContract.authorizeSigner(delegateContract, block.timestamp + 1);
 
     // DelegateFrontend provides unsigned order to Delegate.
     IDelegate(delegateContract).provideOrder(Types.Order(
@@ -265,7 +265,7 @@ contract DelegateFrontend {
     ));
 
     // DelegateFrontend revokes the authorization of the Delegate.
-    swapContract.revoke(delegateContract);
+    swapContract.revokeSigner(delegateContract);
 
     // DelegateFrontend transfers received amount to the User.
     IERC20(_senderToken).transfer(msg.sender, senderAmount);

--- a/helpers/delegate-frontend/test/DelegateFrontend.js
+++ b/helpers/delegate-frontend/test/DelegateFrontend.js
@@ -80,14 +80,14 @@ contract('DelegateFrontend', async accounts => {
       )
     })
 
-    it('Alice authorizes the new delegate', async () => {
+    it('Alice authorizes the new delegate to be an AuthorizedSender', async () => {
       emitted(
-        await swapContract.authorize(
+        await swapContract.authorizeSender(
           aliceDelegate.address,
           await getTimestampPlusDays(1),
           { from: aliceAddress }
         ),
-        'Authorize'
+        'AuthorizeSender'
       )
     })
 

--- a/helpers/wrapper/test/Wrapper.js
+++ b/helpers/wrapper/test/Wrapper.js
@@ -98,13 +98,13 @@ contract('Wrapper', async ([aliceAddress, bobAddress, carolAddress]) => {
     })
   })
 
-  it('Bob authorizes the Wrapper to send orders on his behalf', async () => {
+  it('Bob authorizesSender the Wrapper to send orders on his behalf', async () => {
     let expiry = await getTimestampPlusDays(1)
-    let tx = await swapContract.authorize(wrapperAddress, expiry, {
+    let tx = await swapContract.authorizeSender(wrapperAddress, expiry, {
       from: bobAddress,
     })
     passes(tx)
-    emitted(tx, 'Authorize')
+    emitted(tx, 'AuthorizeSender')
   })
 
   describe('Wrap Buys', async () => {
@@ -147,11 +147,11 @@ contract('Wrapper', async ([aliceAddress, bobAddress, carolAddress]) => {
 
     it('Alice authorizes the Wrapper to send orders on her behalf', async () => {
       let expiry = await getTimestampPlusDays(1)
-      let tx = await swapContract.authorize(wrapperAddress, expiry, {
+      let tx = await swapContract.authorizeSender(wrapperAddress, expiry, {
         from: aliceAddress,
       })
       passes(tx)
-      emitted(tx, 'Authorize')
+      emitted(tx, 'AuthorizeSender')
     })
 
     it('Alice approves the Wrapper contract to move her WETH', async () => {
@@ -259,11 +259,11 @@ contract('Wrapper', async ([aliceAddress, bobAddress, carolAddress]) => {
 
     it('Bob authorizes the Wrapper to send orders on her behalf', async () => {
       let expiry = await getTimestampPlusDays(1)
-      let tx = await swapContract.authorize(wrapperAddress, expiry, {
+      let tx = await swapContract.authorizeSender(wrapperAddress, expiry, {
         from: bobAddress,
       })
       passes(tx)
-      emitted(tx, 'Authorize')
+      emitted(tx, 'AuthorizeSender')
     })
 
     it('Send order where Bob sends AST to Alice for DAI', async () => {

--- a/helpers/wrapper/test/Wrapper.js
+++ b/helpers/wrapper/test/Wrapper.js
@@ -96,7 +96,7 @@ contract('Wrapper', async ([aliceAddress, bobAddress, carolAddress]) => {
     })
   })
 
-  it('Bob authorizesSender the Wrapper to send orders on his behalf', async () => {
+  it('Bob authorizes the Wrapper to send orders on his behalf', async () => {
     let expiry = await getTimestampPlusDays(1)
     let tx = await swapContract.authorizeSender(wrapperAddress, expiry, {
       from: bobAddress,

--- a/protocols/delegate/test/Delegate.js
+++ b/protocols/delegate/test/Delegate.js
@@ -337,7 +337,7 @@ contract('Delegate', async accounts => {
       )
     })
 
-    it("should not trade if the tradeWallet hasn't authorized the delegate", async () => {
+    it("should not trade if the tradeWallet hasn't authorized the delegate to send", async () => {
       const order = await orders.getOrder({
         signer: {
           wallet: bobAddress,
@@ -373,12 +373,16 @@ contract('Delegate', async accounts => {
         },
       })
 
-      // authorize the delegate
+      // authorize the delegate to be sender
       let expiry = await getTimestampPlusDays(0.5)
-      let tx = await swapContract.authorize(aliceDelegate.address, expiry, {
-        from: aliceTradeWallet,
-      })
-      emitted(tx, 'Authorize')
+      let tx = await swapContract.authorizeSender(
+        aliceDelegate.address,
+        expiry,
+        {
+          from: aliceTradeWallet,
+        }
+      )
+      emitted(tx, 'AuthorizeSender')
 
       // increase time past expiry
       await advanceTime(SECONDS_IN_DAY * 0.6)
@@ -391,7 +395,7 @@ contract('Delegate', async accounts => {
       )
     })
 
-    it('should trade if the tradeWallet has authorized the delegate', async () => {
+    it('should trade if the tradeWallet has authorized the delegate to send', async () => {
       const order = await orders.getOrder({
         signer: {
           wallet: bobAddress,
@@ -421,10 +425,14 @@ contract('Delegate', async accounts => {
 
       // aliceTradeWallet must authorize the Delegate contract to swap
       let expiry = await getTimestampPlusDays(0.5)
-      let tx = await swapContract.authorize(aliceDelegate.address, expiry, {
-        from: aliceTradeWallet,
-      })
-      emitted(tx, 'Authorize')
+      let tx = await swapContract.authorizeSender(
+        aliceDelegate.address,
+        expiry,
+        {
+          from: aliceTradeWallet,
+        }
+      )
+      emitted(tx, 'AuthorizeSender')
 
       // both approve Swap to transfer tokens
       emitted(
@@ -440,7 +448,7 @@ contract('Delegate', async accounts => {
       await aliceDelegate.provideOrder(order, { from: bobAddress })
 
       // remove authorization
-      await swapContract.revoke(aliceDelegate.address, {
+      await swapContract.revokeSender(aliceDelegate.address, {
         from: aliceTradeWallet,
       })
     })

--- a/protocols/swap/contracts/Swap.sol
+++ b/protocols/swap/contracts/Swap.sol
@@ -214,7 +214,7 @@ contract Swap is ISwap {
 
   /**
     * @notice Authorize a delegated sender
-    * @dev Emits an Authorize event
+    * @dev Emits an AuthorizeSender event
     * @param _authorizedSender address to authorize
     * @param _expiry uint256
     */
@@ -230,7 +230,7 @@ contract Swap is ISwap {
 
   /**
     * @notice Authorize a delegated signer
-    * @dev Emits an Authorize event
+    * @dev Emits an AuthorizeSigner event
     * @param _authorizedSigner address to authorize
     * @param _expiry uint256
     */
@@ -246,7 +246,7 @@ contract Swap is ISwap {
 
   /**
     * @notice Revoke an authorized sender
-    * @dev Emits a Revoke event
+    * @dev Emits a RevokeSender event
     * @param _authorizedSender address
     */
   function revokeSender(
@@ -258,7 +258,7 @@ contract Swap is ISwap {
 
   /**
     * @notice Revoke an authorized signer
-    * @dev Emits a Revoke event
+    * @dev Emits a RevokeSigner event
     * @param _authorizedSigner address
     */
   function revokeSigner(
@@ -278,8 +278,8 @@ contract Swap is ISwap {
     address _approver,
     address _delegate
   ) internal view returns (bool) {
-    if (_approver == _delegate) return true;
-    return (senderAuthorizations[_approver][_delegate] > block.timestamp);
+    return ((_approver == _delegate) ||
+      senderAuthorizations[_approver][_delegate] > block.timestamp);
   }
 
   /**
@@ -292,8 +292,8 @@ contract Swap is ISwap {
     address _approver,
     address _delegate
   ) internal view returns (bool) {
-    if (_approver == _delegate) return true;
-    return (signerAuthorizations[_approver][_delegate] > block.timestamp);
+    return ((_approver == _delegate) ||
+      (signerAuthorizations[_approver][_delegate] > block.timestamp));
   }
 
   /**

--- a/protocols/swap/contracts/Swap.sol
+++ b/protocols/swap/contracts/Swap.sol
@@ -38,13 +38,6 @@ contract Swap is ISwap {
   byte constant private TAKEN = 0x01;
   byte constant private CANCELED = 0x02;
 
-  /*
-    bytes4(keccak256('transfer(address,uint256)')) ^
-    bytes4(keccak256('transferFrom(address,address,uint256)')) ^
-    bytes4(keccak256('balanceOf(address)')) ^
-    bytes4(keccak256('allowance(address,address)'));
-  */
-
   // ERC-721 (non-fungible token) interface identifier (ERC-165)
   bytes4 constant internal ERC721_INTERFACE_ID = 0x80ac58cd;
   /*
@@ -59,8 +52,11 @@ contract Swap is ISwap {
     bytes4(keccak256('safeTransferFrom(address,address,uint256,bytes)'));
   */
 
-  // Mapping of peer address to delegate address and expiry.
-  mapping (address => mapping (address => uint256)) public delegateApprovals;
+  // Mapping of sender address to a delegated sender address and expiry.
+  mapping (address => mapping (address => uint256)) public senderApprovals;
+
+  // Mapping of signer address to a delegated signer and expiry.
+  mapping (address => mapping (address => uint256)) public signerApprovals;
 
   // Mapping of signers to orders by nonce as TAKEN (0x01) or CANCELED (0x02)
   mapping (address => mapping (uint256 => byte)) public signerOrderStatus;
@@ -123,7 +119,7 @@ contract Swap is ISwap {
         * thus determines whether the msg.sender is an authorized sender.
         */
       if (msg.sender != _order.sender.wallet) {
-        require(isAuthorized(_order.sender.wallet, msg.sender),
+        require(isSenderAuthorized(_order.sender.wallet, msg.sender),
           "SENDER_UNAUTHORIZED");
       }
       // The specified sender is all clear.
@@ -137,7 +133,7 @@ contract Swap is ISwap {
         * Signature is not provided. The signer may have authorized the
         * msg.sender to swap on its behalf, which does not require a signature.
         */
-      require(isAuthorized(_order.signer.wallet, msg.sender),
+      require(isSignerAuthorized(_order.signer.wallet, msg.sender),
         "SIGNER_UNAUTHORIZED");
 
     } else {
@@ -145,7 +141,7 @@ contract Swap is ISwap {
         * The signature is provided. Determine whether the signer is
         * authorized and if so validate the signature itself.
         */
-      require(isAuthorized(_order.signer.wallet, _order.signature.signatory),
+      require(isSignerAuthorized(_order.signer.wallet, _order.signature.signatory),
         "SIGNER_UNAUTHORIZED");
 
       // Ensure the signature is valid.
@@ -219,45 +215,86 @@ contract Swap is ISwap {
   }
 
   /**
-    * @notice Authorize a delegate
+    * @notice Authorize a delegated sender
     * @dev Emits an Authorize event
-    * @param _delegate address
+    * @param _authorizedSender address to authorize
     * @param _expiry uint256
     */
-  function authorize(
-    address _delegate,
+  function authorizeSender(
+    address _authorizedSender,
     uint256 _expiry
   ) external {
-    require(msg.sender != _delegate, "INVALID_AUTH_DELEGATE");
+    require(msg.sender != _authorizedSender, "INVALID_AUTH_SENDER");
     require(_expiry > block.timestamp, "INVALID_AUTH_EXPIRY");
-    delegateApprovals[msg.sender][_delegate] = _expiry;
-    emit Authorize(msg.sender, _delegate, _expiry);
+    senderApprovals[msg.sender][_authorizedSender] = _expiry;
+    emit AuthorizeSender(msg.sender, _authorizedSender, _expiry);
   }
 
   /**
-    * @notice Revoke an authorization
-    * @dev Emits a Revoke event
-    * @param _delegate address
+    * @notice Authorize a delegated signer
+    * @dev Emits an Authorize event
+    * @param _authorizedSigner address to authorize
+    * @param _expiry uint256
     */
-  function revoke(
-    address _delegate
+  function authorizeSigner(
+    address _authorizedSigner,
+    uint256 _expiry
   ) external {
-    delete delegateApprovals[msg.sender][_delegate];
-    emit Revoke(msg.sender, _delegate);
+    require(msg.sender != _authorizedSigner, "INVALID_AUTH_SIGNER");
+    require(_expiry > block.timestamp, "INVALID_AUTH_EXPIRY");
+    signerApprovals[msg.sender][_authorizedSigner] = _expiry;
+    emit AuthorizeSigner(msg.sender, _authorizedSigner, _expiry);
   }
 
   /**
-    * @notice Determine whether a delegate is authorized
+    * @notice Revoke an authorized sender
+    * @dev Emits a Revoke event
+    * @param _authorizedSender address
+    */
+  function revokeSender(
+    address _authorizedSender
+  ) external {
+    delete senderApprovals[msg.sender][_authorizedSender];
+    emit RevokeSender(msg.sender, _authorizedSender);
+  }
+
+  /**
+    * @notice Revoke an authorized signer
+    * @dev Emits a Revoke event
+    * @param _authorizedSigner address
+    */
+  function revokeSigner(
+    address _authorizedSigner
+  ) external {
+    delete signerApprovals[msg.sender][_authorizedSigner];
+    emit RevokeSigner(msg.sender, _authorizedSigner);
+  }
+
+  /**
+    * @notice Determine whether a sender delegate is authorized
     * @param _approver address
     * @param _delegate address
-    * @return bool returns whether a delegate is authorized
+    * @return bool returns whether a delegate is sender authorized
     */
-  function isAuthorized(
+  function isSenderAuthorized(
+    address _approver,
+    address _delegate
+  ) internal view returns (bool) {
+    return (senderApprovals[_approver][_delegate] > block.timestamp);
+  }
+
+  /**
+    * @notice Determine whether a signer delegate is authorized
+    * @param _approver address
+    * @param _delegate address
+    * @return bool returns whether a delegate is signer authorized
+    */
+  function isSignerAuthorized(
     address _approver,
     address _delegate
   ) internal view returns (bool) {
     if (_approver == _delegate) return true;
-    return (delegateApprovals[_approver][_delegate] > block.timestamp);
+    return (signerApprovals[_approver][_delegate] > block.timestamp);
   }
 
   /**

--- a/protocols/swap/contracts/interfaces/ISwap.sol
+++ b/protocols/swap/contracts/interfaces/ISwap.sol
@@ -67,8 +67,8 @@ interface ISwap {
     address indexed revokedSigner
   );
 
-  function senderApprovals(address, address) external returns (uint256);
-  function signerApprovals(address, address) external returns (uint256);
+  function senderAuthorizations(address, address) external returns (uint256);
+  function signerAuthorizations(address, address) external returns (uint256);
 
   function signerOrderStatus(address, uint256) external returns (byte);
   function signerMinimumNonce(address) external returns (uint256);

--- a/protocols/swap/contracts/interfaces/ISwap.sol
+++ b/protocols/swap/contracts/interfaces/ISwap.sol
@@ -45,18 +45,31 @@ interface ISwap {
     address indexed signerWallet
   );
 
-  event Authorize(
+  event AuthorizeSender(
     address indexed approverAddress,
-    address indexed delegateAddress,
+    address indexed authorizedSender,
     uint256 expiry
   );
 
-  event Revoke(
+  event AuthorizeSigner(
     address indexed approverAddress,
-    address indexed delegateAddress
+    address indexed authorizedSigner,
+    uint256 expiry
   );
 
-  function delegateApprovals(address, address) external returns (uint256);
+  event RevokeSender(
+    address indexed approverAddress,
+    address indexed revokedSender
+  );
+
+  event RevokeSigner(
+    address indexed approverAddress,
+    address indexed revokedSigner
+  );
+
+  function senderApprovals(address, address) external returns (uint256);
+  function signerApprovals(address, address) external returns (uint256);
+
   function signerOrderStatus(address, uint256) external returns (byte);
   function signerMinimumNonce(address) external returns (uint256);
 
@@ -85,21 +98,40 @@ interface ISwap {
   ) external;
 
   /**
-    * @notice Authorize a delegate
-    * @param _delegate address
+    * @notice Authorize a delegated sender
+    * @param _authorizedSender address
     * @param _expiry uint256
     */
-  function authorize(
-    address _delegate,
+  function authorizeSender(
+    address _authorizedSender,
     uint256 _expiry
   ) external;
 
   /**
-    * @notice Revoke an authorization
-    * @param _delegate address
+    * @notice Authorize a delegated signer
+    * @param _authorizedSigner address
+    * @param _expiry uint256
     */
-  function revoke(
-    address _delegate
+  function authorizeSigner(
+    address _authorizedSigner,
+    uint256 _expiry
+  ) external;
+
+
+  /**
+    * @notice Revoke an authorization
+    * @param _authorizedSender address
+    */
+  function revokeSender(
+    address _authorizedSender
+  ) external;
+
+  /**
+    * @notice Revoke an authorization
+    * @param _authorizedSigner address
+    */
+  function revokeSigner(
+    address _authorizedSigner
   ) external;
 
 }

--- a/protocols/swap/test/Swap-unit.js
+++ b/protocols/swap/test/Swap-unit.js
@@ -105,13 +105,15 @@ contract('Swap Unit Tests', async accounts => {
         signature,
       ]
 
-      //sender authorizes signer using authorizeSender
-      emitted(
+      //mockSender authorizes mockSigner using authorizeSender
+      //mocks that case where one can send unsigned orders if authorized
+      // the roles of this authorization need to be reversed for the swap to succeed
+      /*      emitted(
         await swap.authorizeSender(mockSigner, Jun_06_2017T00_00_00_UTC, {
           from: mockSender,
         }),
         'AuthorizeSender'
-      )
+      )*/
 
       //mock sender will take the order
       await reverted(
@@ -224,7 +226,7 @@ contract('Swap Unit Tests', async accounts => {
       await passes(trx)
 
       //check delegateApproval was unset
-      let val = await swap.signerApprovals.call(sender, mockSigner)
+      let val = await swap.signerAuthorizations.call(sender, mockSigner)
       equal(val, futureTime, 'signer approval was not properly set')
 
       //check that event was emitted
@@ -242,8 +244,8 @@ contract('Swap Unit Tests', async accounts => {
     it('test that the revokeSigner is successfully removed', async () => {
       let trx = await swap.revokeSigner(mockSigner, { from: sender })
 
-      //check signerApprovals was unset
-      let val = await swap.signerApprovals.call(sender, mockSigner)
+      //check signerAuthorizations was unset
+      let val = await swap.signerAuthorizations.call(sender, mockSigner)
       equal(val, 0, 'signer approval was not properly unset')
 
       //check that the event was emitted
@@ -255,8 +257,8 @@ contract('Swap Unit Tests', async accounts => {
     it('test that the revokeSender is successfully removed', async () => {
       let trx = await swap.revokeSender(mockSender)
 
-      //check senderApprovals was unset
-      let val = await swap.senderApprovals.call(sender, mockSender)
+      //check senderAuthorizations was unset
+      let val = await swap.senderAuthorizations.call(sender, mockSender)
       equal(val, 0, 'sender approval was not properly unset')
 
       //check that the event was emitted

--- a/protocols/swap/test/Swap-unit.js
+++ b/protocols/swap/test/Swap-unit.js
@@ -105,12 +105,12 @@ contract('Swap Unit Tests', async accounts => {
         signature,
       ]
 
-      //sender authorizes signer
+      //sender authorizes signer using authorizeSender
       emitted(
-        await swap.authorize(mockSigner, Jun_06_2017T00_00_00_UTC, {
+        await swap.authorizeSender(mockSigner, Jun_06_2017T00_00_00_UTC, {
           from: mockSender,
         }),
-        'Authorize'
+        'AuthorizeSender'
       )
 
       //mock sender will take the order
@@ -177,17 +177,20 @@ contract('Swap Unit Tests', async accounts => {
     it('test that given a minimum nonce that all orders below a nonce value are invalidated', async () => {})
   })
 
-  describe('Test authorize', async () => {
-    it('test when the message sender is the delegate', async () => {
+  describe('Test authorize signer', async () => {
+    it('test when the message sender is the authorized signer', async () => {
       let delegate = mockSigner
       await reverted(
-        swap.authorize(delegate, 0, { from: mockSigner }),
-        'INVALID_AUTH_DELEGATE'
+        swap.authorizeSigner(delegate, 0, { from: mockSigner }),
+        'INVALID_AUTH_SIGNER'
       )
     })
 
     it('test when the expiration date has passed', async () => {
-      await reverted(swap.authorize(mockSigner, 0), 'INVALID_AUTH_EXPIRY')
+      await reverted(
+        swap.authorizeSigner(mockSigner, 0, { from: sender }),
+        'INVALID_AUTH_EXPIRY'
+      )
     })
 
     it('test when the expiration == block.timestamp', async () => {
@@ -206,7 +209,7 @@ contract('Swap Unit Tests', async accounts => {
 
       // set the expiry as the same time as the current time - revert
       await reverted(
-        swap.authorize(mockSigner, ONE_DAY_EXPIRY),
+        swap.authorizeSigner(mockSigner, ONE_DAY_EXPIRY, { from: sender }),
         'INVALID_AUTH_EXPIRY'
       )
     })
@@ -215,18 +218,20 @@ contract('Swap Unit Tests', async accounts => {
       const block = await web3.eth.getBlock('latest')
       const time = block.timestamp
       const futureTime = time + 100
-      let trx = await swap.authorize(mockSigner, futureTime)
+      let trx = await swap.authorizeSigner(mockSigner, futureTime, {
+        from: sender,
+      })
       await passes(trx)
 
       //check delegateApproval was unset
-      let val = await swap.delegateApprovals.call(sender, mockSigner)
-      equal(val, futureTime, 'delegate approval was not properly set')
+      let val = await swap.signerApprovals.call(sender, mockSigner)
+      equal(val, futureTime, 'signer approval was not properly set')
 
       //check that event was emitted
-      emitted(trx, 'Authorize', e => {
+      emitted(trx, 'AuthorizeSigner', e => {
         return (
           e.approverAddress === sender &&
-          e.delegateAddress === mockSigner &&
+          e.authorizedSigner === mockSigner &&
           e.expiry.toNumber() === futureTime
         )
       })
@@ -234,16 +239,29 @@ contract('Swap Unit Tests', async accounts => {
   })
 
   describe('Test revoke', async () => {
-    it('test that the approval is successfully removed', async () => {
-      let trx = await swap.revoke(mockSigner)
+    it('test that the revokeSigner is successfully removed', async () => {
+      let trx = await swap.revokeSigner(mockSigner, { from: sender })
 
-      //check delegateApproval was unset
-      let val = await swap.delegateApprovals.call(sender, mockSigner)
-      equal(val, 0, 'delegate approval was not properly unset')
+      //check signerApprovals was unset
+      let val = await swap.signerApprovals.call(sender, mockSigner)
+      equal(val, 0, 'signer approval was not properly unset')
 
       //check that the event was emitted
-      emitted(trx, 'Revoke', e => {
-        return e.approverAddress === sender && e.delegateAddress === mockSigner
+      emitted(trx, 'RevokeSigner', e => {
+        return e.approverAddress === sender && e.revokedSigner === mockSigner
+      })
+    })
+
+    it('test that the revokeSender is successfully removed', async () => {
+      let trx = await swap.revokeSender(mockSender)
+
+      //check senderApprovals was unset
+      let val = await swap.senderApprovals.call(sender, mockSender)
+      equal(val, 0, 'sender approval was not properly unset')
+
+      //check that the event was emitted
+      emitted(trx, 'RevokeSender', e => {
+        return e.approverAddress === sender && e.revokedSender === mockSender
       })
     })
   })

--- a/protocols/swap/test/Swap-unit.js
+++ b/protocols/swap/test/Swap-unit.js
@@ -105,16 +105,6 @@ contract('Swap Unit Tests', async accounts => {
         signature,
       ]
 
-      //mockSender authorizes mockSigner using authorizeSender
-      //mocks that case where one can send unsigned orders if authorized
-      // the roles of this authorization need to be reversed for the swap to succeed
-      /*      emitted(
-        await swap.authorizeSender(mockSigner, Jun_06_2017T00_00_00_UTC, {
-          from: mockSender,
-        }),
-        'AuthorizeSender'
-      )*/
-
       //mock sender will take the order
       await reverted(
         swap.swap(order, { from: mockSender }),

--- a/protocols/swap/test/Swap.js
+++ b/protocols/swap/test/Swap.js
@@ -253,6 +253,7 @@ contract('Swap', async accounts => {
 
   describe('Signer Delegation (Signer-side)', async () => {
     let _order
+    let _unsignedOrder
 
     before('Alice creates an order for Bob (200 AST for 50 DAI)', async () => {
       const order = await orders.getOrder({
@@ -269,16 +270,51 @@ contract('Swap', async accounts => {
         },
       })
       _order = order
+      const unsignedOrder = await orders.getOrder(
+        {
+          signatory: davidAddress,
+          signer: {
+            wallet: aliceAddress,
+            token: tokenAST.address,
+            param: 50,
+          },
+          sender: {
+            wallet: bobAddress,
+            token: tokenDAI.address,
+            param: 10,
+          },
+        },
+        true
+      )
+      _unsignedOrder = unsignedOrder
+      _unsignedOrder.signature = signatures.getEmptySignature()
     })
 
     it('Checks that David cannot make an order on behalf of Alice', async () => {
       await reverted(swap(_order, { from: bobAddress }), 'SIGNER_UNAUTHORIZED')
     })
 
+    it('Checks that David cannot make an order on behalf of Alice without signature', async () => {
+      await reverted(
+        swap(_unsignedOrder, { from: bobAddress }),
+        'SIGNER_UNAUTHORIZED'
+      )
+    })
+
+    it('Alice attempts to incorrectly authorize herself to make orders', async () => {
+      defaultAuthExpiry = await orders.generateExpiry(1)
+      await reverted(
+        swapContract.authorizeSigner(aliceAddress, defaultAuthExpiry, {
+          from: aliceAddress,
+        }),
+        'INVALID_AUTH_SIGNER'
+      )
+    })
+
     it('Alice attempts to authorize David to make orders on her behalf with an invalid expiry', async () => {
       const authExpiry = (await getLatestTimestamp()) - 1
       await reverted(
-        swapContract.authorize(davidAddress, authExpiry, {
+        swapContract.authorizeSigner(davidAddress, authExpiry, {
           from: aliceAddress,
         }),
         'INVALID_AUTH_EXPIRY'
@@ -288,10 +324,10 @@ contract('Swap', async accounts => {
     it('Alice authorizes David to make orders on her behalf', async () => {
       defaultAuthExpiry = await orders.generateExpiry(1)
       emitted(
-        await swapContract.authorize(davidAddress, defaultAuthExpiry, {
+        await swapContract.authorizeSigner(davidAddress, defaultAuthExpiry, {
           from: aliceAddress,
         }),
-        'Authorize'
+        'AuthorizeSigner'
       )
     })
 
@@ -308,8 +344,8 @@ contract('Swap', async accounts => {
 
     it('Alice revokes authorization from David', async () => {
       emitted(
-        await swapContract.revoke(davidAddress, { from: aliceAddress }),
-        'Revoke'
+        await swapContract.revokeSigner(davidAddress, { from: aliceAddress }),
+        'RevokeSigner'
       )
     })
 
@@ -379,12 +415,31 @@ contract('Swap', async accounts => {
       )
     })
 
-    it('Bob authorizes Carol to take orders on his behalf', async () => {
-      emitted(
-        await swapContract.authorize(carolAddress, defaultAuthExpiry, {
+    it('Bob tries to unsuccessfully authorize himself to be an authorized sender', async () => {
+      await reverted(
+        swapContract.authorizeSender(bobAddress, defaultAuthExpiry, {
           from: bobAddress,
         }),
-        'Authorize'
+        'INVALID_AUTH_SENDER'
+      )
+    })
+
+    it('Bob tries to unsuccessfully authorize invalid time', async () => {
+      const authExpiry = (await getLatestTimestamp()) - 1
+      await reverted(
+        swapContract.authorizeSender(carolAddress, authExpiry, {
+          from: bobAddress,
+        }),
+        'INVALID_AUTH_EXPIRY'
+      )
+    })
+
+    it('Bob authorizes Carol to take orders on his behalf', async () => {
+      emitted(
+        await swapContract.authorizeSender(carolAddress, defaultAuthExpiry, {
+          from: bobAddress,
+        }),
+        'AuthorizeSender'
       )
     })
 
@@ -394,8 +449,8 @@ contract('Swap', async accounts => {
 
     it('Bob revokes sender authorization from Carol', async () => {
       emitted(
-        await swapContract.revoke(carolAddress, { from: bobAddress }),
-        'Revoke'
+        await swapContract.revokeSender(carolAddress, { from: bobAddress }),
+        'RevokeSender'
       )
     })
 
@@ -440,19 +495,19 @@ contract('Swap', async accounts => {
   describe('Signer and Sender Delegation (Three Way)', async () => {
     it('Alice approves David to make orders on her behalf', async () => {
       emitted(
-        await swapContract.authorize(davidAddress, defaultAuthExpiry, {
+        await swapContract.authorizeSigner(davidAddress, defaultAuthExpiry, {
           from: aliceAddress,
         }),
-        'Authorize'
+        'AuthorizeSigner'
       )
     })
 
     it('Bob approves David to take orders on his behalf', async () => {
       emitted(
-        await swapContract.authorize(davidAddress, defaultAuthExpiry, {
+        await swapContract.authorizeSender(davidAddress, defaultAuthExpiry, {
           from: bobAddress,
         }),
-        'Authorize'
+        'AuthorizeSender'
       )
     })
 
@@ -507,10 +562,10 @@ contract('Swap', async accounts => {
   describe('Signer and Sender Delegation (Four Way)', async () => {
     it('Bob approves Carol to take orders on his behalf', async () => {
       emitted(
-        await swapContract.authorize(carolAddress, defaultAuthExpiry, {
+        await swapContract.authorizeSender(carolAddress, defaultAuthExpiry, {
           from: bobAddress,
         }),
-        'Authorize'
+        'AuthorizeSender'
       )
     })
 
@@ -534,10 +589,10 @@ contract('Swap', async accounts => {
 
     it('Bob revokes the authorization to Carol', async () => {
       emitted(
-        await swapContract.revoke(carolAddress, {
+        await swapContract.revokeSender(carolAddress, {
           from: bobAddress,
         }),
-        'Revoke'
+        'RevokeSender'
       )
     })
 
@@ -844,10 +899,10 @@ contract('Swap', async accounts => {
 
     it('Alice authorizes Eve to make orders on her behalf', async () => {
       emitted(
-        await swapContract.authorize(eveAddress, defaultAuthExpiry, {
+        await swapContract.authorizeSigner(eveAddress, defaultAuthExpiry, {
           from: aliceAddress,
         }),
-        'Authorize'
+        'AuthorizeSigner'
       )
     })
 


### PR DESCRIPTION
## Description

Implements features described in #156 to add two separate mappings for sender and signer.

Quick description:
- [X] New features

## Changes

* Adding two mappings `senderAuthorizations` and `signerAuthorizations`

Added 4 new methods and events:
* `authorizeSender`, `authorizeSigner`, `revokeSender`, `revokeSigner`.
* `AuthorizeSender`, `AuthorizeSigner`, `RevokeSender`, `RevokeSigner`

## Tests
Swap.sol
  66 passing (56s)

Also fixed Delegate, Delegate-Frontend, and Wrapper tests.

## Test Coverage

```
--------------|----------|----------|----------|----------|----------------|
File          |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------|----------|----------|----------|----------|----------------|
 contracts/   |      100 |      100 |      100 |      100 |                |
  Imports.sol |      100 |      100 |      100 |      100 |                |
  Swap.sol    |      100 |      100 |      100 |      100 |                |
--------------|----------|----------|----------|----------|----------------|
All files     |      100 |      100 |      100 |      100 |                |
--------------|----------|----------|----------|----------|----------------|

```