### PR TITLE
unused wrapper line

### DIFF
--- a/helpers/wrapper/contracts/Wrapper.sol
+++ b/helpers/wrapper/contracts/Wrapper.sol
@@ -32,7 +32,6 @@ contract Wrapper {
   // WETH contract to wrap ether
   IWETH public wethContract;
 
-  uint256 constant MAX_INT = 2**256 - 1;
   /**
     * @notice Contract Constructor
     * @param _swapContract address
@@ -44,9 +43,6 @@ contract Wrapper {
   ) public {
     swapContract = ISwap(_swapContract);
     wethContract = IWETH(_wethContract);
-
-    // Sets unlimited allowance for the Wrapper contract.
-    wethContract.approve(_swapContract, MAX_INT);
   }
 
   /**


### PR DESCRIPTION
## Description
Quick description:

- [X] Typo/small tweaks

## Changes

This line of the wrapper is seemingly useless.
- During a trade the wrapper gives the tokens to the order.sender.
- This means the tokens are swapped out of the sender's wallet not the wrapper
- The swap contract therefore never needs to move tokens out of the wrapper itself.

## Tests

  33 passing (5s)

## Test Coverage
