### PR TITLE
Resolve spelling of test message

### DIFF
--- a/source/indexer/test/Indexer-unit.js
+++ b/source/indexer/test/Indexer-unit.js
@@ -370,7 +370,7 @@ contract('Indexer Unit Tests', async accounts => {
       equal(stakedAmount, 350, 'Staked amount did not increase')
     })
 
-    it('should failed updating intent when tranfers tokens fail', async () => {
+    it('should fail updating the intent when transfer of staking tokens fails', async () => {
       // make the index first
       await indexer.createIndex(tokenOne, tokenTwo, {
         from: aliceAddress,


### PR DESCRIPTION
## Description

Quick description:
- [X] Typo/small tweaks

## Changes

Updated the spelling on a test message where transfer was spelling incorrectly.

## Tests

  130 passing (28s)

