### PR TITLE
Remove mkdir output for already created dir

### DIFF
--- a/source/delegate-factory/package.json
+++ b/source/delegate-factory/package.json
@@ -14,7 +14,7 @@
     "ganache": "ganache-cli -p 8545 --gasLimit 0xfffffffffff --time '2017-05-10T00:00:00+00:00'",
     "hint": "yarn solhint \"./contracts/**/*.sol\"",
     "lint": "yarn eslint \"./test/**/*.js\"",
-    "cp_migration_flat": "mkdir flatten/; cp contracts/Migrations.sol flatten/",
+    "cp_migration_flat": "mkdir -p flatten/; cp contracts/Migrations.sol flatten/",
     "test": "truffle test",
     "flatten": "truffle run flatten",
     "migrate": "yarn cp_migration_flat; truffle migrate --skip-dry-run",

--- a/source/delegate/package.json
+++ b/source/delegate/package.json
@@ -14,7 +14,7 @@
     "ganache": "ganache-cli -p 8545 --gasLimit 0xfffffffffff --time '2017-05-10T00:00:00+00:00'",
     "hint": "yarn solhint \"./contracts/**/*.sol\"",
     "lint": "yarn eslint \"./test/**/*.js\"",
-    "cp_migration_flat": "mkdir flatten/; cp contracts/Migrations.sol flatten/",
+    "cp_migration_flat": "mkdir -p flatten/; cp contracts/Migrations.sol flatten/",
     "test": "truffle test",
     "flatten": "truffle run flatten",
     "migrate": "yarn cp_migration_flat; truffle migrate --skip-dry-run",

--- a/source/index/package.json
+++ b/source/index/package.json
@@ -14,7 +14,7 @@
     "ganache": "ganache-cli -p 8545 --gasLimit 0xfffffffffff --time '2017-05-10T00:00:00+00:00'",
     "hint": "yarn solhint \"./contracts/**/*.sol\"",
     "lint": "yarn eslint \"./test/**/*.js\"",
-    "cp_migration_flat": "mkdir flatten/; cp contracts/Migrations.sol flatten/",
+    "cp_migration_flat": "mkdir -p flatten/; cp contracts/Migrations.sol flatten/",
     "test": "truffle test",
     "flatten": "truffle run flatten",
     "migrate": "yarn cp_migration_flat; truffle migrate --skip-dry-run",

--- a/source/indexer/package.json
+++ b/source/indexer/package.json
@@ -14,7 +14,7 @@
     "ganache": "ganache-cli -p 8545 --gasLimit 0xfffffffffff --time '2017-05-10T00:00:00+00:00'",
     "hint": "yarn solhint \"./contracts/**/*.sol\"",
     "lint": "yarn eslint \"./test/**/*.js\"",
-    "cp_migration_flat": "mkdir flatten/; cp contracts/Migrations.sol flatten/",
+    "cp_migration_flat": "mkdir -p flatten/; cp contracts/Migrations.sol flatten/",
     "test": "truffle test",
     "flatten": "truffle run flatten",
     "migrate": "yarn cp_migration_flat; truffle migrate --skip-dry-run",

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -14,7 +14,7 @@
     "ganache": "ganache-cli -p 8545 --gasLimit 0xfffffffffff --time '2017-05-10T00:00:00+00:00'",
     "hint": "yarn solhint \"./contracts/**/*.sol\"",
     "lint": "yarn eslint \"./test/**/*.js\"",
-    "cp_migration_flat": "mkdir flatten/; cp contracts/Migrations.sol flatten/",
+    "cp_migration_flat": "mkdir -p flatten/; cp contracts/Migrations.sol flatten/",
     "test": "truffle test",
     "flatten": "truffle run flatten",
     "migrate": "yarn cp_migration_flat; truffle migrate --skip-dry-run",

--- a/source/types/package.json
+++ b/source/types/package.json
@@ -14,7 +14,7 @@
     "clean": "rm -rf ./build",
     "compile": "truffle compile",
     "coverage": "node_modules/.bin/solidity-coverage",
-    "cp_migration_flat": "mkdir flatten/; cp contracts/Migrations.sol flatten/",
+    "cp_migration_flat": "mkdir -p flatten/; cp contracts/Migrations.sol flatten/",
     "test": "truffle test",
     "flatten": "truffle run flatten",
     "migrate": "yarn cp_migration_flat; truffle migrate --skip-dry-run",

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -15,7 +15,7 @@
     "hint": "yarn solhint \"./contracts/**/*.sol\"",
     "lint": "yarn eslint \"./test/**/*.js\"",
     "truffle": "node_modules/.bin/truffle --network development",
-    "cp_migration_flat": "mkdir flatten/; cp contracts/Migrations.sol flatten/",
+    "cp_migration_flat": "mkdir -p flatten/; cp contracts/Migrations.sol flatten/",
     "test": "truffle test",
     "flatten": "truffle run flatten",
     "migrate": "yarn cp_migration_flat; truffle migrate --skip-dry-run",


### PR DESCRIPTION
## Description

This annoyed me:
```
mkdir src
mkdir: src: File exists
```
so I added the -p flag to reduce output and remove the error
```
mkdir -p src
```

from mkdir -p flag man page
> Create intermediate directories as required.  If this option is not specified, the full path prefix of each operand must already exist.  On the other hand, with this option specified, no error will be reported if a directory given as an operand already exists.  Intermediate directories are created with permission bits of rwxrwxrwx (0777) as modified by the current umask, plus write and search permission for the owner.
