### PR TITLE
Revert if ETH return is unsuccessful

### DIFF
--- a/source/wrapper/contracts/HelperMock.sol
+++ b/source/wrapper/contracts/HelperMock.sol
@@ -1,0 +1,31 @@
+pragma solidity 0.5.12;
+pragma experimental ABIEncoderV2;
+
+import "@airswap/types/contracts/Types.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "./Wrapper.sol";
+
+contract HelperMock {
+
+  Wrapper public wrapper;
+
+  constructor(Wrapper helperWrapper) public {
+    wrapper = helperWrapper;
+  }
+
+  function forwardSwap(
+    Types.Order calldata order
+  ) external {
+    wrapper.swap(order);
+  }
+
+  function authorizeWrapperToSend() external {
+    ISwap swap = wrapper.swapContract();
+    swap.authorizeSender(address(wrapper));
+  }
+
+  function approveToken(IERC20 token, address toApprove, uint256 amount) external {
+    token.approve(toApprove, amount);
+  }
+
+}

--- a/source/wrapper/contracts/HelperMock.sol
+++ b/source/wrapper/contracts/HelperMock.sol
@@ -5,6 +5,16 @@ import "@airswap/types/contracts/Types.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "./Wrapper.sol";
 
+/**
+  * @title HelperMock: This mock contract has been created to test the Wrapper.
+  *
+  * In the final lines of Wrapper.swap ETH is transferred to the sender of the order,
+  * having completed a swap in which the sender received WETH. If this ETH transfer fails
+  * the transaction must revert to prevent ETH trapped in the Wrapper. This situation
+  * occurs when the ETH recipient is a non-payable contract that therefore rejects
+  * the ETH.
+  *
+  */
 contract HelperMock {
 
   Wrapper public wrapper;

--- a/source/wrapper/contracts/Wrapper.sol
+++ b/source/wrapper/contracts/Wrapper.sol
@@ -148,7 +148,9 @@ contract Wrapper is Ownable {
 
       // Transfer ether to the user.
       // solium-disable-next-line security/no-call-value
-      msg.sender.call.value(order.signer.param)("");
+      (bool success, ) = msg.sender.call.value(order.signer.param)("");
+
+      require(success, "ETH_RETURN_FAILED");
     }
   }
 }


### PR DESCRIPTION
## Description

https://github.com/airswap/airswap-protocols/issues/298

Quick description:

- [ ] N/A
- [ ] New features
- [X] Bug fixes
- [ ] Typo/small tweaks

## Changes

- Added a revert statement when ETH fails to send to a non-payable contract in the wrapper
- Created a mock contract that is non-payable to test this new revert
- Added an integration test that uses the new mock to test the revert

## Tests
```
Wrapper:
  39 passing (10s)
```