### PR TITLE
Solidity update

### DIFF
--- a/helpers/delegate-frontend/contracts/DelegateFrontend.sol
+++ b/helpers/delegate-frontend/contracts/DelegateFrontend.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";

--- a/helpers/delegate-frontend/contracts/Imports.sol
+++ b/helpers/delegate-frontend/contracts/Imports.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "@airswap/delegate/contracts/Delegate.sol";
 import "@airswap/indexer/contracts/Indexer.sol";

--- a/helpers/delegate-frontend/truffle-config.js
+++ b/helpers/delegate-frontend/truffle-config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.5.10',
+      version: '0.5.12',
       optimization: false,
     },
   },

--- a/helpers/tokens/contracts/FungibleToken.sol
+++ b/helpers/tokens/contracts/FungibleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
 

--- a/helpers/tokens/contracts/KittyCore.sol
+++ b/helpers/tokens/contracts/KittyCore.sol
@@ -4,7 +4,7 @@
  * implement safeTransferFrom
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 
 /**

--- a/helpers/tokens/contracts/NonFungibleToken.sol
+++ b/helpers/tokens/contracts/NonFungibleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "openzeppelin-solidity/contracts/access/roles/MinterRole.sol";
 import "./AdaptedERC721.sol";

--- a/helpers/tokens/contracts/OMGToken.sol
+++ b/helpers/tokens/contracts/OMGToken.sol
@@ -4,7 +4,7 @@
  *        transferFrom function that does not return bool
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 
 /**

--- a/helpers/tokens/contracts/WETH9.sol
+++ b/helpers/tokens/contracts/WETH9.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // solhint-disable
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 
 contract WETH9 {

--- a/helpers/tokens/contracts/interfaces/IWETH.sol
+++ b/helpers/tokens/contracts/interfaces/IWETH.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 interface IWETH {
 

--- a/helpers/tokens/truffle-config.js
+++ b/helpers/tokens/truffle-config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.5.10',
+      version: '0.5.12',
       optimization: false,
     },
   },

--- a/helpers/wrapper/contracts/Imports.sol
+++ b/helpers/wrapper/contracts/Imports.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "@airswap/tokens/contracts/FungibleToken.sol";
 import "@airswap/tokens/contracts/WETH9.sol";

--- a/helpers/wrapper/contracts/Wrapper.sol
+++ b/helpers/wrapper/contracts/Wrapper.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/swap/contracts/interfaces/ISwap.sol";

--- a/helpers/wrapper/truffle-config.js
+++ b/helpers/wrapper/truffle-config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.5.10',
+      version: '0.5.12',
       optimization: false,
     },
   },

--- a/protocols/delegate-factory/contracts/DelegateFactory.sol
+++ b/protocols/delegate-factory/contracts/DelegateFactory.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "@airswap/delegate/contracts/Delegate.sol";
 import "@airswap/swap/contracts/interfaces/ISwap.sol";

--- a/protocols/delegate-factory/contracts/Imports.sol
+++ b/protocols/delegate-factory/contracts/Imports.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "@airswap/swap/contracts/Swap.sol";
 import "@airswap/tokens/contracts/FungibleToken.sol";

--- a/protocols/delegate-factory/contracts/interfaces/IDelegateFactory.sol
+++ b/protocols/delegate-factory/contracts/interfaces/IDelegateFactory.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 interface IDelegateFactory {
 

--- a/protocols/delegate-factory/truffle-config.js
+++ b/protocols/delegate-factory/truffle-config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.5.10',
+      version: '0.5.12',
       optimization: false,
     },
   },

--- a/protocols/delegate/contracts/Delegate.sol
+++ b/protocols/delegate/contracts/Delegate.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/delegate/contracts/interfaces/IDelegate.sol";

--- a/protocols/delegate/contracts/Imports.sol
+++ b/protocols/delegate/contracts/Imports.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "@airswap/swap/contracts/Swap.sol";
 import "@airswap/tokens/contracts/FungibleToken.sol";

--- a/protocols/delegate/contracts/interfaces/IDelegate.sol
+++ b/protocols/delegate/contracts/interfaces/IDelegate.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/types/contracts/Types.sol";

--- a/protocols/delegate/truffle-config.js
+++ b/protocols/delegate/truffle-config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.5.10',
+      version: '0.5.12',
       optimization: false,
     },
   },

--- a/protocols/index/contracts/Imports.sol
+++ b/protocols/index/contracts/Imports.sol
@@ -1,3 +1,3 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 contract Imports {}

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/protocols/index/truffle-config.js
+++ b/protocols/index/truffle-config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.5.10',
+      version: '0.5.12',
       optimization: false,
     },
   },

--- a/protocols/indexer/contracts/Imports.sol
+++ b/protocols/indexer/contracts/Imports.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "@airswap/tokens/contracts/FungibleToken.sol";
 import "@airswap/index/contracts/Index.sol";

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/indexer/contracts/interfaces/IIndexer.sol";

--- a/protocols/indexer/contracts/interfaces/IIndexer.sol
+++ b/protocols/indexer/contracts/interfaces/IIndexer.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 interface IIndexer {
 

--- a/protocols/indexer/contracts/interfaces/ILocatorWhitelist.sol
+++ b/protocols/indexer/contracts/interfaces/ILocatorWhitelist.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 interface ILocatorWhitelist {
 

--- a/protocols/indexer/truffle-config.js
+++ b/protocols/indexer/truffle-config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.5.10',
+      version: '0.5.12',
       optimization: false,
     },
   },

--- a/protocols/swap/.solcover.js
+++ b/protocols/swap/.solcover.js
@@ -7,7 +7,7 @@ module.exports = {
     skipFiles: ['analysis', 'interfaces', 'contracts/Imports.sol'],
     compilers: {
         solc: {
-          version: "0.5.10" // A version or constraint - Ex. "^0.5.0"
+          version: "0.5.12" // A version or constraint - Ex. "^0.5.0"
         }
     }
 };

--- a/protocols/swap/contracts/Imports.sol
+++ b/protocols/swap/contracts/Imports.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "@airswap/tokens/contracts/FungibleToken.sol";
 import "@airswap/tokens/contracts/NonFungibleToken.sol";

--- a/protocols/swap/contracts/Swap.sol
+++ b/protocols/swap/contracts/Swap.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/swap/contracts/interfaces/ISwap.sol";

--- a/protocols/swap/contracts/interfaces/ISwap.sol
+++ b/protocols/swap/contracts/interfaces/ISwap.sol
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/types/contracts/Types.sol";

--- a/protocols/swap/truffle-config.js
+++ b/protocols/swap/truffle-config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.5.10',
+      version: '0.5.12',
       optimization: false,
     },
   },

--- a/protocols/types/contracts/Imports.sol
+++ b/protocols/types/contracts/Imports.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 
 import "@airswap/tokens/contracts/FungibleToken.sol";
 import "@airswap/tokens/contracts/NonFungibleToken.sol";

--- a/protocols/types/contracts/Types.sol
+++ b/protocols/types/contracts/Types.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.10;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/protocols/types/truffle-config.js
+++ b/protocols/types/truffle-config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.5.10',
+      version: '0.5.12',
       optimization: false,
     },
   },


### PR DESCRIPTION
## Description

Upgrade of the solc version.
https://github.com/airswap/airswap-protocols/issues/172

Quick description:

- [X] Typo/small tweaks

## Changes

Upgrade of the solc version.

Solc 0.5.11 had the following bug fix in it, and while it doesnt directly affect us, it is closely related to our struct calldata:
`This release fixes a bug related to calldata structs in ABIEncoderV2`
`Code Generator: Treat dynamically encoded but statically sized arrays and structs in calldata properly.`

## Tests


## Test Coverage
