### PR TITLE
No Transfer call with 0 Stake

### DIFF
--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -154,10 +154,12 @@ contract Delegate is IDelegate, Ownable {
     );
 
     // Transfer the staking tokens from the sender to the Delegate.
-    require(
-      IERC20(indexer.stakingToken())
-      .transferFrom(msg.sender, address(this), amountToStake), "STAKING_TRANSFER_FAILED"
-    );
+    if (amountToStake > 0) {
+      require(
+        IERC20(indexer.stakingToken())
+        .transferFrom(msg.sender, address(this), amountToStake), "STAKING_TRANSFER_FAILED"
+      );
+    }
 
     indexer.setIntent(
       signerToken,
@@ -186,10 +188,12 @@ contract Delegate is IDelegate, Ownable {
 
     // Upon unstaking, the Delegate will be given the staking amount.
     // This is returned to the msg.sender.
-    require(
-      IERC20(indexer.stakingToken())
-        .transfer(msg.sender, stakedAmount),"STAKING_TRANSFER_FAILED"
-    );
+    if (amountToStake > 0) {
+      require(
+        IERC20(indexer.stakingToken())
+          .transfer(msg.sender, stakedAmount),"STAKING_TRANSFER_FAILED"
+      );
+    }
   }
 
   /**

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -188,7 +188,7 @@ contract Delegate is IDelegate, Ownable {
 
     // Upon unstaking, the Delegate will be given the staking amount.
     // This is returned to the msg.sender.
-    if (amountToStake > 0) {
+    if (stakedAmount > 0) {
       require(
         IERC20(indexer.stakingToken())
           .transfer(msg.sender, stakedAmount),"STAKING_TRANSFER_FAILED"

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -318,13 +318,13 @@ contract('Delegate Unit Tests', async accounts => {
 
   describe('Test setRuleAndIntent()', async () => {
     it('Test calling setRuleAndIntent with transfer error', async () => {
-      let intentAmount = 250
+      let stakedAmount = 250
 
       let rule = [100000, 300, 0]
 
       await mockStakingToken.givenMethodReturnUint(
         mockStakingToken_allowance,
-        intentAmount
+        stakedAmount
       )
       //mock unsuccessful transfer
       await mockStakingToken.givenMethodReturnBool(
@@ -333,19 +333,34 @@ contract('Delegate Unit Tests', async accounts => {
       )
 
       await reverted(
-        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, intentAmount),
+        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, stakedAmount),
         'STAKING_TRANSFER_FAILED'
       )
     })
 
-    it('Test successfully calling setRuleAndIntent', async () => {
-      let intentAmount = 250
+    it('Test successfully calling setRuleAndIntent with 0 staked amount', async () => {
+      let stakedAmount = 0
+
+      let rule = [100000, 300, 0]
+
+      await mockStakingToken.givenMethodReturnBool(
+        mockStakingToken_approve,
+        true
+      )
+
+      await passes(
+        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, stakedAmount)
+      )
+    })
+
+    it('Test successfully calling setRuleAndIntent with staked amount', async () => {
+      let stakedAmount = 250
 
       let rule = [100000, 300, 0]
 
       await mockStakingToken.givenMethodReturnUint(
         mockStakingToken_allowance,
-        intentAmount
+        stakedAmount
       )
       await mockStakingToken.givenMethodReturnBool(
         mockStakingToken_transferFrom,
@@ -357,7 +372,7 @@ contract('Delegate Unit Tests', async accounts => {
       )
 
       await passes(
-        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, intentAmount)
+        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, stakedAmount)
       )
     })
   })
@@ -384,7 +399,19 @@ contract('Delegate Unit Tests', async accounts => {
       )
     })
 
-    it('Test successfully calling unsetRuleAndIntent()', async () => {
+    it('Test successfully calling unsetRuleAndIntent() with 0 staked amount', async () => {
+      let mockScore = 0
+
+      //mock the score/staked amount to be transferred
+      await mockIndexer.givenMethodReturnUint(
+        mockIndexer_getStakedAmount,
+        mockScore
+      )
+
+      await passes(delegate.unsetRuleAndIntent(MOCK_WETH, MOCK_DAI))
+    })
+
+    it('Test successfully calling unsetRuleAndIntent() with staked amount', async () => {
       let mockScore = 1000
 
       //mock the score/staked amount to be transferred

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -318,13 +318,13 @@ contract('Delegate Unit Tests', async accounts => {
 
   describe('Test setRuleAndIntent()', async () => {
     it('Test calling setRuleAndIntent with transfer error', async () => {
-      let stakedAmount = 250
+      let stakeAmount = 250
 
       let rule = [100000, 300, 0]
 
       await mockStakingToken.givenMethodReturnUint(
         mockStakingToken_allowance,
-        stakedAmount
+        stakeAmount
       )
       //mock unsuccessful transfer
       await mockStakingToken.givenMethodReturnBool(
@@ -333,13 +333,13 @@ contract('Delegate Unit Tests', async accounts => {
       )
 
       await reverted(
-        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, stakedAmount),
+        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, stakeAmount),
         'STAKING_TRANSFER_FAILED'
       )
     })
 
     it('Test successfully calling setRuleAndIntent with 0 staked amount', async () => {
-      let stakedAmount = 0
+      let stakeAmount = 0
 
       let rule = [100000, 300, 0]
 
@@ -349,18 +349,18 @@ contract('Delegate Unit Tests', async accounts => {
       )
 
       await passes(
-        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, stakedAmount)
+        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, stakeAmount)
       )
     })
 
     it('Test successfully calling setRuleAndIntent with staked amount', async () => {
-      let stakedAmount = 250
+      let stakeAmount = 250
 
       let rule = [100000, 300, 0]
 
       await mockStakingToken.givenMethodReturnUint(
         mockStakingToken_allowance,
-        stakedAmount
+        stakeAmount
       )
       await mockStakingToken.givenMethodReturnBool(
         mockStakingToken_transferFrom,
@@ -372,7 +372,7 @@ contract('Delegate Unit Tests', async accounts => {
       )
 
       await passes(
-        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, stakedAmount)
+        delegate.setRuleAndIntent(MOCK_WETH, MOCK_DAI, rule, stakeAmount)
       )
     })
   })


### PR DESCRIPTION
## Description
https://github.com/airswap/airswap-protocols/issues/213

## Changes
- `setRuleAndIntent()` - added check that doesn't call `transferFrom()` with 0 staked amount
- `unsetRuleAndIntent()` - added check that doesn't call `transfer()` with 0 staked amount

## Tests and Coverage
```
  70 passing (8s)

-----------------------|----------|----------|----------|----------|----------------|
File                   |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-----------------------|----------|----------|----------|----------|----------------|
 contracts/            |      100 |      100 |      100 |      100 |                |
  Delegate.sol         |      100 |      100 |      100 |      100 |                |
  Imports.sol          |      100 |      100 |      100 |      100 |                |
 contracts/interfaces/ |      100 |      100 |      100 |      100 |                |
  IDelegate.sol        |      100 |      100 |      100 |      100 |                |
-----------------------|----------|----------|----------|----------|----------------|
All files              |      100 |      100 |      100 |      100 |                |
-----------------------|----------|----------|----------|----------|----------------|
```