### PR TITLE
Indexer update stake

### DIFF
--- a/source/index/contracts/Index.sol
+++ b/source/index/contracts/Index.sol
@@ -168,7 +168,7 @@ contract Index is Ownable {
     result = new bytes32[](count);
 
     // Iterate over the list until the end or count.
-    uint8 i = 0;
+    uint256 i = 0;
     while (i < count && identifier != HEAD) {
       result[i] = entries[identifier].locator;
       i = i + 1;

--- a/source/index/contracts/Index.sol
+++ b/source/index/contracts/Index.sol
@@ -139,7 +139,7 @@ contract Index is Ownable {
     */
   function getLocator(
     address identifier
-  ) external view returns (uint256) {
+  ) external view returns (bytes32) {
     return entries[identifier].locator;
   }
 

--- a/source/index/contracts/Index.sol
+++ b/source/index/contracts/Index.sol
@@ -132,6 +132,17 @@ contract Index is Ownable {
     return entries[identifier].score;
   }
 
+    /**
+    * @notice Get a Locator
+    * @param identifier address On-chain address identifying the owner of a locator
+    * @return uint256 Locator information
+    */
+  function getLocator(
+    address identifier
+  ) external view returns (uint256) {
+    return entries[identifier].locator;
+  }
+
   /**
     * @notice Get a Range of Locators
     * @dev start value of 0x0 starts at the head

--- a/source/index/contracts/Index.sol
+++ b/source/index/contracts/Index.sol
@@ -135,7 +135,7 @@ contract Index is Ownable {
     /**
     * @notice Get a Locator
     * @param identifier address On-chain address identifying the owner of a locator
-    * @return uint256 Locator information
+    * @return bytes32 Locator information
     */
   function getLocator(
     address identifier
@@ -168,7 +168,7 @@ contract Index is Ownable {
     result = new bytes32[](count);
 
     // Iterate over the list until the end or count.
-    uint256 i = 0;
+    uint256 i;
     while (i < count && identifier != HEAD) {
       result[i] = entries[identifier].locator;
       i = i + 1;

--- a/source/index/test/Index-unit.js
+++ b/source/index/test/Index-unit.js
@@ -254,8 +254,8 @@ contract('Index Unit Tests', async accounts => {
     })
   })
 
-  describe('Test getLocator', async () => {
-    beforeEach('Setup entries again', async () => {
+  describe('Test getScore', async () => {
+    beforeEach('Setup locators again', async () => {
       await index.setLocator(aliceAddress, 2000, aliceLocator, {
         from: owner,
       })
@@ -267,7 +267,7 @@ contract('Index Unit Tests', async accounts => {
       })
     })
 
-    it('should return empty entry for a non-user', async () => {
+    it('should return no score for a non-user', async () => {
       let davidScore = await index.getScore(davidAddress)
       equal(davidScore, 0, 'David: Locator score not correct')
 
@@ -277,12 +277,44 @@ contract('Index Unit Tests', async accounts => {
       equal(testScore, 0, 'Carol: Locator score not correct')
     })
 
-    it('should return the correct entry for a valid user', async () => {
+    it('should return the correct score for a valid user', async () => {
       let aliceScore = await index.getScore(aliceAddress)
       equal(aliceScore, 2000, 'Alice: Locator score not correct')
 
       let bobScore = await index.getScore(bobAddress)
       equal(bobScore, 500, 'Bob: Locator score not correct')
+    })
+  })
+
+  describe('Test getLocator', async () => {
+    beforeEach('Setup locators again', async () => {
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
+        from: owner,
+      })
+      await index.setLocator(bobAddress, 500, bobLocator, {
+        from: owner,
+      })
+      await index.setLocator(carolAddress, 1500, carolLocator, {
+        from: owner,
+      })
+    })
+
+    it('should return empty locator for a non-user', async () => {
+      let locator = await index.getLocator(davidAddress)
+      equal(locator, emptyLocator, 'David: Locator score not correct')
+
+      // now for a recently unset entry
+      await index.unsetLocator(carolAddress, { from: owner })
+      locator = await index.getLocator(carolAddress)
+      equal(locator, emptyLocator, 'Carol: Locator score not correct')
+    })
+
+    it('should return the correct locator for a valid user', async () => {
+      let locator = await index.getLocator(aliceAddress)
+      equal(locator, aliceLocator, 'Alice: Locator score not correct')
+
+      locator = await index.getLocator(bobAddress)
+      equal(locator, bobLocator, 'Bob: Locator score not correct')
     })
   })
 

--- a/source/indexer/contracts/Imports.sol
+++ b/source/indexer/contracts/Imports.sol
@@ -3,5 +3,9 @@ pragma solidity 0.5.12;
 import "@airswap/tokens/contracts/FungibleToken.sol";
 import "@airswap/index/contracts/Index.sol";
 import "@gnosis.pm/mock-contract/contracts/MockContract.sol";
+import "@airswap/delegate-factory/contracts/DelegateFactory.sol";
+import "@airswap/swap/contracts/Swap.sol";
+import "@airswap/types/contracts/Types.sol";
+
 
 contract Imports {}

--- a/source/indexer/contracts/Indexer.sol
+++ b/source/indexer/contracts/Indexer.sol
@@ -255,7 +255,7 @@ contract Indexer is IIndexer, Ownable {
     address senderToken,
     address startAddress,
     uint256 count
-  ) external notPaused returns (
+  ) external view notPaused returns (
     bytes32[] memory locators
   ) {
     // Ensure neither token is blacklisted.
@@ -283,7 +283,7 @@ contract Indexer is IIndexer, Ownable {
     address user,
     address signerToken,
     address senderToken
-  ) public indexExists(signerToken, senderToken) returns (uint256) {
+  ) public view indexExists(signerToken, senderToken) returns (uint256) {
 
     // Return the score, equivalent to the stake amount.
     return indexes[signerToken][senderToken].getScore(user);

--- a/source/indexer/contracts/Indexer.sol
+++ b/source/indexer/contracts/Indexer.sol
@@ -299,12 +299,14 @@ contract Indexer is IIndexer, Ownable {
   ) internal {
     // If the new stake is bigger, collect the difference.
     if (oldAmount < newAmount) {
+      // Note: SafeMath not required due to the inequality check above
       require(stakingToken.transferFrom(user, address(this), newAmount - oldAmount),
         "UNABLE_TO_STAKE");
     }
 
     // If the old stake is bigger, return the excess.
     if (newAmount < oldAmount) {
+      // Note: SafeMath not required due to the inequality check above
       require(stakingToken.transfer(user, oldAmount - newAmount));
     }
 

--- a/source/indexer/contracts/Indexer.sol
+++ b/source/indexer/contracts/Indexer.sol
@@ -297,22 +297,22 @@ contract Indexer is IIndexer, Ownable {
     bytes32 newLocator,
     uint256 oldAmount
   ) internal {
-      // If the new stake is bigger, collect the difference.
-      if (oldAmount < newAmount) {
-        require(stakingToken.transferFrom(user, address(this), newAmount - oldAmount),
-          "UNABLE_TO_STAKE");
-      }
+    // If the new stake is bigger, collect the difference.
+    if (oldAmount < newAmount) {
+      require(stakingToken.transferFrom(user, address(this), newAmount - oldAmount),
+        "UNABLE_TO_STAKE");
+    }
 
-      // If the old stake is bigger, return the excess.
-      if (newAmount < oldAmount) {
-        require(stakingToken.transfer(user, oldAmount - newAmount));
-      }
+    // If the old stake is bigger, return the excess.
+    if (newAmount < oldAmount) {
+      require(stakingToken.transfer(user, oldAmount - newAmount));
+    }
 
-      emit Stake(user, signerToken, senderToken, newAmount);
+    emit Stake(user, signerToken, senderToken, newAmount);
 
-      // Unset their old intent, and set their new intent.
-      indexes[signerToken][senderToken].unsetLocator(user);
-      indexes[signerToken][senderToken].setLocator(user, newAmount, newLocator);
+    // Unset their old intent, and set their new intent.
+    indexes[signerToken][senderToken].unsetLocator(user);
+    indexes[signerToken][senderToken].setLocator(user, newAmount, newLocator);
 
   }
 

--- a/source/indexer/contracts/Indexer.sol
+++ b/source/indexer/contracts/Indexer.sol
@@ -255,7 +255,7 @@ contract Indexer is IIndexer, Ownable {
     address senderToken,
     address startAddress,
     uint256 count
-  ) external view notPaused returns (
+  ) external notPaused returns (
     bytes32[] memory locators
   ) {
     // Ensure neither token is blacklisted.
@@ -283,7 +283,7 @@ contract Indexer is IIndexer, Ownable {
     address user,
     address signerToken,
     address senderToken
-  ) public view indexExists(signerToken, senderToken) returns (uint256) {
+  ) public indexExists(signerToken, senderToken) returns (uint256) {
 
     // Return the score, equivalent to the stake amount.
     return indexes[signerToken][senderToken].getScore(user);

--- a/source/indexer/contracts/interfaces/IIndexer.sol
+++ b/source/indexer/contracts/interfaces/IIndexer.sol
@@ -88,13 +88,13 @@ interface IIndexer {
     address user,
     address signerToken,
     address senderToken
-  ) external view returns (uint256);
+  ) external returns (uint256);
 
   function getLocators(
     address signerToken,
     address senderToken,
     address startAddress,
     uint256 count
-  ) external view returns (bytes32[] memory);
+  ) external returns (bytes32[] memory);
 
 }

--- a/source/indexer/contracts/interfaces/IIndexer.sol
+++ b/source/indexer/contracts/interfaces/IIndexer.sol
@@ -88,13 +88,13 @@ interface IIndexer {
     address user,
     address signerToken,
     address senderToken
-  ) external returns (uint256);
+  ) external view returns (uint256);
 
   function getLocators(
     address signerToken,
     address senderToken,
     address startAddress,
     uint256 count
-  ) external returns (bytes32[] memory);
+  ) external view returns (bytes32[] memory);
 
 }

--- a/source/indexer/test/Indexer-unit.js
+++ b/source/indexer/test/Indexer-unit.js
@@ -321,7 +321,7 @@ contract('Indexer Unit Tests', async accounts => {
       })
     })
 
-    it('should update an intent if the user has already staked', async () => {
+    it('should update an intent if the user has already staked - increase stake', async () => {
       // make the index first
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
@@ -332,7 +332,7 @@ contract('Indexer Unit Tests', async accounts => {
         from: aliceAddress,
       })
 
-      let stakedAmount = await indexer.getStakedAmount(
+      let stakedAmount = await indexer.getStakedAmount.call(
         aliceAddress,
         tokenOne,
         tokenTwo
@@ -353,13 +353,95 @@ contract('Indexer Unit Tests', async accounts => {
 
       emitted(result, 'Stake')
 
-      stakedAmount = await indexer.getStakedAmount(
+      stakedAmount = await indexer.getStakedAmount.call(
         aliceAddress,
         tokenOne,
         tokenTwo
       )
 
       equal(stakedAmount, 350, 'Staked amount did not increase')
+    })
+
+    it('should update an intent if the user has already staked - decrease stake', async () => {
+      // make the index first
+      await indexer.createIndex(tokenOne, tokenTwo, {
+        from: aliceAddress,
+      })
+
+      // set one intent
+      await indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
+        from: aliceAddress,
+      })
+
+      let stakedAmount = await indexer.getStakedAmount.call(
+        aliceAddress,
+        tokenOne,
+        tokenTwo
+      )
+
+      equal(stakedAmount, 250, 'Staked amount incorrect')
+
+      // now try to set another - decreasing the stake
+      let result = await indexer.setIntent(
+        tokenOne,
+        tokenTwo,
+        150,
+        aliceLocator,
+        {
+          from: aliceAddress,
+        }
+      )
+
+      emitted(result, 'Stake')
+
+      stakedAmount = await indexer.getStakedAmount.call(
+        aliceAddress,
+        tokenOne,
+        tokenTwo
+      )
+
+      equal(stakedAmount, 150, 'Staked amount did not decrease')
+    })
+
+    it('should update an intent if the user has already staked - same stake', async () => {
+      // make the index first
+      await indexer.createIndex(tokenOne, tokenTwo, {
+        from: aliceAddress,
+      })
+
+      // set one intent
+      await indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
+        from: aliceAddress,
+      })
+
+      let stakedAmount = await indexer.getStakedAmount.call(
+        aliceAddress,
+        tokenOne,
+        tokenTwo
+      )
+
+      equal(stakedAmount, 250, 'Staked amount incorrect')
+
+      // now try to set another - decreasing the stake
+      let result = await indexer.setIntent(
+        tokenOne,
+        tokenTwo,
+        250,
+        bobLocator,
+        {
+          from: aliceAddress,
+        }
+      )
+
+      emitted(result, 'Stake')
+
+      stakedAmount = await indexer.getStakedAmount.call(
+        aliceAddress,
+        tokenOne,
+        tokenTwo
+      )
+
+      equal(stakedAmount, 250, 'Staked amount did not stay same')
     })
   })
 
@@ -716,7 +798,7 @@ contract('Indexer Unit Tests', async accounts => {
     })
   })
 
-  describe('Test getStakedAmount', async () => {
+  describe('Test getStakedAmount.call', async () => {
     it('should fail if the index does not exist', async () => {
       await reverted(
         indexer.getStakedAmount.call(aliceAddress, tokenOne, tokenTwo, {

--- a/source/indexer/test/Indexer-unit.js
+++ b/source/indexer/test/Indexer-unit.js
@@ -194,6 +194,11 @@ contract('Indexer Unit Tests', async accounts => {
     })
 
     it('should not set an intent if the locator is not whitelisted', async () => {
+      // make the index first
+      await whitelistedIndexer.createIndex(tokenOne, tokenTwo, {
+        from: aliceAddress,
+      })
+
       await reverted(
         whitelistedIndexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
           from: aliceAddress,
@@ -203,6 +208,11 @@ contract('Indexer Unit Tests', async accounts => {
     })
 
     it('should not set an intent if a token is blacklisted', async () => {
+      // make the index first
+      await indexer.createIndex(tokenOne, tokenTwo, {
+        from: aliceAddress,
+      })
+
       // blacklist tokenOne
       await indexer.addToBlacklist(tokenOne, {
         from: owner,
@@ -311,7 +321,7 @@ contract('Indexer Unit Tests', async accounts => {
       })
     })
 
-    it('should not set an intent if the user has already staked', async () => {
+    it('should update an intent if the user has already staked', async () => {
       // make the index first
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,
@@ -322,13 +332,34 @@ contract('Indexer Unit Tests', async accounts => {
         from: aliceAddress,
       })
 
-      // now try to set another
-      await reverted(
-        indexer.setIntent(tokenOne, tokenTwo, 250, aliceLocator, {
-          from: aliceAddress,
-        }),
-        'ENTRY_ALREADY_EXISTS'
+      let stakedAmount = await indexer.getStakedAmount(
+        aliceAddress,
+        tokenOne,
+        tokenTwo
       )
+
+      equal(stakedAmount, 250, 'Staked amount incorrect')
+
+      // now try to set another - increasing the stake
+      let result = await indexer.setIntent(
+        tokenOne,
+        tokenTwo,
+        350,
+        aliceLocator,
+        {
+          from: aliceAddress,
+        }
+      )
+
+      emitted(result, 'Stake')
+
+      stakedAmount = await indexer.getStakedAmount(
+        aliceAddress,
+        tokenOne,
+        tokenTwo
+      )
+
+      equal(stakedAmount, 350, 'Staked amount did not increase')
     })
   })
 

--- a/source/indexer/test/Indexer.js
+++ b/source/indexer/test/Indexer.js
@@ -347,6 +347,33 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       equal(staked, 1)
     })
 
+    it('Bob can keep the same stake amount', async () => {
+      // Now he updates his stake to be the same
+      emitted(
+        await indexer.setIntent(
+          tokenWETH.address,
+          tokenDAI.address,
+          1,
+          bobLocator,
+          {
+            from: bobAddress,
+          }
+        ),
+        'Stake'
+      )
+
+      // Bob still has
+      ok(await balances(bobAddress, [[tokenAST, 999]]))
+      ok(await balances(indexerAddress, [[tokenAST, 1]]))
+
+      let staked = await indexer.getStakedAmount.call(
+        bobAddress,
+        tokenWETH.address,
+        tokenDAI.address
+      )
+      equal(staked, 1)
+    })
+
     it('Owner sets the locator whitelist, and alice cannot set intent', async () => {
       await indexer.setLocatorWhitelist(delegateFactory.address, {
         from: ownerAddress,

--- a/source/indexer/test/Indexer.js
+++ b/source/indexer/test/Indexer.js
@@ -1,5 +1,8 @@
 const Indexer = artifacts.require('Indexer')
 const FungibleToken = artifacts.require('FungibleToken')
+const DelegateFactory = artifacts.require('DelegateFactory')
+const Swap = artifacts.require('Swap')
+const Types = artifacts.require('Types')
 const {
   emitted,
   notEmitted,
@@ -17,6 +20,10 @@ let snapshotId
 contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
   let indexer
   let indexerAddress
+
+  let delegateFactory
+  let swap
+  let types
 
   let tokenAST
   let tokenDAI
@@ -73,6 +80,25 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
         }),
         'CreateIndex'
       )
+    })
+
+    it('The owner can set and unset the locator whitelist', async () => {
+      types = await Types.new()
+      await Swap.link('Types', types.address)
+      swap = await Swap.new()
+      delegateFactory = await DelegateFactory.new(swap.address, indexer.address)
+
+      await indexer.setLocatorWhitelist(delegateFactory.address, {
+        from: ownerAddress,
+      })
+
+      let whitelist = await indexer.locatorWhitelist.call()
+
+      equal(whitelist, delegateFactory.address)
+
+      await indexer.setLocatorWhitelist(EMPTY_ADDRESS, {
+        from: ownerAddress,
+      })
     })
 
     it('Bob ensures no intents are on the Indexer for existing index', async () => {

--- a/source/indexer/test/Indexer.js
+++ b/source/indexer/test/Indexer.js
@@ -105,6 +105,10 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       await indexer.setLocatorWhitelist(EMPTY_ADDRESS, {
         from: ownerAddress,
       })
+
+      whitelist = await indexer.locatorWhitelist.call()
+
+      equal(whitelist, EMPTY_ADDRESS)
     })
 
     it('Bob ensures no intents are on the Indexer for existing index', async () => {
@@ -408,6 +412,10 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       await indexer.setLocatorWhitelist(EMPTY_ADDRESS, {
         from: ownerAddress,
       })
+
+      let whitelist = await indexer.locatorWhitelist.call()
+
+      equal(whitelist, delegateFactory.address)
     })
   })
 

--- a/source/indexer/test/Indexer.js
+++ b/source/indexer/test/Indexer.js
@@ -415,7 +415,7 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
 
       let whitelist = await indexer.locatorWhitelist.call()
 
-      equal(whitelist, delegateFactory.address)
+      equal(whitelist, EMPTY_ADDRESS)
     })
   })
 

--- a/source/indexer/test/Indexer.js
+++ b/source/indexer/test/Indexer.js
@@ -337,6 +337,29 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
       equal(staked, 1)
     })
 
+    it('Owner sets the locator whitelist, and alice cannot set intent', async () => {
+      await indexer.setLocatorWhitelist(delegateFactory.address, {
+        from: ownerAddress,
+      })
+
+      await reverted(
+        indexer.setIntent(
+          tokenWETH.address,
+          tokenDAI.address,
+          500,
+          aliceLocator,
+          {
+            from: aliceAddress,
+          }
+        ),
+        'LOCATOR_NOT_WHITELISTED'
+      )
+
+      await indexer.setLocatorWhitelist(EMPTY_ADDRESS, {
+        from: ownerAddress,
+      })
+    })
+
     it('Restake Alice and unstake Bob for future tests', async () => {
       emitted(
         await indexer.setIntent(

--- a/source/types/contracts/Types.sol
+++ b/source/types/contracts/Types.sol
@@ -85,7 +85,6 @@ library Types {
     "address wallet,",
     "address token,",
     "uint256 param",
-
     ")"
   ));
 


### PR DESCRIPTION
## Description

Quick description:

- [X] New features

## Changes

- Updated `setIntent` to allow stakes and locators to be updated without unsetting intent first. Discussed in issue https://github.com/airswap/airswap-protocols/issues/225.
- Added tests for this test case, as well as some more tests for the locatorWhitelist, as this was seemingly lacking in the integration tests previously.

## Tests
  90 passing (15s)

## Test Coverage
100%
