### PR TITLE
Indexer and Index API and syntax cleanup

### DIFF
--- a/helpers/delegate-frontend/contracts/DelegateFrontend.sol
+++ b/helpers/delegate-frontend/contracts/DelegateFrontend.sol
@@ -60,7 +60,7 @@ contract DelegateFrontend {
     lowestAmount = MAX_INT;
 
     // Fetch an array of locators from the Indexer.
-    bytes32[] memory locators = indexer.getIntents(
+    bytes32[] memory locators = indexer.getLocators(
       _signerToken,
       _senderToken,
       address(0), // This is to start at the head of the list of intents
@@ -112,7 +112,7 @@ contract DelegateFrontend {
     highAmount = 0;
 
     // Fetch an array of locators from the Indexer.
-    bytes32[] memory locators = indexer.getIntents(
+    bytes32[] memory locators = indexer.getLocators(
       _signerToken,
       _senderToken,
       address(0), // This is to start at the head of the list of intents

--- a/helpers/delegate-frontend/test/DelegateFrontend-unit.js
+++ b/helpers/delegate-frontend/test/DelegateFrontend-unit.js
@@ -28,8 +28,8 @@ contract('DelegateFrontend Unit Tests', async () => {
   let mockUserSendToken
   let mockUserReceiveToken
   let indexer_getLocators
-  let mockstakingToken
-  let mockstakingToken_approve
+  let mockStakingToken
+  let mockStakingToken_approve
 
   let emptyLocator = padAddressToLocator(EMPTY_ADDRESS)
 
@@ -121,14 +121,14 @@ contract('DelegateFrontend Unit Tests', async () => {
   }
 
   async function setupMockTokens() {
-    mockstakingToken = await MockContract.new()
+    mockStakingToken = await MockContract.new()
     let mockFungibleTokenTemplate = await FungibleToken.new()
 
-    mockstakingToken_approve = await mockFungibleTokenTemplate.contract.methods
+    mockStakingToken_approve = await mockFungibleTokenTemplate.contract.methods
       .approve(EMPTY_ADDRESS, 0)
       .encodeABI()
 
-    await mockstakingToken.givenMethodReturnBool(mockstakingToken_approve, true)
+    await mockStakingToken.givenMethodReturnBool(mockStakingToken_approve, true)
   }
 
   async function setupMockIndexer() {
@@ -144,7 +144,7 @@ contract('DelegateFrontend Unit Tests', async () => {
       .encodeABI()
     await mockIndexer.givenMethodReturnAddress(
       mockIndexer_stakingToken,
-      mockstakingToken.address
+      mockStakingToken.address
     )
   }
 

--- a/helpers/delegate-frontend/test/DelegateFrontend-unit.js
+++ b/helpers/delegate-frontend/test/DelegateFrontend-unit.js
@@ -27,9 +27,9 @@ contract('DelegateFrontend Unit Tests', async () => {
   let delegateFrontend
   let mockUserSendToken
   let mockUserReceiveToken
-  let indexer_getIntents
-  let mockStakeToken
-  let mockStakeToken_approve
+  let indexer_getLocators
+  let mockstakingToken
+  let mockstakingToken_approve
 
   let emptyLocator = padAddressToLocator(EMPTY_ADDRESS)
 
@@ -121,30 +121,30 @@ contract('DelegateFrontend Unit Tests', async () => {
   }
 
   async function setupMockTokens() {
-    mockStakeToken = await MockContract.new()
+    mockstakingToken = await MockContract.new()
     let mockFungibleTokenTemplate = await FungibleToken.new()
 
-    mockStakeToken_approve = await mockFungibleTokenTemplate.contract.methods
+    mockstakingToken_approve = await mockFungibleTokenTemplate.contract.methods
       .approve(EMPTY_ADDRESS, 0)
       .encodeABI()
 
-    await mockStakeToken.givenMethodReturnBool(mockStakeToken_approve, true)
+    await mockstakingToken.givenMethodReturnBool(mockstakingToken_approve, true)
   }
 
   async function setupMockIndexer() {
     let indexerTemplate = await Indexer.new(EMPTY_ADDRESS)
     mockIndexer = await MockContract.new()
 
-    indexer_getIntents = indexerTemplate.contract.methods
-      .getIntents(EMPTY_ADDRESS, EMPTY_ADDRESS, EMPTY_ADDRESS, 0)
+    indexer_getLocators = indexerTemplate.contract.methods
+      .getLocators(EMPTY_ADDRESS, EMPTY_ADDRESS, EMPTY_ADDRESS, 0)
       .encodeABI()
 
-    let mockIndexer_stakeToken = indexerTemplate.contract.methods
-      .stakeToken()
+    let mockIndexer_stakingToken = indexerTemplate.contract.methods
+      .stakingToken()
       .encodeABI()
     await mockIndexer.givenMethodReturnAddress(
-      mockIndexer_stakeToken,
-      mockStakeToken.address
+      mockIndexer_stakingToken,
+      mockstakingToken.address
     )
   }
 
@@ -185,9 +185,9 @@ contract('DelegateFrontend Unit Tests', async () => {
 
   describe('Test getBestSenderSideQuote()', async () => {
     it('test default values are returned with an empty indexer', async () => {
-      //mock indexer getIntents() where there are no locators
+      //mock indexer getLocators() where there are no locators
       await mockIndexer.givenMethodReturn(
-        indexer_getIntents,
+        indexer_getLocators,
         abi.rawEncode(['bytes32[]'], [[]])
       )
 
@@ -204,9 +204,9 @@ contract('DelegateFrontend Unit Tests', async () => {
     })
 
     it('test that the lowest cost delegate is returned with an indexer ordered high to low', async () => {
-      //mock indexer getIntents() where locators are ordered high to low
+      //mock indexer getLocators() where locators are ordered high to low
       await mockIndexer.givenMethodReturn(
-        indexer_getIntents,
+        indexer_getLocators,
         abi.rawEncode(
           ['bytes32[]'],
           [[mockDelegateHighLocator, mockDelegateLowLocator]]
@@ -226,9 +226,9 @@ contract('DelegateFrontend Unit Tests', async () => {
     })
 
     it('test that the lowest cost delegate is returned with an indexer ordered low to high', async () => {
-      //mock indexer getIntents() where locators are ordered low to high
+      //mock indexer getLocators() where locators are ordered low to high
       await mockIndexer.givenMethodReturn(
-        indexer_getIntents,
+        indexer_getLocators,
         abi.rawEncode(
           ['bytes32[]'],
           [[mockDelegateLowLocator, mockDelegateHighLocator]]
@@ -249,9 +249,9 @@ contract('DelegateFrontend Unit Tests', async () => {
 
   describe('Test getBestSignerSideQuote()', async () => {
     it('test default values are returned with an empty indexer', async () => {
-      //mock indexer getIntents() where there are no locators
+      //mock indexer getLocators() where there are no locators
       await mockIndexer.givenMethodReturn(
-        indexer_getIntents,
+        indexer_getLocators,
         abi.rawEncode(['bytes32[]'], [[]])
       )
 
@@ -268,9 +268,9 @@ contract('DelegateFrontend Unit Tests', async () => {
     })
 
     it('test that the lowest cost delegate is returned with an indexer ordered high to low', async () => {
-      //mock indexer getIntents() where locators are ordered high to low
+      //mock indexer getLocators() where locators are ordered high to low
       await mockIndexer.givenMethodReturn(
-        indexer_getIntents,
+        indexer_getLocators,
         abi.rawEncode(
           ['bytes32[]'],
           [[mockDelegateHighLocator, mockDelegateLowLocator]]
@@ -290,9 +290,9 @@ contract('DelegateFrontend Unit Tests', async () => {
     })
 
     it('test that the lowest cost delegate is returned with an indexer ordered low to high', async () => {
-      //mock indexer getIntents() where locators are ordered low to high
+      //mock indexer getLocators() where locators are ordered low to high
       await mockIndexer.givenMethodReturn(
-        indexer_getIntents,
+        indexer_getLocators,
         abi.rawEncode(
           ['bytes32[]'],
           [[mockDelegateLowLocator, mockDelegateHighLocator]]
@@ -313,9 +313,9 @@ contract('DelegateFrontend Unit Tests', async () => {
 
   describe('Test fillBestSenderSideOrder()', async () => {
     it('test by ensuring all internal methods are called', async () => {
-      //mock indexer getIntents() where locators are ordered low to high
+      //mock indexer getLocators() where locators are ordered low to high
       await mockIndexer.givenMethodReturn(
-        indexer_getIntents,
+        indexer_getLocators,
         abi.rawEncode(
           ['bytes32[]'],
           [[mockDelegateLowLocator, mockDelegateHighLocator]]

--- a/helpers/delegate-frontend/test/DelegateFrontend.js
+++ b/helpers/delegate-frontend/test/DelegateFrontend.js
@@ -186,7 +186,7 @@ contract('DelegateFrontend', async accounts => {
 
   describe('DelegateFrontend - SenderSide', async () => {
     it('Get the intent', async () => {
-      const result = await indexer.getIntents.call(
+      const result = await indexer.getLocators.call(
         tokenDAI.address,
         tokenWETH.address,
         EMPTY_ADDRESS,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-prettier": "^3.1.0",
+    "eslint-utils": "^1.4.2",
     "ethereumjs-abi": "^0.6.7",
     "ganache-cli": "^6.4.4",
     "lerna": "^3.15.0",
@@ -36,8 +37,5 @@
     "tabWidth": 2,
     "semi": false,
     "singleQuote": true
-  },
-  "dependencies": {
-    "eslint-utils": "^1.4.2"
   }
 }

--- a/protocols/delegate-factory/contracts/DelegateFactory.sol
+++ b/protocols/delegate-factory/contracts/DelegateFactory.sol
@@ -60,10 +60,17 @@ contract DelegateFactory is IDelegateFactory, ILocatorWhitelist {
     require(_delegateContractOwner != address(0),
       'DELEGATE_CONTRACT_OWNER_REQUIRED');
 
-    delegateContractAddress = address(new Delegate(swapContract, indexerContract, _delegateContractOwner, _delegateTradeWallet));
+    delegateContractAddress = address(
+      new Delegate(swapContract, indexerContract, _delegateContractOwner, _delegateTradeWallet));
     deployedAddresses[delegateContractAddress] = true;
 
-    emit CreateDelegate(delegateContractAddress, address(swapContract), address(indexerContract), _delegateContractOwner, _delegateTradeWallet);
+    emit CreateDelegate(
+      delegateContractAddress,
+      address(swapContract),
+      address(indexerContract),
+      _delegateContractOwner,
+      _delegateTradeWallet
+    );
 
     return delegateContractAddress;
   }

--- a/protocols/delegate-factory/test/Delegate-Factory-unit.js
+++ b/protocols/delegate-factory/test/Delegate-Factory-unit.js
@@ -21,8 +21,8 @@ contract('Delegate Factory Tests', async accounts => {
   const tradeWalletTwo = accounts[5]
 
   let mockIndexer
-  let mockstakingToken
-  let mockstakingToken_approve
+  let mockStakingToken
+  let mockStakingToken_approve
 
   let snapshotId
   let delegateFactory
@@ -46,14 +46,14 @@ contract('Delegate Factory Tests', async accounts => {
   })
 
   async function setupMockToken() {
-    mockstakingToken = await MockContract.new()
+    mockStakingToken = await MockContract.new()
     let mockFungibleTokenTemplate = await FungibleToken.new()
 
-    mockstakingToken_approve = await mockFungibleTokenTemplate.contract.methods
+    mockStakingToken_approve = await mockFungibleTokenTemplate.contract.methods
       .approve(EMPTY_ADDRESS, 0)
       .encodeABI()
 
-    await mockstakingToken.givenMethodReturnBool(mockstakingToken_approve, true)
+    await mockStakingToken.givenMethodReturnBool(mockStakingToken_approve, true)
   }
 
   async function setupMockIndexer() {
@@ -66,7 +66,7 @@ contract('Delegate Factory Tests', async accounts => {
       .encodeABI()
     await mockIndexer.givenMethodReturnAddress(
       mockIndexer_stakingToken,
-      mockstakingToken.address
+      mockStakingToken.address
     )
   }
 

--- a/protocols/delegate-factory/test/Delegate-Factory-unit.js
+++ b/protocols/delegate-factory/test/Delegate-Factory-unit.js
@@ -21,8 +21,8 @@ contract('Delegate Factory Tests', async accounts => {
   const tradeWalletTwo = accounts[5]
 
   let mockIndexer
-  let mockStakeToken
-  let mockStakeToken_approve
+  let mockstakingToken
+  let mockstakingToken_approve
 
   let snapshotId
   let delegateFactory
@@ -46,27 +46,27 @@ contract('Delegate Factory Tests', async accounts => {
   })
 
   async function setupMockToken() {
-    mockStakeToken = await MockContract.new()
+    mockstakingToken = await MockContract.new()
     let mockFungibleTokenTemplate = await FungibleToken.new()
 
-    mockStakeToken_approve = await mockFungibleTokenTemplate.contract.methods
+    mockstakingToken_approve = await mockFungibleTokenTemplate.contract.methods
       .approve(EMPTY_ADDRESS, 0)
       .encodeABI()
 
-    await mockStakeToken.givenMethodReturnBool(mockStakeToken_approve, true)
+    await mockstakingToken.givenMethodReturnBool(mockstakingToken_approve, true)
   }
 
   async function setupMockIndexer() {
     mockIndexer = await MockContract.new()
     let mockIndexerTemplate = await Indexer.new(EMPTY_ADDRESS)
 
-    //mock stakeToken()
-    let mockIndexer_stakeToken = mockIndexerTemplate.contract.methods
-      .stakeToken()
+    //mock stakingToken()
+    let mockIndexer_stakingToken = mockIndexerTemplate.contract.methods
+      .stakingToken()
       .encodeABI()
     await mockIndexer.givenMethodReturnAddress(
-      mockIndexer_stakeToken,
-      mockStakeToken.address
+      mockIndexer_stakingToken,
+      mockstakingToken.address
     )
   }
 

--- a/protocols/delegate/contracts/Delegate.sol
+++ b/protocols/delegate/contracts/Delegate.sol
@@ -82,7 +82,7 @@ contract Delegate is IDelegate, Ownable {
 
     //ensure that the indexer can pull funds from delegate account
     require(
-      IERC20(indexer.stakeToken())
+      IERC20(indexer.stakingToken())
       .approve(address(indexer), MAX_INT), "STAKING_APPROVAL_FAILED"
     );
   }
@@ -105,11 +105,11 @@ contract Delegate is IDelegate, Ownable {
     uint256 _priceExp
   ) external onlyOwner {
     setRuleInternal(
-       _senderToken,
-       _signerToken,
-       _maxSenderAmount,
-       _priceCoef,
-       _priceExp
+      _senderToken,
+      _signerToken,
+      _maxSenderAmount,
+      _priceCoef,
+      _priceExp
     );
   }
 
@@ -154,7 +154,7 @@ contract Delegate is IDelegate, Ownable {
     );
 
     require(
-      IERC20(indexer.stakeToken())
+      IERC20(indexer.stakingToken())
       .transferFrom(msg.sender, address(this), _amountToStake), "STAKING_TRANSFER_FAILED"
     );
 
@@ -181,14 +181,14 @@ contract Delegate is IDelegate, Ownable {
     unsetRuleInternal(_senderToken, _signerToken);
 
     //query against indexer for amount staked
-    uint256 stakedAmount = indexer.getScore(_signerToken, _senderToken, address(this));
+    uint256 stakedAmount = indexer.getStakeAmount(address(this), _signerToken, _senderToken);
     indexer.unsetIntent(_signerToken, _senderToken);
 
     //upon unstaking the manager will be given the staking amount
     //push the staking amount to the msg.sender
 
     require(
-      IERC20(indexer.stakeToken())
+      IERC20(indexer.stakingToken())
         .transfer(msg.sender, stakedAmount),"STAKING_TRANSFER_FAILED"
     );
   }

--- a/protocols/delegate/contracts/Delegate.sol
+++ b/protocols/delegate/contracts/Delegate.sol
@@ -181,7 +181,7 @@ contract Delegate is IDelegate, Ownable {
     unsetRuleInternal(_senderToken, _signerToken);
 
     //query against indexer for amount staked
-    uint256 stakedAmount = indexer.getStakeAmount(address(this), _signerToken, _senderToken);
+    uint256 stakedAmount = indexer.getStakedAmount(address(this), _signerToken, _senderToken);
     indexer.unsetIntent(_signerToken, _senderToken);
 
     //upon unstaking the manager will be given the staking amount

--- a/protocols/delegate/test/Delegate-unit.js
+++ b/protocols/delegate/test/Delegate-unit.js
@@ -37,7 +37,7 @@ contract('Delegate Unit Tests', async accounts => {
   let mockStakingToken_transfer
   let mockStakingToken_approve
   let mockIndexer
-  let mockIndexer_getStakeAmount
+  let mockIndexer_getStakedAmount
 
   beforeEach(async () => {
     let snapShot = await takeSnapshot()
@@ -104,9 +104,9 @@ contract('Delegate Unit Tests', async accounts => {
       mockStakingToken.address
     )
 
-    //mock getStakeAmount()
-    mockIndexer_getStakeAmount = mockIndexerTemplate.contract.methods
-      .getStakeAmount(EMPTY_ADDRESS, EMPTY_ADDRESS, EMPTY_ADDRESS)
+    //mock getStakedAmount()
+    mockIndexer_getStakedAmount = mockIndexerTemplate.contract.methods
+      .getStakedAmount(EMPTY_ADDRESS, EMPTY_ADDRESS, EMPTY_ADDRESS)
       .encodeABI()
   }
 
@@ -347,7 +347,7 @@ contract('Delegate Unit Tests', async accounts => {
 
       //mock the score/staked amount to be transferred
       await mockIndexer.givenMethodReturnUint(
-        mockIndexer_getStakeAmount,
+        mockIndexer_getStakedAmount,
         mockScore
       )
 
@@ -368,7 +368,7 @@ contract('Delegate Unit Tests', async accounts => {
 
       //mock the score/staked amount to be transferred
       await mockIndexer.givenMethodReturnUint(
-        mockIndexer_getStakeAmount,
+        mockIndexer_getStakedAmount,
         mockScore
       )
 

--- a/protocols/delegate/test/Delegate-unit.js
+++ b/protocols/delegate/test/Delegate-unit.js
@@ -31,13 +31,13 @@ contract('Delegate Unit Tests', async accounts => {
   let mockSwap
   let snapshotId
   let swapFunction
-  let mockStakeToken
-  let mockStakeToken_allowance
-  let mockStakeToken_transferFrom
-  let mockStakeToken_transfer
-  let mockStakeToken_approve
+  let mockStakingToken
+  let mockStakingToken_allowance
+  let mockStakingToken_transferFrom
+  let mockStakingToken_transfer
+  let mockStakingToken_approve
   let mockIndexer
-  let mockIndexer_getScore
+  let mockIndexer_getStakeAmount
 
   beforeEach(async () => {
     let snapShot = await takeSnapshot()
@@ -49,22 +49,22 @@ contract('Delegate Unit Tests', async accounts => {
   })
 
   async function setupMockTokens() {
-    mockStakeToken = await MockContract.new()
+    mockStakingToken = await MockContract.new()
     let mockFungibleTokenTemplate = await FungibleToken.new()
 
-    mockStakeToken_allowance = await mockFungibleTokenTemplate.contract.methods
+    mockStakingToken_allowance = await mockFungibleTokenTemplate.contract.methods
       .allowance(EMPTY_ADDRESS, EMPTY_ADDRESS)
       .encodeABI()
 
-    mockStakeToken_transferFrom = await mockFungibleTokenTemplate.contract.methods
+    mockStakingToken_transferFrom = await mockFungibleTokenTemplate.contract.methods
       .transferFrom(EMPTY_ADDRESS, EMPTY_ADDRESS, 0)
       .encodeABI()
 
-    mockStakeToken_transfer = await mockFungibleTokenTemplate.contract.methods
+    mockStakingToken_transfer = await mockFungibleTokenTemplate.contract.methods
       .transfer(EMPTY_ADDRESS, 0)
       .encodeABI()
 
-    mockStakeToken_approve = await mockFungibleTokenTemplate.contract.methods
+    mockStakingToken_approve = await mockFungibleTokenTemplate.contract.methods
       .approve(EMPTY_ADDRESS, 0)
       .encodeABI()
   }
@@ -95,18 +95,18 @@ contract('Delegate Unit Tests', async accounts => {
       .encodeABI()
     await mockIndexer.givenMethodReturnBool(mockIndexer_unsetIntent, true)
 
-    //mock stakeToken()
-    let mockIndexer_stakeToken = mockIndexerTemplate.contract.methods
-      .stakeToken()
+    //mock stakingToken()
+    let mockIndexer_stakingToken = mockIndexerTemplate.contract.methods
+      .stakingToken()
       .encodeABI()
     await mockIndexer.givenMethodReturnAddress(
-      mockIndexer_stakeToken,
-      mockStakeToken.address
+      mockIndexer_stakingToken,
+      mockStakingToken.address
     )
 
-    //mock getScore()
-    mockIndexer_getScore = mockIndexerTemplate.contract.methods
-      .getScore(EMPTY_ADDRESS, EMPTY_ADDRESS, EMPTY_ADDRESS)
+    //mock getStakeAmount()
+    mockIndexer_getStakeAmount = mockIndexerTemplate.contract.methods
+      .getStakeAmount(EMPTY_ADDRESS, EMPTY_ADDRESS, EMPTY_ADDRESS)
       .encodeABI()
   }
 
@@ -115,7 +115,7 @@ contract('Delegate Unit Tests', async accounts => {
     await setupMockSwap()
     await setupMockIndexer()
 
-    await mockStakeToken.givenMethodReturnBool(mockStakeToken_approve, true)
+    await mockStakingToken.givenMethodReturnBool(mockStakingToken_approve, true)
 
     delegate = await Delegate.new(
       mockSwap.address,
@@ -140,7 +140,10 @@ contract('Delegate Unit Tests', async accounts => {
     })
 
     it('Test constructor sets the owner as the trade wallet on empty address', async () => {
-      await mockStakeToken.givenMethodReturnBool(mockStakeToken_approve, true)
+      await mockStakingToken.givenMethodReturnBool(
+        mockStakingToken_approve,
+        true
+      )
 
       let newDelegate = await Delegate.new(
         mockSwap.address,
@@ -162,7 +165,10 @@ contract('Delegate Unit Tests', async accounts => {
     })
 
     it('Test owner is set correctly if provided an address', async () => {
-      await mockStakeToken.givenMethodReturnBool(mockStakeToken_approve, true)
+      await mockStakingToken.givenMethodReturnBool(
+        mockStakingToken_approve,
+        true
+      )
 
       let newDelegate = await Delegate.new(
         mockSwap.address,
@@ -295,13 +301,13 @@ contract('Delegate Unit Tests', async accounts => {
 
       let rule = [100000, 300, 0]
 
-      await mockStakeToken.givenMethodReturnUint(
-        mockStakeToken_allowance,
+      await mockStakingToken.givenMethodReturnUint(
+        mockStakingToken_allowance,
         intentAmount
       )
       //mock unsuccessful transfer
-      await mockStakeToken.givenMethodReturnBool(
-        mockStakeToken_transferFrom,
+      await mockStakingToken.givenMethodReturnBool(
+        mockStakingToken_transferFrom,
         false
       )
 
@@ -316,15 +322,18 @@ contract('Delegate Unit Tests', async accounts => {
 
       let rule = [100000, 300, 0]
 
-      await mockStakeToken.givenMethodReturnUint(
-        mockStakeToken_allowance,
+      await mockStakingToken.givenMethodReturnUint(
+        mockStakingToken_allowance,
         intentAmount
       )
-      await mockStakeToken.givenMethodReturnBool(
-        mockStakeToken_transferFrom,
+      await mockStakingToken.givenMethodReturnBool(
+        mockStakingToken_transferFrom,
         true
       )
-      await mockStakeToken.givenMethodReturnBool(mockStakeToken_approve, true)
+      await mockStakingToken.givenMethodReturnBool(
+        mockStakingToken_approve,
+        true
+      )
 
       await passes(
         delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, intentAmount)
@@ -337,10 +346,16 @@ contract('Delegate Unit Tests', async accounts => {
       let mockScore = 1000
 
       //mock the score/staked amount to be transferred
-      await mockIndexer.givenMethodReturnUint(mockIndexer_getScore, mockScore)
+      await mockIndexer.givenMethodReturnUint(
+        mockIndexer_getStakeAmount,
+        mockScore
+      )
 
       //mock a failed transfer
-      await mockStakeToken.givenMethodReturnBool(mockStakeToken_transfer, false)
+      await mockStakingToken.givenMethodReturnBool(
+        mockStakingToken_transfer,
+        false
+      )
 
       await reverted(
         delegate.unsetRuleAndIntent(MOCK_WETH, MOCK_DAI),
@@ -352,10 +367,16 @@ contract('Delegate Unit Tests', async accounts => {
       let mockScore = 1000
 
       //mock the score/staked amount to be transferred
-      await mockIndexer.givenMethodReturnUint(mockIndexer_getScore, mockScore)
+      await mockIndexer.givenMethodReturnUint(
+        mockIndexer_getStakeAmount,
+        mockScore
+      )
 
       //mock a successful transfer
-      await mockStakeToken.givenMethodReturnBool(mockStakeToken_transfer, true)
+      await mockStakingToken.givenMethodReturnBool(
+        mockStakingToken_transfer,
+        true
+      )
 
       await passes(delegate.unsetRuleAndIntent(MOCK_WETH, MOCK_DAI))
     })

--- a/protocols/delegate/test/Delegate.js
+++ b/protocols/delegate/test/Delegate.js
@@ -160,7 +160,7 @@ contract('Delegate Integration Tests', async accounts => {
       })
 
       //check the score of the delegate before
-      let scoreBefore = await indexer.getStakeAmount(
+      let scoreBefore = await indexer.getStakedAmount(
         aliceDelegate.address,
         tokenDAI.address,
         tokenWETH.address
@@ -180,7 +180,7 @@ contract('Delegate Integration Tests', async accounts => {
       )
 
       //check the score of the manager after
-      let scoreAfter = await indexer.getStakeAmount(
+      let scoreAfter = await indexer.getStakedAmount(
         aliceDelegate.address,
         tokenDAI.address,
         tokenWETH.address
@@ -196,7 +196,7 @@ contract('Delegate Integration Tests', async accounts => {
   describe('Test unsetRuleAndIntent()', async () => {
     it('Test successfully calling unsetRuleAndIntent()', async () => {
       //check the score of the manager before
-      let scoreBefore = await indexer.getStakeAmount(
+      let scoreBefore = await indexer.getStakedAmount(
         aliceDelegate.address,
         tokenDAI.address,
         tokenWETH.address
@@ -210,7 +210,7 @@ contract('Delegate Integration Tests', async accounts => {
       )
 
       //check the score of the manager after
-      let scoreAfter = await indexer.getStakeAmount(
+      let scoreAfter = await indexer.getStakedAmount(
         aliceDelegate.address,
         tokenDAI.address,
         tokenWETH.address

--- a/protocols/delegate/test/Delegate.js
+++ b/protocols/delegate/test/Delegate.js
@@ -30,7 +30,7 @@ contract('Delegate Integration Tests', async accounts => {
   const carolAddress = accounts[3]
   const aliceTradeWallet = accounts[4]
 
-  let stakeToken
+  let stakingToken
   let tokenDAI
   let tokenWETH
   let aliceDelegate
@@ -44,11 +44,11 @@ contract('Delegate Integration Tests', async accounts => {
   async function setupTokens() {
     tokenWETH = await FungibleToken.new()
     tokenDAI = await FungibleToken.new()
-    stakeToken = await FungibleToken.new()
+    stakingToken = await FungibleToken.new()
 
     await tokenWETH.mint(aliceAddress, STARTING_BALANCE)
     await tokenDAI.mint(aliceAddress, STARTING_BALANCE)
-    await stakeToken.mint(aliceAddress, STARTING_BALANCE)
+    await stakingToken.mint(aliceAddress, STARTING_BALANCE)
   }
 
   async function setupFactory() {
@@ -59,7 +59,7 @@ contract('Delegate Integration Tests', async accounts => {
   }
 
   async function setupIndexer() {
-    indexer = await Indexer.new(stakeToken.address)
+    indexer = await Indexer.new(stakingToken.address)
     await indexer.createIndex(tokenDAI.address, tokenWETH.address)
   }
 
@@ -155,15 +155,15 @@ contract('Delegate Integration Tests', async accounts => {
       let rule = [100000, 300, 0]
 
       //give allowance to the delegate to pull staking amount
-      await stakeToken.approve(aliceDelegate.address, INTENT_AMOUNT, {
+      await stakingToken.approve(aliceDelegate.address, INTENT_AMOUNT, {
         from: aliceAddress,
       })
 
       //check the score of the delegate before
-      let scoreBefore = await indexer.getScore(
+      let scoreBefore = await indexer.getStakeAmount(
+        aliceDelegate.address,
         tokenDAI.address,
-        tokenWETH.address,
-        aliceDelegate.address
+        tokenWETH.address
       )
       equal(scoreBefore.toNumber(), 0, 'intent score is incorrect')
 
@@ -180,26 +180,26 @@ contract('Delegate Integration Tests', async accounts => {
       )
 
       //check the score of the manager after
-      let scoreAfter = await indexer.getScore(
+      let scoreAfter = await indexer.getStakeAmount(
+        aliceDelegate.address,
         tokenDAI.address,
-        tokenWETH.address,
-        aliceDelegate.address
+        tokenWETH.address
       )
       equal(scoreAfter.toNumber(), INTENT_AMOUNT, 'intent score is incorrect')
 
       //check owner stake balance has been reduced
-      let stakeTokenBal = await stakeToken.balanceOf(aliceAddress)
-      equal(stakeTokenBal.toNumber(), STARTING_BALANCE - INTENT_AMOUNT)
+      let stakingTokenBal = await stakingToken.balanceOf(aliceAddress)
+      equal(stakingTokenBal.toNumber(), STARTING_BALANCE - INTENT_AMOUNT)
     })
   })
 
   describe('Test unsetRuleAndIntent()', async () => {
     it('Test successfully calling unsetRuleAndIntent()', async () => {
       //check the score of the manager before
-      let scoreBefore = await indexer.getScore(
+      let scoreBefore = await indexer.getStakeAmount(
+        aliceDelegate.address,
         tokenDAI.address,
-        tokenWETH.address,
-        aliceDelegate.address
+        tokenWETH.address
       )
       equal(scoreBefore.toNumber(), INTENT_AMOUNT, 'intent score is incorrect')
 
@@ -210,17 +210,17 @@ contract('Delegate Integration Tests', async accounts => {
       )
 
       //check the score of the manager after
-      let scoreAfter = await indexer.getScore(
+      let scoreAfter = await indexer.getStakeAmount(
+        aliceDelegate.address,
         tokenDAI.address,
-        tokenWETH.address,
-        aliceDelegate.address
+        tokenWETH.address
       )
       equal(scoreAfter.toNumber(), 0, 'intent score is incorrect')
 
       //check owner stake balance has been increased
-      let stakeTokenBal = await stakeToken.balanceOf(aliceAddress)
+      let stakingTokenBal = await stakingToken.balanceOf(aliceAddress)
 
-      equal(stakeTokenBal.toNumber(), STARTING_BALANCE)
+      equal(stakingTokenBal.toNumber(), STARTING_BALANCE)
     })
   })
 

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -149,12 +149,11 @@ contract Index is Ownable {
 
     address identifier = _entries[HEAD].next;
 
-    // if there's a valid start user, start there instead of the head
+    // If a valid _start is provided, start there.
     if (_start != address(0) && _start != HEAD) {
-      // check they exist
+      // Check that the provided _start identifier exists.
       require(hasEntry(_start), 'START_ENTRY_NOT_FOUND');
-
-      // the locator of the start user
+      // Set the identifier to the provided _start.
       identifier = _start;
     }
 

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -99,11 +99,10 @@ contract Index is Ownable {
   /**
     * @notice Unset a Locator
     * @param _identifier address
-    * @return bool return true on success
     */
   function unsetLocator(
     address _identifier
-  ) external onlyOwner returns (bool) {
+  ) external onlyOwner {
 
     // Ensure the entry exists.
     require(hasEntry(_identifier), "ENTRY_DOES_NOT_EXIST");
@@ -136,8 +135,8 @@ contract Index is Ownable {
   /**
     * @notice Get a Range of Locators
     * @dev _start value of 0x0 starts at the head
-    * @param _start address The identifier to start
-    * @param _count uint256 The number to return
+    * @param _start address Identifier to start with
+    * @param _count uint256 Number of locators to return
     * @return result bytes32[]
     */
   function getLocators(
@@ -174,10 +173,7 @@ contract Index is Ownable {
   function hasEntry(
     address _identifier
   ) internal view returns (bool) {
-    if (_entries[_identifier].locator != bytes32(0)) {
-      return true;
-    }
-    return false;
+    return _entries[_identifier].locator != bytes32(0);
   }
 
   /**

--- a/protocols/index/contracts/Index.sol
+++ b/protocols/index/contracts/Index.sol
@@ -119,15 +119,13 @@ contract Index is Ownable {
 
     // Decrement the index length.
     length = length - 1;
-
     emit UnsetLocator(_identifier);
-    return true;
   }
 
   /**
     * @notice Get a Score
     * @param _identifier address
-    * @return (uint256, bytes32) score and locator
+    * @return uint256
     */
   function getScore(
     address _identifier

--- a/protocols/index/test/Index-unit.js
+++ b/protocols/index/test/Index-unit.js
@@ -199,12 +199,6 @@ contract('Index Unit Tests', async accounts => {
     })
 
     it('should unset the entry for a valid user', async () => {
-      // check it returns true
-      let returnValue = await index.unsetLocator.call(bobAddress, {
-        from: owner,
-      })
-      equal(returnValue, true, 'unsetLocator should have returned true')
-
       // check it emits an event correctly
       let result = await index.unsetLocator(bobAddress, { from: owner })
       emitted(result, 'UnsetLocator', event => {

--- a/protocols/index/test/Index-unit.js
+++ b/protocols/index/test/Index-unit.js
@@ -31,10 +31,6 @@ contract('Index Unit Tests', async accounts => {
   let fredLocator = padAddressToLocator(fredAddress)
   let emptyLocator = padAddressToLocator(EMPTY_ADDRESS)
 
-  // helpers
-  const SCORE = 0
-  const LOCATOR = 1
-
   beforeEach(async () => {
     let snapShot = await takeSnapshot()
     snapshotId = snapShot['result']
@@ -53,37 +49,37 @@ contract('Index Unit Tests', async accounts => {
       let listLength = await index.length()
       equal(listLength, 0, 'list length should be 0')
 
-      let locators = await index.fetchLocators(EMPTY_ADDRESS, 10)
+      let locators = await index.getLocators(EMPTY_ADDRESS, 10)
       equal(locators.length, 10, 'list should have 10 slots')
       equal(locators[0], emptyLocator, 'The locator should be empty')
     })
   })
 
-  describe('Test setEntry', async () => {
-    it('should not allow a non owner to call setEntry', async () => {
+  describe('Test setLocator', async () => {
+    it('should not allow a non owner to call setLocator', async () => {
       await reverted(
-        index.setEntry(aliceAddress, 2000, aliceAddress, { from: nonOwner }),
+        index.setLocator(aliceAddress, 2000, aliceAddress, { from: nonOwner }),
         'Ownable: caller is not the owner'
       )
     })
 
     it('should allow an entry to be inserted by the owner', async () => {
       // set an entry from the owner
-      let result = await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      let result = await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
 
-      // check the SetEntry event was emitted
-      emitted(result, 'SetEntry', event => {
+      // check the SetLocator event was emitted
+      emitted(result, 'SetLocator', event => {
         return (
-          event.user === aliceAddress &&
+          event.identifier === aliceAddress &&
           event.score.toNumber() === 2000 &&
           event.locator === aliceLocator
         )
       })
 
       // check it has been inserted into the linked list correctly
-      let locators = await index.fetchLocators(EMPTY_ADDRESS, 10)
+      let locators = await index.getLocators(EMPTY_ADDRESS, 10)
       equal(locators.length, 10, 'list should be of size 10')
       equal(locators[0], aliceLocator, 'Alice should be in list')
       equal(locators[1], emptyLocator, 'The second locator should be empty')
@@ -95,32 +91,32 @@ contract('Index Unit Tests', async accounts => {
 
     it('should insert subsequent entries in the correct order', async () => {
       // insert alice
-      await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
 
       // now add more
-      let result = await index.setEntry(bobAddress, 500, bobLocator, {
+      let result = await index.setLocator(bobAddress, 500, bobLocator, {
         from: owner,
       })
 
-      // check the SetEntry event was emitted
-      emitted(result, 'SetEntry', event => {
+      // check the SetLocator event was emitted
+      emitted(result, 'SetLocator', event => {
         return (
-          event.user === bobAddress &&
+          event.identifier === bobAddress &&
           event.score.toNumber() === 500 &&
           event.locator === bobLocator
         )
       })
 
-      await index.setEntry(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocator, {
         from: owner,
       })
 
       let listLength = await index.length()
       equal(listLength, 3, 'list length should be 3')
 
-      const locators = await index.fetchLocators(EMPTY_ADDRESS, 7)
+      const locators = await index.getLocators(EMPTY_ADDRESS, 7)
       equal(locators[0], aliceLocator, 'Alice should be first')
       equal(locators[1], carolLocator, 'Carol should be second')
       equal(locators[2], bobLocator, 'Bob should be third')
@@ -128,24 +124,24 @@ contract('Index Unit Tests', async accounts => {
 
     it('should insert an identical stake after the pre-existing one', async () => {
       // two at 2000 and two at 0
-      await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
-      await index.setEntry(bobAddress, 0, bobLocator, {
+      await index.setLocator(bobAddress, 0, bobLocator, {
         from: owner,
       })
 
-      await index.setEntry(carolAddress, 2000, carolLocator, {
+      await index.setLocator(carolAddress, 2000, carolLocator, {
         from: owner,
       })
-      await index.setEntry(davidAddress, 0, davidLocator, {
+      await index.setLocator(davidAddress, 0, davidLocator, {
         from: owner,
       })
 
       let listLength = await index.length()
       equal(listLength, 4, 'Link list length should be 4')
 
-      const locators = await index.fetchLocators(EMPTY_ADDRESS, 7)
+      const locators = await index.getLocators(EMPTY_ADDRESS, 7)
       equal(locators[0], aliceLocator, 'Alice should be first')
       equal(locators[1], carolLocator, 'Carol should be second')
       equal(locators[2], bobLocator, 'Bob should be third')
@@ -153,11 +149,11 @@ contract('Index Unit Tests', async accounts => {
     })
 
     it('should not be able to set a second locator if one already exists for an address', async () => {
-      let trx = index.setEntry(aliceAddress, 2000, aliceLocator, {
+      let trx = index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
       await passes(trx)
-      trx = index.setEntry(aliceAddress, 5000, aliceLocator, {
+      trx = index.setLocator(aliceAddress, 5000, aliceLocator, {
         from: owner,
       })
       await reverted(trx, 'ENTRY_ALREADY_EXISTS')
@@ -167,38 +163,36 @@ contract('Index Unit Tests', async accounts => {
     })
   })
 
-  describe('Test unsetEntry', async () => {
+  describe('Test unsetLocator', async () => {
     beforeEach('Setup entries', async () => {
-      await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
-      await index.setEntry(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocator, {
         from: owner,
       })
-      await index.setEntry(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocator, {
         from: owner,
       })
     })
 
-    it('should not allow a non owner to call unsetEntry', async () => {
+    it('should not allow a non owner to call unsetLocator', async () => {
       await reverted(
-        index.unsetEntry(aliceAddress, { from: nonOwner }),
+        index.unsetLocator(aliceAddress, { from: nonOwner }),
         'Ownable: caller is not the owner'
       )
     })
 
     it('should leave state unchanged for someone who hasnt staked', async () => {
-      let returnValue = await index.unsetEntry.call(davidAddress, {
+      let trx = index.unsetLocator(davidAddress, {
         from: owner,
       })
-      equal(returnValue, false, 'unsetEntry should have returned false')
-
-      await index.unsetEntry(davidAddress, { from: owner })
+      await reverted(trx, 'ENTRY_DOES_NOT_EXIST')
 
       let listLength = await index.length()
       equal(listLength, 3, 'list length should be 3')
 
-      const locators = await index.fetchLocators(EMPTY_ADDRESS, 7)
+      const locators = await index.getLocators(EMPTY_ADDRESS, 7)
       equal(locators[0], aliceLocator, 'Alice should be first')
       equal(locators[1], carolLocator, 'Carol should be second')
       equal(locators[2], bobLocator, 'Bob should be third')
@@ -206,92 +200,74 @@ contract('Index Unit Tests', async accounts => {
 
     it('should unset the entry for a valid user', async () => {
       // check it returns true
-      let returnValue = await index.unsetEntry.call(bobAddress, {
+      let returnValue = await index.unsetLocator.call(bobAddress, {
         from: owner,
       })
-      equal(returnValue, true, 'unsetEntry should have returned true')
+      equal(returnValue, true, 'unsetLocator should have returned true')
 
       // check it emits an event correctly
-      let result = await index.unsetEntry(bobAddress, { from: owner })
-      emitted(result, 'UnsetEntry', event => {
-        return event.user === bobAddress
+      let result = await index.unsetLocator(bobAddress, { from: owner })
+      emitted(result, 'UnsetLocator', event => {
+        return event.identifier === bobAddress
       })
 
       let listLength = await index.length()
       equal(listLength, 2, 'list length should be 2')
 
-      let locators = await index.fetchLocators(EMPTY_ADDRESS, 7)
+      let locators = await index.getLocators(EMPTY_ADDRESS, 7)
       equal(locators[0], aliceLocator, 'Alice should be first')
       equal(locators[1], carolLocator, 'Carol should be second')
 
-      await index.unsetEntry(aliceAddress, { from: owner })
-      await index.unsetEntry(carolAddress, { from: owner })
+      await index.unsetLocator(aliceAddress, { from: owner })
+      await index.unsetLocator(carolAddress, { from: owner })
 
       listLength = await index.length()
       equal(listLength, 0, 'list length should be 0')
 
-      locators = await index.fetchLocators(EMPTY_ADDRESS, 4)
+      locators = await index.getLocators(EMPTY_ADDRESS, 4)
       equal(locators.length, 4, 'list should have 4 locators')
       equal(locators[0], emptyLocator, 'The first locator should be empty')
       equal(locators[1], emptyLocator, 'The second locator should be empty')
       equal(locators[2], emptyLocator, 'The third locator should be empty')
       equal(locators[3], emptyLocator, 'The fouth locator should be empty')
     })
-
-    it('unsetting entry twice in a row for an address has no effect', async () => {
-      let trx = index.unsetEntry(bobAddress, { from: owner })
-      await passes(trx)
-      let size = await index.length.call()
-      equal(size, 2, 'Locator was improperly removed')
-      trx = index.unsetEntry(bobAddress, { from: owner })
-      await passes(trx)
-      equal(size, 2, 'Locator was improperly removed')
-
-      let locators = await index.fetchLocators(EMPTY_ADDRESS, 7)
-      equal(locators[0], aliceLocator, 'Alice should be first')
-      equal(locators[1], carolLocator, 'Carol should be second')
-    })
   })
 
   describe('Test getLocator', async () => {
     beforeEach('Setup entries again', async () => {
-      await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
-      await index.setEntry(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocator, {
         from: owner,
       })
-      await index.setEntry(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocator, {
         from: owner,
       })
     })
 
     it('should return empty entry for a non-user', async () => {
-      let davidEntry = await index.getEntry(davidAddress)
-      equal(davidEntry[SCORE], 0, 'David: Locator score not correct')
-      equal(davidEntry[LOCATOR], emptyLocator, 'David: Locator not correct')
+      let davidScore = await index.getScore(davidAddress)
+      equal(davidScore, 0, 'David: Locator score not correct')
 
       // now for a recently unset entry
-      await index.unsetEntry(carolAddress, { from: owner })
-      let testEntry = await index.getEntry(carolAddress)
-      equal(testEntry[SCORE], 0, 'Carol: Locator score not correct')
-      equal(testEntry[LOCATOR], emptyLocator, 'Carol: Locator not correct')
+      await index.unsetLocator(carolAddress, { from: owner })
+      let testScore = await index.getScore(carolAddress)
+      equal(testScore, 0, 'Carol: Locator score not correct')
     })
 
     it('should return the correct entry for a valid user', async () => {
-      let aliceEntry = await index.getEntry(aliceAddress)
-      equal(aliceEntry[SCORE], 2000, 'Alice: Locator score not correct')
-      equal(aliceEntry[LOCATOR], aliceLocator, 'Alice: Locator not correct')
+      let aliceScore = await index.getScore(aliceAddress)
+      equal(aliceScore, 2000, 'Alice: Locator score not correct')
 
-      let bobEntry = await index.getEntry(bobAddress)
-      equal(bobEntry[SCORE], 500, 'Bob: Locator score not correct')
-      equal(bobEntry[LOCATOR], bobLocator, 'Bob: Locator not correct')
+      let bobScore = await index.getScore(bobAddress)
+      equal(bobScore, 500, 'Bob: Locator score not correct')
     })
   })
 
-  describe('Test fetchLocators', async () => {
+  describe('Test getLocators', async () => {
     it('returns an array of empty locators', async () => {
-      const locators = await index.fetchLocators(EMPTY_ADDRESS, 7)
+      const locators = await index.getLocators(EMPTY_ADDRESS, 7)
       equal(locators.length, 7, 'there should be 7 locators')
       equal(locators[0], emptyLocator, 'The first locator should be empty')
       equal(locators[1], emptyLocator, 'The second locator should be empty')
@@ -299,24 +275,24 @@ contract('Index Unit Tests', async accounts => {
 
     it('returns specified number of elements if < length', async () => {
       // add 3 locators
-      await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
-      await index.setEntry(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocator, {
         from: owner,
       })
-      await index.setEntry(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocator, {
         from: owner,
       })
 
-      let locators = await index.fetchLocators(EMPTY_ADDRESS, 2)
+      let locators = await index.getLocators(EMPTY_ADDRESS, 2)
       equal(locators.length, 2, 'there should only be 2 locators returned')
 
       equal(locators[0], aliceLocator, 'Alice should be first')
       equal(locators[1], carolLocator, 'Carol should be second')
 
       // the same should happen passing HEAD
-      locators = await index.fetchLocators(HEAD, 2)
+      locators = await index.getLocators(HEAD, 2)
       equal(locators.length, 2, 'there should only be 2 locators returned')
 
       equal(locators[0], aliceLocator, 'Alice should be first')
@@ -325,17 +301,17 @@ contract('Index Unit Tests', async accounts => {
 
     it('returns only length if requested number if larger', async () => {
       // add 3 entries
-      await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
-      await index.setEntry(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocator, {
         from: owner,
       })
-      await index.setEntry(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocator, {
         from: owner,
       })
 
-      const locators = await index.fetchLocators(EMPTY_ADDRESS, 10)
+      const locators = await index.getLocators(EMPTY_ADDRESS, 10)
       equal(locators.length, 10, 'there should be 10 locators returned')
 
       equal(locators[0], aliceLocator, 'Alice should be first')
@@ -347,17 +323,17 @@ contract('Index Unit Tests', async accounts => {
 
     it('starts the array at the specified starting user', async () => {
       // add 3 locators
-      await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
-      await index.setEntry(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocator, {
         from: owner,
       })
-      await index.setEntry(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocator, {
         from: owner,
       })
 
-      const locators = await index.fetchLocators(bobAddress, 10)
+      const locators = await index.getLocators(bobAddress, 10)
       equal(locators.length, 10, 'there should be 10 locators returned')
 
       equal(locators[0], bobLocator, 'Bob should be first')
@@ -367,27 +343,27 @@ contract('Index Unit Tests', async accounts => {
 
     it('starts the array at the specified starting user - longer list', async () => {
       // add 3 locators
-      await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
-      await index.setEntry(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocator, {
         from: owner,
       })
-      await index.setEntry(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocator, {
         from: owner,
       })
-      await index.setEntry(davidAddress, 700, davidLocator, {
+      await index.setLocator(davidAddress, 700, davidLocator, {
         from: owner,
       })
-      await index.setEntry(emilyAddress, 1, emilyLocator, {
+      await index.setLocator(emilyAddress, 1, emilyLocator, {
         from: owner,
       })
-      await index.setEntry(fredAddress, 4000, fredLocator, {
+      await index.setLocator(fredAddress, 4000, fredLocator, {
         from: owner,
       })
 
       // fetch 4 from first element
-      let locators = await index.fetchLocators(fredAddress, 4)
+      let locators = await index.getLocators(fredAddress, 4)
       equal(locators.length, 4, 'there should be 4 locators returned')
 
       equal(locators[0], fredLocator, 'Fred should be first')
@@ -396,7 +372,7 @@ contract('Index Unit Tests', async accounts => {
       equal(locators[3], davidLocator, 'David should be fourth')
 
       // now fetch the next 4
-      locators = await index.fetchLocators(bobAddress, 4)
+      locators = await index.getLocators(bobAddress, 4)
       equal(locators.length, 4, 'there should be 4 locators returned')
       equal(locators[0], bobLocator, 'Bob should be first')
       equal(locators[1], emilyLocator, 'Emily should be second')
@@ -406,17 +382,20 @@ contract('Index Unit Tests', async accounts => {
 
     it('throws an error for an unstaked user', async () => {
       // add 3 locators
-      await index.setEntry(aliceAddress, 2000, aliceLocator, {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
-      await index.setEntry(bobAddress, 500, bobLocator, {
+      await index.setLocator(bobAddress, 500, bobLocator, {
         from: owner,
       })
-      await index.setEntry(carolAddress, 1500, carolLocator, {
+      await index.setLocator(carolAddress, 1500, carolLocator, {
         from: owner,
       })
 
-      await reverted(index.fetchLocators(davidAddress, 10), 'USER_HAS_NO_ENTRY')
+      await reverted(
+        index.getLocators(davidAddress, 10),
+        'START_ENTRY_NOT_FOUND'
+      )
     })
   })
 })

--- a/protocols/indexer/contracts/Indexer.sol
+++ b/protocols/indexer/contracts/Indexer.sol
@@ -193,7 +193,7 @@ contract Indexer is IIndexer, Ownable {
     * @param _user address
     * @return uint256
     */
-  function getStakeAmount(
+  function getStakedAmount(
     address _user,
     address _signerToken,
     address _senderToken
@@ -292,7 +292,7 @@ contract Indexer is IIndexer, Ownable {
     uint256 score = indexes[_signerToken][_senderToken].getScore(_user);
 
     // Unset the locator on the index.
-    require(indexes[_signerToken][_senderToken].unsetLocator(_user), 'ENTRY_DOES_NOT_EXIST');
+    indexes[_signerToken][_senderToken].unsetLocator(_user);
 
     if (score > 0) {
       // Return the staked tokens. Reverts on failure.

--- a/protocols/indexer/contracts/interfaces/IIndexer.sol
+++ b/protocols/indexer/contracts/interfaces/IIndexer.sol
@@ -78,7 +78,7 @@ interface IIndexer {
     address _senderToken
   ) external;
 
-  function getStakeAmount(
+  function getStakedAmount(
     address _user,
     address _signerToken,
     address _senderToken
@@ -94,7 +94,7 @@ interface IIndexer {
   function unsetIntentForUser(
     address _user,
     address _signerToken,
-    address _senderToken)
-  external;
+    address _senderToken
+  ) external;
 
 }

--- a/protocols/indexer/contracts/interfaces/IIndexer.sol
+++ b/protocols/indexer/contracts/interfaces/IIndexer.sol
@@ -45,9 +45,13 @@ interface IIndexer {
     address token
   );
 
-  function stakeToken() external returns (address);
+  function stakingToken() external returns (address);
   function indexes(address, address) external returns (address);
   function blacklist(address) external returns (bool);
+
+  function setLocatorWhitelist(
+    address _locatorWhitelist
+  ) external;
 
   function createIndex(
     address _signerToken,
@@ -74,17 +78,23 @@ interface IIndexer {
     address _senderToken
   ) external;
 
-  function getScore(
+  function getStakeAmount(
+    address _user,
     address _signerToken,
-    address _senderToken,
-    address _user
+    address _senderToken
   ) external view returns (uint256);
 
-  function getIntents(
+  function getLocators(
     address _signerToken,
     address _senderToken,
     address _startAddress,
     uint256 _count
   ) external view returns (bytes32[] memory);
+
+  function unsetIntentForUser(
+    address _user,
+    address _signerToken,
+    address _senderToken)
+  external;
 
 }

--- a/protocols/indexer/test/Indexer-unit.js
+++ b/protocols/indexer/test/Indexer-unit.js
@@ -685,7 +685,7 @@ contract('Indexer Unit Tests', async accounts => {
     })
   })
 
-  describe('Test getStakeAmount', async () => {
+  describe('Test getStakedAmount', async () => {
     it('should fail if the index does not exist', async () => {
       await reverted(
         indexer.setIntent(tokenOne, tokenTwo, 1000, aliceLocator, {
@@ -706,7 +706,7 @@ contract('Indexer Unit Tests', async accounts => {
         from: aliceAddress,
       })
 
-      let val = await indexer.getStakeAmount(aliceAddress, tokenOne, tokenTwo)
+      let val = await indexer.getStakedAmount(aliceAddress, tokenOne, tokenTwo)
       equal(val.toNumber(), stakeAmount, 'stake was improperly saved')
     })
   })

--- a/protocols/indexer/test/Indexer-unit.js
+++ b/protocols/indexer/test/Indexer-unit.js
@@ -71,7 +71,7 @@ contract('Indexer Unit Tests', async accounts => {
 
   describe('Check constructor', async () => {
     it('should set the staking token address correctly', async () => {
-      const actualAddress = await indexer.stakeToken()
+      const actualAddress = await indexer.stakingToken()
       equal(
         actualAddress,
         stakingTokenAddress,
@@ -472,9 +472,9 @@ contract('Indexer Unit Tests', async accounts => {
     })
   })
 
-  describe('Test getIntents', async () => {
+  describe('Test getLocators', async () => {
     it('should return an empty array if the index doesnt exist', async () => {
-      let intents = await indexer.getIntents.call(
+      let intents = await indexer.getLocators.call(
         tokenOne,
         tokenTwo,
         EMPTY_ADDRESS,
@@ -500,7 +500,7 @@ contract('Indexer Unit Tests', async accounts => {
       })
 
       // now try to get the intents
-      let intents = await indexer.getIntents.call(
+      let intents = await indexer.getLocators.call(
         tokenOne,
         tokenTwo,
         EMPTY_ADDRESS,
@@ -527,7 +527,7 @@ contract('Indexer Unit Tests', async accounts => {
       })
 
       // now try to get the intents
-      let intents = await indexer.getIntents.call(
+      let intents = await indexer.getLocators.call(
         tokenOne,
         tokenTwo,
         EMPTY_ADDRESS,
@@ -540,7 +540,7 @@ contract('Indexer Unit Tests', async accounts => {
       equal(intents[3], emptyLocatorData, 'intent should be empty')
 
       // should only get the number specified
-      intents = await indexer.getIntents.call(
+      intents = await indexer.getLocators.call(
         tokenOne,
         tokenTwo,
         EMPTY_ADDRESS,
@@ -550,7 +550,7 @@ contract('Indexer Unit Tests', async accounts => {
       equal(intents[0], bobLocator, 'intent should be bob')
 
       // should start in the specified location
-      intents = await indexer.getIntents.call(
+      intents = await indexer.getLocators.call(
         tokenOne,
         tokenTwo,
         carolAddress,
@@ -685,7 +685,7 @@ contract('Indexer Unit Tests', async accounts => {
     })
   })
 
-  describe('Test getScore', async () => {
+  describe('Test getStakeAmount', async () => {
     it('should fail if the index does not exist', async () => {
       await reverted(
         indexer.setIntent(tokenOne, tokenTwo, 1000, aliceLocator, {
@@ -706,7 +706,7 @@ contract('Indexer Unit Tests', async accounts => {
         from: aliceAddress,
       })
 
-      let val = await indexer.getScore(tokenOne, tokenTwo, aliceAddress)
+      let val = await indexer.getStakeAmount(aliceAddress, tokenOne, tokenTwo)
       equal(val.toNumber(), stakeAmount, 'stake was improperly saved')
     })
   })

--- a/protocols/indexer/test/Indexer.js
+++ b/protocols/indexer/test/Indexer.js
@@ -76,7 +76,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
     })
 
     it('Bob ensures no intents are on the Indexer for existing index', async () => {
-      const intents = await indexer.getIntents.call(
+      const intents = await indexer.getLocators.call(
         tokenWETH.address,
         tokenDAI.address,
         EMPTY_ADDRESS,
@@ -91,7 +91,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
     })
 
     it('Bob ensures no intents are on the Indexer for non-existing index', async () => {
-      const intents = await indexer.getIntents.call(
+      const intents = await indexer.getLocators.call(
         tokenDAI.address,
         tokenWETH.address,
         EMPTY_ADDRESS,
@@ -249,7 +249,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
 
   describe('Intent integrity', async () => {
     it('Bob ensures only one intent is on the Indexer', async () => {
-      const intents = await indexer.getIntents.call(
+      const intents = await indexer.getLocators.call(
         tokenWETH.address,
         tokenDAI.address,
         EMPTY_ADDRESS,
@@ -296,7 +296,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
     })
 
     it('Bob ensures there are no more intents the Indexer', async () => {
-      const intents = await indexer.getIntents.call(
+      const intents = await indexer.getLocators.call(
         tokenWETH.address,
         tokenDAI.address,
         EMPTY_ADDRESS,
@@ -346,7 +346,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
     })
 
     it('Bob tries to fetch intent on blacklisted token which returns 0', async () => {
-      const intents = await indexer.getIntents.call(
+      const intents = await indexer.getLocators.call(
         tokenWETH.address,
         tokenDAI.address,
         EMPTY_ADDRESS,
@@ -446,7 +446,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
     })
 
     it('Bob fetches intents starting at bobAddress', async () => {
-      const intents = await indexer.getIntents.call(
+      const intents = await indexer.getLocators.call(
         tokenWETH.address,
         tokenDAI.address,
         bobAddress,

--- a/protocols/types/contracts/Types.sol
+++ b/protocols/types/contracts/Types.sol
@@ -27,8 +27,8 @@ library Types {
 
   struct Rule {
     uint256 maxSenderAmount;      // The maximum amount of ERC-20 token the delegate would send
-    uint256 priceCoef;            // The whole number that will be multiplied by the 10^(-priceExp) - the price coefficient
-    uint256 priceExp;             // The exponent of the price to indicate location of the decimal priceCoef * 10^(-priceExp)
+    uint256 priceCoef;            // Number to be multiplied by 10^(-priceExp) - the price coefficient
+    uint256 priceExp;             // Indicates location of the decimal priceCoef * 10^(-priceExp)
   }
 
   struct Order {


### PR DESCRIPTION
API pass, cleanup, full eslint and solhint pass.

Updates to `Index.sol`:

1. Remove traces of "user" and replace with "identifier"
2. Update API to work with locators only. Consider an "Entry" to be an implementation detail
3. Remove references to "linked list"
4. `getEntry` becomes `getScore` and only returns score
5. Add a `require` to `unsetLocator` to throw if locator does not exist

Updates to `Indexer.sol`:
1. `getIntents` becomes `getLocators`
2. `stakeToken` becomes `stakingToken`
3. `Indexer.getScore becomes` becomes `Indexer.getStakeAmount`
4. Adds recent `Indexer.sol` additions to `IIndexer.sol` interface