### PR TITLE
restructing of the structs, to close #150

### DIFF
--- a/helpers/delegate-frontend/contracts/DelegateFrontend.sol
+++ b/helpers/delegate-frontend/contracts/DelegateFrontend.sol
@@ -178,18 +178,18 @@ contract DelegateFrontend {
         _senderToken))),
       block.timestamp + 1,
       Types.Party(
+        0x277f8169,
         address(this),
         _signerToken,
-        signerAmount,
-        0x277f8169
+        signerAmount
       ),
       Types.Party(
+        0x277f8169,
         IDelegate(delegateContract).tradeWallet(),
         _senderToken,
-        _senderAmount,
-        0x277f8169
+        _senderAmount
       ),
-      Types.Party(address(0), address(0), 0, bytes4(0)),
+      Types.Party(bytes4(0), address(0), address(0), 0),
       Types.Signature(address(0), 0, 0, 0, 0)
     ));
 
@@ -249,18 +249,18 @@ contract DelegateFrontend {
       ))),
       block.timestamp + 1,
       Types.Party(
+        0x277f8169,
         address(this),
         _signerToken,
-        _signerAmount,
-        0x277f8169
+        _signerAmount
       ),
       Types.Party(
+        0x277f8169,
         IDelegate(delegateContract).tradeWallet(),
         _senderToken,
-        senderAmount,
-        0x277f8169
+        senderAmount
       ),
-      Types.Party(address(0), address(0), 0, bytes4(0)),
+      Types.Party(bytes4(0), address(0), address(0), 0),
       Types.Signature(address(0), 0, 0, 0, 0)
     ));
 

--- a/packages/order-utils/src/constants.js
+++ b/packages/order-utils/src/constants.js
@@ -41,18 +41,18 @@ module.exports = {
       { name: 'affiliate', type: 'Party' },
     ],
     Party: [
+      { name: 'kind', type: 'bytes4' },
       { name: 'wallet', type: 'address' },
       { name: 'token', type: 'address' },
       { name: 'param', type: 'uint256' },
-      { name: 'kind', type: 'bytes4' },
     ],
   },
   defaults: {
     Party: {
+      kind: '0x277f8169',
       wallet: '0x0000000000000000000000000000000000000000',
       token: '0x0000000000000000000000000000000000000000',
       param: '0',
-      kind: '0x277f8169',
     },
   },
 }

--- a/packages/order-utils/src/hashes.js
+++ b/packages/order-utils/src/hashes.js
@@ -41,8 +41,8 @@ const PARTY_TYPEHASH = ethUtil.keccak256(stringify('Party'))
 function hashParty(party) {
   return ethUtil.keccak256(
     abi.rawEncode(
-      ['bytes32', 'address', 'address', 'uint256', 'bytes4'],
-      [PARTY_TYPEHASH, party.wallet, party.token, party.param, party.kind]
+      ['bytes32', 'bytes4', 'address', 'address', 'uint256'],
+      [PARTY_TYPEHASH, party.kind, party.wallet, party.token, party.param]
     )
   )
 }

--- a/packages/order-utils/test/signatures.js
+++ b/packages/order-utils/test/signatures.js
@@ -40,9 +40,6 @@ describe('Signatures', async () => {
       swapAddress
     )
 
-    console.log(signature.r.toString('hex'))
-    console.log(signature.s.toString('hex'))
-
     expect(signature).to.deep.include({
       version: '0x45',
       signatory: signerWallet,
@@ -83,8 +80,6 @@ describe('Signatures', async () => {
       swapAddress
     )
 
-    console.log(signature.r.toString('hex'))
-    console.log(signature.s.toString('hex'))
     expect(signature).to.deep.include({
       version: '0x01',
       signatory: signerWallet,

--- a/packages/order-utils/test/signatures.js
+++ b/packages/order-utils/test/signatures.js
@@ -39,15 +39,19 @@ describe('Signatures', async () => {
       signerPrivKey,
       swapAddress
     )
+
+    console.log(signature.r.toString('hex'))
+    console.log(signature.s.toString('hex'))
+
     expect(signature).to.deep.include({
       version: '0x45',
       signatory: signerWallet,
       r: Buffer.from(
-        '539d93cf04378950229dffac7887fffb2b6a91072273c3b14d8942d109251998',
+        '6ce2f4c1d5f21f9b101a8043ae1e9fecf93972720399a65237abd70e43cc05d8',
         'hex'
       ),
       s: Buffer.from(
-        '55ee011f45450a444c83fa9c42f179efa3c130e254c175a8bd89560a15c8775e',
+        '39c1efa6505ef3e87c09e9105f63e449d9c29d11c50dc968f0070a5a860bfd49',
         'hex'
       ),
       v: 28,
@@ -78,15 +82,18 @@ describe('Signatures', async () => {
       signerPrivKey,
       swapAddress
     )
+
+    console.log(signature.r.toString('hex'))
+    console.log(signature.s.toString('hex'))
     expect(signature).to.deep.include({
       version: '0x01',
       signatory: signerWallet,
       r: Buffer.from(
-        'c78d7d33e620fdbec03176353f44d684178c079bb5a23c2d3cf72b6d40f32ce9',
+        '3d884c1025eb35ec6f6d4305bebe65416ee7e8acb48ceefece3a585f74e44030',
         'hex'
       ),
       s: Buffer.from(
-        '49dfeaee6792ee5a88e6747d1b49bd836af552db8ad8c6f45ed3d3e8f18248c1',
+        '31f3161d9a3451841ff3fe6bd16738e17a284ea2f8c235ea769d04bf6aa12855',
         'hex'
       ),
       v: 27,

--- a/protocols/swap/test/Swap-unit.js
+++ b/protocols/swap/test/Swap-unit.js
@@ -47,20 +47,20 @@ contract('Swap Unit Tests', async accounts => {
 
   describe('Test swap', async () => {
     it('test when order is expired', async () => {
-      let signer = [EMPTY_ADDRESS, EMPTY_ADDRESS, 200, kind]
-      let sender = [EMPTY_ADDRESS, EMPTY_ADDRESS, 200, kind]
-      let affiliate = [EMPTY_ADDRESS, EMPTY_ADDRESS, 200, kind]
-      let signature = [EMPTY_ADDRESS, v, r, s, ver]
+      let signer = [kind, EMPTY_ADDRESS, EMPTY_ADDRESS, 200]
+      let sender = [kind, EMPTY_ADDRESS, EMPTY_ADDRESS, 200]
+      let affiliate = [kind, EMPTY_ADDRESS, EMPTY_ADDRESS, 200]
+      let signature = [EMPTY_ADDRESS, ver, v, r, s]
       let order = [0, 0, signer, sender, affiliate, signature]
 
       await reverted(swap.swap(order), 'ORDER_EXPIRED')
     })
 
     it('test when order nonce is too low', async () => {
-      let signer = [mockSigner, EMPTY_ADDRESS, 200, kind]
-      let sender = [EMPTY_ADDRESS, EMPTY_ADDRESS, 200, kind]
-      let affiliate = [EMPTY_ADDRESS, EMPTY_ADDRESS, 200, kind]
-      let signature = [EMPTY_ADDRESS, v, r, s, ver]
+      let signer = [kind, mockSigner, EMPTY_ADDRESS, 200]
+      let sender = [kind, EMPTY_ADDRESS, EMPTY_ADDRESS, 200]
+      let affiliate = [kind, EMPTY_ADDRESS, EMPTY_ADDRESS, 200]
+      let signature = [EMPTY_ADDRESS, ver, v, r, s]
       let order = [
         0,
         Jun_06_2017T00_00_00_UTC,
@@ -75,10 +75,10 @@ contract('Swap Unit Tests', async accounts => {
     })
 
     it('test when sender is provided, and the sender is unauthorized', async () => {
-      let signer = [mockSigner, EMPTY_ADDRESS, 200, kind]
-      let sender = [mockSender, EMPTY_ADDRESS, 200, kind]
-      let affiliate = [EMPTY_ADDRESS, EMPTY_ADDRESS, 200, kind]
-      let signature = [EMPTY_ADDRESS, v, r, s, ver]
+      let signer = [kind, mockSigner, EMPTY_ADDRESS, 200]
+      let sender = [kind, mockSender, EMPTY_ADDRESS, 200]
+      let affiliate = [kind, EMPTY_ADDRESS, EMPTY_ADDRESS, 200]
+      let signature = [EMPTY_ADDRESS, ver, v, r, s]
       let order = [
         0,
         Jun_06_2017T00_00_00_UTC,
@@ -92,10 +92,10 @@ contract('Swap Unit Tests', async accounts => {
     })
 
     it('test when sender is provided, the sender is authorized, the signature.v is 0, and the signer wallet is unauthorized', async () => {
-      let signer = [mockSigner, EMPTY_ADDRESS, 200, kind]
-      let sender = [mockSender, EMPTY_ADDRESS, 200, kind]
-      let affiliate = [EMPTY_ADDRESS, EMPTY_ADDRESS, 200, kind]
-      let signature = [EMPTY_ADDRESS, 0, r, s, ver]
+      let signer = [kind, mockSigner, EMPTY_ADDRESS, 200]
+      let sender = [kind, mockSender, EMPTY_ADDRESS, 200]
+      let affiliate = [kind, EMPTY_ADDRESS, EMPTY_ADDRESS, 200]
+      let signature = [EMPTY_ADDRESS, ver, 0, r, s]
       let order = [
         0,
         Jun_06_2017T00_00_00_UTC,

--- a/protocols/types/contracts/Types.sol
+++ b/protocols/types/contracts/Types.sol
@@ -1,3 +1,4 @@
+
 /*
   Copyright 2019 Swap Holdings Ltd.
 
@@ -34,18 +35,18 @@ library Types {
   }
 
   struct Party {
+    bytes4 kind;          // Interface ID of the token
     address wallet;       // Wallet address of the party
     address token;        // Contract address of the token
     uint256 param;        // Value (ERC-20) or ID (ERC-721)
-    bytes4 kind;          // Interface ID of the token
   }
 
   struct Signature {
     address signatory;    // Address of the wallet used to sign
+    bytes1 version;       // EIP-191 signature version
     uint8 v;              // `v` value of an ECDSA signature
     bytes32 r;            // `r` value of an ECDSA signature
     bytes32 s;            // `s` value of an ECDSA signature
-    bytes1 version;       // EIP-191 signature version
   }
 
   bytes32 constant DOMAIN_TYPEHASH = keccak256(abi.encodePacked(
@@ -65,19 +66,20 @@ library Types {
     "Party affiliate",
     ")",
     "Party(",
+    "bytes4 kind,",
     "address wallet,",
     "address token,",
-    "uint256 param,",
-    "bytes4 kind",
+    "uint256 param",
     ")"
   ));
 
   bytes32 constant PARTY_TYPEHASH = keccak256(abi.encodePacked(
     "Party(",
+    "bytes4 kind,",
     "address wallet,",
     "address token,",
-    "uint256 param,",
-    "bytes4 kind",
+    "uint256 param",
+
     ")"
   ));
 
@@ -101,24 +103,24 @@ library Types {
         _order.expiry,
         keccak256(abi.encode(
           PARTY_TYPEHASH,
+          _order.signer.kind,
           _order.signer.wallet,
           _order.signer.token,
-          _order.signer.param,
-          _order.signer.kind
+          _order.signer.param
         )),
         keccak256(abi.encode(
           PARTY_TYPEHASH,
+          _order.sender.kind,
           _order.sender.wallet,
           _order.sender.token,
-          _order.sender.param,
-          _order.sender.kind
+          _order.sender.param
         )),
         keccak256(abi.encode(
           PARTY_TYPEHASH,
+          _order.affiliate.kind,
           _order.affiliate.wallet,
           _order.affiliate.token,
-          _order.affiliate.param,
-          _order.affiliate.kind
+          _order.affiliate.param
         ))
       ))
     ));


### PR DESCRIPTION
## Description

Quick description: 
Updated struct for Party and Signature.

- [X] Typo/small tweaks

## Changes

Two primary changes in Types.sol that resulted in Party struct and Signature struct to have the below ordering. Longer explanation found in #150. 

  ```
struct Party {
    bytes4 kind;          // Interface ID of the token
    address wallet;       // Wallet address of the party
    address token;        // Contract address of the token
    uint256 param;        // Value (ERC-20) or ID (ERC-721)
  }

  struct Signature {
    address signatory;    // Address of the wallet used to sign
    bytes1 version;       // EIP-191 signature version
    uint8 v;              // `v` value of an ECDSA signature
    bytes32 r;            // `r` value of an ECDSA signature
    bytes32 s;            // `s` value of an ECDSA signature
  }
```


## Tests

All tests pass

## Test Coverage

For Types.sol
```
--------------|----------|----------|----------|----------|----------------|
File          |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------|----------|----------|----------|----------|----------------|
 contracts/   |      100 |      100 |      100 |      100 |                |
  Imports.sol |      100 |      100 |      100 |      100 |                |
  Types.sol   |      100 |      100 |      100 |      100 |                |
--------------|----------|----------|----------|----------|----------------|
All files     |      100 |      100 |      100 |      100 |                |
--------------|----------|----------|----------|----------|----------------|
```

Coverage has not changed 