### PR TITLE
update ordering of unsetRuleAndIntent

### DIFF
--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -176,8 +176,8 @@ contract Delegate is IDelegate, Ownable {
     * @param signerToken address Taker token  in the token pair for rules and intents
     */
   function unsetRuleAndIntent(
-    address signerToken,
-    address senderToken
+    address senderToken,
+    address signerToken
   ) external onlyOwner {
 
     _unsetRule(senderToken, signerToken);

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -197,7 +197,7 @@ contract('Delegate Integration Tests', async accounts => {
       equal(scoreBefore.toNumber(), INTENT_AMOUNT, 'intent score is incorrect')
 
       await passes(
-        aliceDelegate.unsetRuleAndIntent(tokenDAI.address, tokenWETH.address, {
+        aliceDelegate.unsetRuleAndIntent(tokenWETH.address, tokenDAI.address, {
           from: aliceAddress,
         })
       )


### PR DESCRIPTION
## Description

Noticed when doing documentation, this was the older function in delegate that had signerToken and then senderToken.

Full issue mentioned: https://github.com/airswap/airswap-protocols/issues/254

Quick description:

- [X ] Typo/small tweaks

## Changes

Switch the ordering of inputting token addresses to unsetRuleAndIntent 
## Tests

100%

## Test Coverage

100%
