### PR TITLE
Delegate price bug

### DIFF
--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -425,7 +425,7 @@ contract Delegate is IDelegate, Ownable {
   }
 
   /**
-    * @notice Calculate the signer amount for a given sender amount and price
+    * @notice Calculate the signer param (amount) for a given sender param and price
     * @param senderParam uint256 The amount the delegate would send in the swap
     * @param priceCoef uint256 Coefficient of the token price defined in the rule
     * @param priceExp uint256 Exponent of the token price defined in the rule
@@ -448,7 +448,7 @@ contract Delegate is IDelegate, Ownable {
   }
 
   /**
-    * @notice Calculate the signer amount for a given sender amount and price
+    * @notice Calculate the sender param (amount) for a given signer param and price
     * @param signerParam uint256 The amount the signer would send in the swap
     * @param priceCoef uint256 Coefficient of the token price defined in the rule
     * @param priceExp uint256 Exponent of the token price defined in the rule

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -244,7 +244,7 @@ contract Delegate is IDelegate, Ownable {
     // Ensure the order is priced according to the rule.
     require(order.sender.param <= order.signer.param
       .mul(10 ** rule.priceExp).div(rule.priceCoef),
-      "PRICE_INCORRECT");
+      "PRICE_INVALID");
 
     // Overwrite the rule with a decremented maxSenderAmount.
     rules[order.sender.token][order.signer.token] = Rule({

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -303,9 +303,7 @@ contract Delegate is IDelegate, Ownable {
         signerParam = multiplier.div(10 ** rule.priceExp);
 
         // If the div rounded down, round up!
-        uint256 modulo = multiplier.mod(10 ** rule.priceExp);
-
-        if (modulo > 0) {
+        if (multiplier.mod(10 ** rule.priceExp) > 0) {
           signerParam++;
         }
 
@@ -365,13 +363,23 @@ contract Delegate is IDelegate, Ownable {
 
     Rule memory rule = rules[senderToken][signerToken];
 
+    uint256 senderParam = rule.maxSenderAmount;
+
     // Ensure that a rule exists.
-    if(rule.maxSenderAmount > 0) {
+    if (senderParam > 0) {
+      // calculate a signerParam
+      uint256 multiplier = senderParam.mul(rule.priceCoef);
+      signerParam = multiplier.div(10 ** rule.priceExp);
+
+      // If the div rounded down, round up!
+      if (multiplier.mod(10 ** rule.priceExp) > 0) {
+        signerParam++;
+      }
 
       // Return the maxSenderAmount and calculated signerParam.
       return (
-        rule.maxSenderAmount,
-        rule.maxSenderAmount.mul(rule.priceCoef).div(10 ** rule.priceExp)
+        senderParam,
+        signerParam
       );
     }
     return (0, 0);

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -135,7 +135,7 @@ contract Delegate is IDelegate, Ownable {
     * @dev delegate needs to be given allowance from msg.sender for the newStakeAmount
     * @dev swap needs to be given permission to move funds from the delegate
     * @param senderToken address Token the delgeate will send
-    * @param senderToken address Token the delegate will receive
+    * @param signerToken address Token the delegate will receive
     * @param rule Rule Rule to set on a delegate
     * @param newStakeAmount uint256 Amount to stake for an intent
     */

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -242,7 +242,7 @@ contract Delegate is IDelegate, Ownable {
       "AMOUNT_EXCEEDS_MAX");
 
     // Ensure the order is priced according to the rule.
-    require(order.sender.param == order.signer.param
+    require(order.sender.param <= order.signer.param
       .mul(10 ** rule.priceExp).div(rule.priceCoef),
       "PRICE_INCORRECT");
 
@@ -299,9 +299,15 @@ contract Delegate is IDelegate, Ownable {
       // Ensure the senderParam does not exceed maximum for the rule.
       if(senderParam <= rule.maxSenderAmount) {
 
-        signerParam = senderParam
-            .mul(rule.priceCoef)
-            .div(10 ** rule.priceExp);
+        uint256 multiplier = senderParam.mul(rule.priceCoef);
+        signerParam = multiplier.div(10 ** rule.priceExp);
+
+        // If the div rounded down, round up!
+        uint256 modulo = multiplier.mod(10 ** rule.priceExp);
+
+        if (modulo > 0) {
+          signerParam++;
+        }
 
         // Return the quote.
         return signerParam;

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -357,7 +357,7 @@ contract Delegate is IDelegate, Ownable {
 
     Rule memory rule = rules[senderToken][signerToken];
 
-    uint256 senderParam = rule.maxSenderAmount;
+    senderParam = rule.maxSenderAmount;
 
     // Ensure that a rule exists.
     if (senderParam > 0) {

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -408,7 +408,6 @@ contract Delegate is IDelegate, Ownable {
 
   /**
     * @notice Unset a Trading Rule
-    * @dev only callable by the owner of the contract, removes from a mapping
     * @param senderToken address Address of an ERC-20 token the delegate would send
     * @param signerToken address Address of an ERC-20 token the consumer would send
     */
@@ -427,6 +426,12 @@ contract Delegate is IDelegate, Ownable {
     );
   }
 
+  /**
+    * @notice Calculate the signer amount for a given sender amount and price
+    * @param senderParam uint256 The amount the delegate would send in the swap
+    * @param priceCoef uint256 Coefficient of the token price defined in the rule
+    * @param priceExp uint256 Exponent of the token price defined in the rule
+    */
   function _calculateSignerParam(
     uint256 senderParam,
     uint256 priceCoef,

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -447,7 +447,7 @@ contract Delegate is IDelegate, Ownable {
     }
   }
 
-    /**
+  /**
     * @notice Calculate the signer amount for a given sender amount and price
     * @param signerParam uint256 The amount the signer would send in the swap
     * @param priceCoef uint256 Coefficient of the token price defined in the rule
@@ -462,7 +462,7 @@ contract Delegate is IDelegate, Ownable {
   ) {
     // Calculate the param using the price formula
     senderParam = signerParam
-        .mul(10 ** priceExp)
-        .div(priceCoef);
+      .mul(10 ** priceExp)
+      .div(priceCoef);
   }
 }

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -299,13 +299,7 @@ contract Delegate is IDelegate, Ownable {
       // Ensure the senderParam does not exceed maximum for the rule.
       if(senderParam <= rule.maxSenderAmount) {
 
-        uint256 multiplier = senderParam.mul(rule.priceCoef);
-        signerParam = multiplier.div(10 ** rule.priceExp);
-
-        // If the div rounded down, round up!
-        if (multiplier.mod(10 ** rule.priceExp) > 0) {
-          signerParam++;
-        }
+        signerParam = _calculateSignerParam(senderParam, rule.priceCoef, rule.priceExp);
 
         // Return the quote.
         return signerParam;
@@ -367,14 +361,8 @@ contract Delegate is IDelegate, Ownable {
 
     // Ensure that a rule exists.
     if (senderParam > 0) {
-      // calculate a signerParam
-      uint256 multiplier = senderParam.mul(rule.priceCoef);
-      signerParam = multiplier.div(10 ** rule.priceExp);
-
-      // If the div rounded down, round up!
-      if (multiplier.mod(10 ** rule.priceExp) > 0) {
-        signerParam++;
-      }
+      // calculate the signerParam
+      signerParam = _calculateSignerParam(senderParam, rule.priceCoef, rule.priceExp);
 
       // Return the maxSenderAmount and calculated signerParam.
       return (
@@ -437,5 +425,22 @@ contract Delegate is IDelegate, Ownable {
       senderToken,
       signerToken
     );
+  }
+
+  function _calculateSignerParam(
+    uint256 senderParam,
+    uint256 priceCoef,
+    uint256 priceExp
+  ) internal pure returns (
+    uint256 signerParam
+  ) {
+    // Calculate the param using the price formula
+    uint256 multiplier = senderParam.mul(priceCoef);
+    signerParam = multiplier.div(10 ** priceExp);
+
+    // If the div rounded down, round up
+    if (multiplier.mod(10 ** priceExp) > 0) {
+      signerParam++;
+    }
   }
 }

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -242,8 +242,7 @@ contract Delegate is IDelegate, Ownable {
       "AMOUNT_EXCEEDS_MAX");
 
     // Ensure the order is priced according to the rule.
-    require(order.sender.param <= order.signer.param
-      .mul(10 ** rule.priceExp).div(rule.priceCoef),
+    require(order.sender.param <= _calculateSenderParam(order.signer.param, rule.priceCoef, rule.priceExp),
       "PRICE_INVALID");
 
     // Overwrite the rule with a decremented maxSenderAmount.
@@ -329,8 +328,7 @@ contract Delegate is IDelegate, Ownable {
     if(rule.maxSenderAmount > 0) {
 
       // Calculate the senderParam.
-      senderParam = signerParam
-        .mul(10 ** rule.priceExp).div(rule.priceCoef);
+      senderParam = _calculateSenderParam(signerParam, rule.priceCoef, rule.priceExp);
 
       // Ensure the senderParam does not exceed the maximum trade amount.
       if(senderParam <= rule.maxSenderAmount) {
@@ -447,5 +445,24 @@ contract Delegate is IDelegate, Ownable {
     if (multiplier.mod(10 ** priceExp) > 0) {
       signerParam++;
     }
+  }
+
+    /**
+    * @notice Calculate the signer amount for a given sender amount and price
+    * @param signerParam uint256 The amount the signer would send in the swap
+    * @param priceCoef uint256 Coefficient of the token price defined in the rule
+    * @param priceExp uint256 Exponent of the token price defined in the rule
+    */
+  function _calculateSenderParam(
+    uint256 signerParam,
+    uint256 priceCoef,
+    uint256 priceExp
+  ) internal pure returns (
+    uint256 senderParam
+  ) {
+    // Calculate the param using the price formula
+    senderParam = signerParam
+        .mul(10 ** priceExp)
+        .div(priceCoef);
   }
 }

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -1059,5 +1059,44 @@ contract('Delegate Unit Tests', async accounts => {
         "rule's max delegate amount was not decremented"
       )
     })
+
+    it('test a getting a signerSideQuote and passing it into provideOrder', async () => {
+      await delegate.setRule(
+        SENDER_TOKEN,
+        SIGNER_TOKEN,
+        MAX_SENDER_AMOUNT,
+        PRICE_COEF,
+        EXP
+      )
+
+      const senderAmount = 123
+      const signerQuote = await delegate.getSignerSideQuote.call(
+        senderAmount,
+        SENDER_TOKEN,
+        SIGNER_TOKEN
+      )
+
+      const signerAmount = signerQuote.toNumber()
+
+      // put that quote into an order
+      const order = await orders.getOrder({
+        signer: {
+          wallet: notOwner,
+          param: signerAmount,
+          token: SIGNER_TOKEN,
+        },
+        sender: {
+          wallet: tradeWallet,
+          param: senderAmount,
+          token: SENDER_TOKEN,
+        },
+      })
+
+      const tx = await delegate.provideOrder(order, {
+        from: notOwner,
+      })
+
+      passes(tx)
+    })
   })
 })

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -680,16 +680,16 @@ contract('Delegate Unit Tests', async accounts => {
       equal(
         val[0].toNumber(),
         MAX_SENDER_AMOUNT,
-        'no quote should be available if a peer does not exist'
+        'get max quote returned incorrect sender quote'
       )
 
-      const expectedValue = Math.floor(
+      const expectedValue = Math.ceil(
         (MAX_SENDER_AMOUNT * PRICE_COEF) / 10 ** EXP
       )
       equal(
         val[1].toNumber(),
         expectedValue,
-        'no quote should be available if a delegate does not exist'
+        'get max quote returned incorrect signer quote'
       )
     })
   })
@@ -953,7 +953,7 @@ contract('Delegate Unit Tests', async accounts => {
       equal(
         ruleAfter[0].toNumber(),
         ruleBefore[0].toNumber() - signerAmount,
-        "rule's max peer amount was not decremented"
+        "rule's max sender amount was not decremented"
       )
 
       //check if swap() was called

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -1099,6 +1099,45 @@ contract('Delegate Unit Tests', async accounts => {
       passes(tx)
     })
 
+    it('test a getting a senderSideQuote and passing it into provideOrder', async () => {
+      await delegate.setRule(
+        SENDER_TOKEN,
+        SIGNER_TOKEN,
+        MAX_SENDER_AMOUNT,
+        PRICE_COEF,
+        EXP
+      )
+
+      const signerAmount = 8425
+      const senderQuote = await delegate.getSenderSideQuote.call(
+        signerAmount,
+        SIGNER_TOKEN,
+        SENDER_TOKEN
+      )
+
+      const senderAmount = senderQuote.toNumber()
+
+      // put that quote into an order
+      const order = await orders.getOrder({
+        signer: {
+          wallet: notOwner,
+          param: signerAmount,
+          token: SIGNER_TOKEN,
+        },
+        sender: {
+          wallet: tradeWallet,
+          param: senderAmount,
+          token: SENDER_TOKEN,
+        },
+      })
+
+      const tx = await delegate.provideOrder(order, {
+        from: notOwner,
+      })
+
+      passes(tx)
+    })
+
     it('test a getting a getMaxQuote and passing it into provideOrder', async () => {
       await delegate.setRule(
         SENDER_TOKEN,
@@ -1132,6 +1171,41 @@ contract('Delegate Unit Tests', async accounts => {
       })
 
       passes(tx)
+    })
+
+    it('test the signer trying to trade just 1 unit over the rule price', async () => {
+      // 1 SenderToken for 0.005 SignerToken => 200 SenderToken for 1 SignerToken
+      await delegate.setRule(
+        SENDER_TOKEN,
+        SIGNER_TOKEN,
+        MAX_SENDER_AMOUNT,
+        5,
+        3
+      )
+
+      const senderAmount = 201 // 1 unit more than the delegate wants to send
+      const signerAmount = 1
+
+      const order = await orders.getOrder({
+        signer: {
+          wallet: notOwner,
+          param: signerAmount,
+          token: SIGNER_TOKEN,
+        },
+        sender: {
+          wallet: tradeWallet,
+          param: senderAmount,
+          token: SENDER_TOKEN,
+        },
+      })
+
+      // check the delegate doesnt allow this
+      await reverted(
+        delegate.provideOrder(order, {
+          from: notOwner,
+        }),
+        'PRICE_INVALID'
+      )
     })
   })
 })

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -839,7 +839,7 @@ contract('Delegate Unit Tests', async accounts => {
         delegate.provideOrder(order, {
           from: notOwner,
         }),
-        'PRICE_INCORRECT'
+        'PRICE_INVALID'
       )
     })
 

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -1173,7 +1173,7 @@ contract('Delegate Unit Tests', async accounts => {
       passes(tx)
     })
 
-    it('test the signer trying to trade just 1 unit over the rule price', async () => {
+    it('test the signer trying to trade just 1 unit over the rule price - fails', async () => {
       // 1 SenderToken for 0.005 SignerToken => 200 SenderToken for 1 SignerToken
       await delegate.setRule(
         SENDER_TOKEN,
@@ -1206,6 +1206,40 @@ contract('Delegate Unit Tests', async accounts => {
         }),
         'PRICE_INVALID'
       )
+    })
+
+    it('test the signer trying to trade just 1 unit less than the rule price - passes', async () => {
+      // 1 SenderToken for 0.005 SignerToken => 200 SenderToken for 1 SignerToken
+      await delegate.setRule(
+        SENDER_TOKEN,
+        SIGNER_TOKEN,
+        MAX_SENDER_AMOUNT,
+        5,
+        3
+      )
+
+      const senderAmount = 199 // 1 unit less than the delegate rule
+      const signerAmount = 1
+
+      const order = await orders.getOrder({
+        signer: {
+          wallet: notOwner,
+          param: signerAmount,
+          token: SIGNER_TOKEN,
+        },
+        sender: {
+          wallet: tradeWallet,
+          param: senderAmount,
+          token: SENDER_TOKEN,
+        },
+      })
+
+      // check the delegate allows this
+      const tx = await delegate.provideOrder(order, {
+        from: notOwner,
+      })
+
+      passes(tx)
     })
   })
 })

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -1098,5 +1098,40 @@ contract('Delegate Unit Tests', async accounts => {
 
       passes(tx)
     })
+
+    it('test a getting a getMaxQuote and passing it into provideOrder', async () => {
+      await delegate.setRule(
+        SENDER_TOKEN,
+        SIGNER_TOKEN,
+        MAX_SENDER_AMOUNT,
+        PRICE_COEF,
+        EXP
+      )
+
+      const val = await delegate.getMaxQuote.call(SENDER_TOKEN, SIGNER_TOKEN)
+
+      const senderAmount = val[0].toNumber()
+      const signerAmount = val[1].toNumber()
+
+      // put that quote into an order
+      const order = await orders.getOrder({
+        signer: {
+          wallet: notOwner,
+          param: signerAmount,
+          token: SIGNER_TOKEN,
+        },
+        sender: {
+          wallet: tradeWallet,
+          param: senderAmount,
+          token: SENDER_TOKEN,
+        },
+      })
+
+      const tx = await delegate.provideOrder(order, {
+        from: notOwner,
+      })
+
+      passes(tx)
+    })
   })
 })

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -1241,5 +1241,39 @@ contract('Delegate Unit Tests', async accounts => {
 
       passes(tx)
     })
+
+    it('test the signer trying to trade the exact amount of rule price - passes', async () => {
+      // 1 SenderToken for 0.005 SignerToken => 200 SenderToken for 1 SignerToken
+      await delegate.setRule(
+        SENDER_TOKEN,
+        SIGNER_TOKEN,
+        MAX_SENDER_AMOUNT,
+        5,
+        3
+      )
+
+      const senderAmount = 200
+      const signerAmount = 1
+
+      const order = await orders.getOrder({
+        signer: {
+          wallet: notOwner,
+          param: signerAmount,
+          token: SIGNER_TOKEN,
+        },
+        sender: {
+          wallet: tradeWallet,
+          param: senderAmount,
+          token: SENDER_TOKEN,
+        },
+      })
+
+      // check the delegate allows this
+      const tx = await delegate.provideOrder(order, {
+        from: notOwner,
+      })
+
+      passes(tx)
+    })
   })
 })

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -589,7 +589,7 @@ contract('Delegate Unit Tests', async accounts => {
         SENDER_TOKEN,
         SIGNER_TOKEN
       )
-      const expectedValue = Math.floor((1234 * PRICE_COEF) / 10 ** EXP)
+      const expectedValue = Math.ceil((1234 * PRICE_COEF) / 10 ** EXP)
       equal(val.toNumber(), expectedValue, 'there should be a quote available')
     })
   })

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -569,36 +569,47 @@ contract('Delegate Integration Tests', async accounts => {
       }
     )
 
-    it('Gets a quote to buy 20K DAI for WETH (Quote: 64 WETH)', async () => {
+    it('Gets a quote to buy 23412 DAI for WETH (Quote: 74.9184 WETH)', async () => {
+      const amount = 23412
       const quote = await aliceDelegate.getSignerSideQuote.call(
-        20000,
+        amount,
         tokenDAI.address,
         tokenWETH.address
       )
-      equal(quote, 64)
+      // This rounds up, just as getSignerSideQuote does
+      // 74.9184 becomes 75
+      const expectedValue = Math.ceil((amount * 32) / 10 ** 4)
+      equal(quote.toNumber(), expectedValue)
     })
 
     it('Gets a quote to sell 100K (Max) DAI for WETH (Quote: 320 WETH)', async () => {
+      const amount = 100000
       const quote = await aliceDelegate.getSignerSideQuote.call(
-        100000,
+        amount,
         tokenDAI.address,
         tokenWETH.address
       )
-      equal(quote, 320)
+      // This does not end up rounding up as the sum reaches a whole number - 320
+      const expectedValue = Math.ceil((amount * 32) / 10 ** 4)
+      equal(quote.toNumber(), expectedValue)
     })
 
-    it('Gets a quote to sell 1 WETH for DAI (Quote: 300 DAI)', async () => {
+    it('Gets a quote to sell 1 WETH for DAI (Quote: 312.5 DAI)', async () => {
+      const amount = 1
       const quote = await aliceDelegate.getSenderSideQuote.call(
-        1,
+        amount,
         tokenWETH.address,
         tokenDAI.address
       )
-      equal(quote, 312)
+      // This floors as solidity rounds down - 312.5 becomes 312
+      const expectedValue = Math.floor((amount * 10 ** 4) / 32)
+      equal(quote.toNumber(), expectedValue)
     })
 
     it('Gets a quote to sell 500 DAI for WETH (False: No rule)', async () => {
+      const amount = 500
       const quote = await aliceDelegate.getSenderSideQuote.call(
-        500,
+        amount,
         tokenDAI.address,
         tokenWETH.address
       )

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -22,7 +22,7 @@ const {
 let snapshotId
 
 contract('Delegate Integration Tests', async accounts => {
-  const STARTING_BALANCE = 700
+  const STARTING_BALANCE = 100000000
   const INTENT_AMOUNT = 250
   const aliceAddress = accounts[1]
   const bobAddress = accounts[2]
@@ -805,11 +805,15 @@ contract('Delegate Integration Tests', async accounts => {
 
       // both approve Swap to transfer tokens
       emitted(
-        await tokenDAI.approve(swapAddress, 200, { from: aliceTradeWallet }),
+        await tokenDAI.approve(swapAddress, STARTING_BALANCE, {
+          from: aliceTradeWallet,
+        }),
         'Approval'
       )
       emitted(
-        await tokenWETH.approve(swapAddress, 1, { from: bobAddress }),
+        await tokenWETH.approve(swapAddress, STARTING_BALANCE, {
+          from: bobAddress,
+        }),
         'Approval'
       )
 
@@ -830,16 +834,37 @@ contract('Delegate Integration Tests', async accounts => {
   })
 
   describe('Provide some orders to the Delegate', async () => {
-    let quote
-    before('Gets a quote for 1 WETH', async () => {
-      quote = await aliceDelegate.getSenderSideQuote.call(
-        1,
-        tokenWETH.address,
-        tokenDAI.address
+    before('Sets up rule and quote', async () => {
+      // Delegate will trade up to 100,000 DAI for WETH, at 200 DAI/WETH
+      await aliceDelegate.setRule(
+        tokenDAI.address, // Delegate's token
+        tokenWETH.address, // Signer's token
+        100000,
+        5,
+        3,
+        { from: aliceAddress }
+      )
+
+      // mint the relevant tokens
+      await tokenWETH.mint(bobAddress, STARTING_BALANCE)
+      await tokenDAI.mint(aliceTradeWallet, STARTING_BALANCE)
+
+      // grant swap token approvals
+      emitted(
+        await tokenDAI.approve(swapAddress, STARTING_BALANCE, {
+          from: aliceTradeWallet,
+        }),
+        'Approval'
+      )
+      emitted(
+        await tokenWETH.approve(swapAddress, STARTING_BALANCE, {
+          from: bobAddress,
+        }),
+        'Approval'
       )
     })
 
-    it('Use quote with non-extent rule', async () => {
+    it('Use quote with non-existent rule', async () => {
       // Note: Consumer is the order signer, Delegate is the order sender.
       const order = await orders.getOrder({
         signer: {
@@ -862,6 +887,13 @@ contract('Delegate Integration Tests', async accounts => {
     })
 
     it('Use quote with incorrect signer wallet', async () => {
+      // Signer wants to trade 1 WETH for x DAI
+      const quote = await aliceDelegate.getSenderSideQuote.call(
+        1,
+        tokenWETH.address,
+        tokenDAI.address
+      )
+
       // Note: Consumer is the order signer, Delegate is the order sender.
       const order = await orders.getOrder({
         signer: {
@@ -884,7 +916,7 @@ contract('Delegate Integration Tests', async accounts => {
     })
 
     it('Use quote larger than delegate rule', async () => {
-      // Delegate trades WETH for 100 DAI. Max trade is 2 WETH.
+      // Delegate trades 1 WETH for 100 DAI. Max trade is 2 WETH.
       await aliceDelegate.setRule(
         tokenWETH.address, // Delegate's token
         tokenDAI.address, // Signer's token
@@ -893,6 +925,7 @@ contract('Delegate Integration Tests', async accounts => {
         0,
         { from: aliceAddress }
       )
+      // Order is made for 300 DAI for 3 WETH
       const order = await orders.getOrder({
         signer: {
           wallet: bobAddress,
@@ -902,7 +935,7 @@ contract('Delegate Integration Tests', async accounts => {
         sender: {
           wallet: aliceTradeWallet,
           token: tokenWETH.address,
-          param: quote.toNumber(),
+          param: 3,
         },
       })
 
@@ -923,7 +956,7 @@ contract('Delegate Integration Tests', async accounts => {
         sender: {
           wallet: aliceTradeWallet,
           token: tokenDAI.address,
-          param: 500, //this is more than the delegate rule would pay out
+          param: 201, // Rule is 1 WETH for 200 DAI
         },
       })
 
@@ -945,7 +978,7 @@ contract('Delegate Integration Tests', async accounts => {
         sender: {
           wallet: aliceTradeWallet,
           token: tokenDAI.address,
-          param: quote.toNumber(),
+          param: 200, // Rule is 1 WETH for 200 DAI
         },
       })
 
@@ -967,7 +1000,7 @@ contract('Delegate Integration Tests', async accounts => {
         sender: {
           wallet: aliceTradeWallet,
           token: tokenDAI.address,
-          param: quote.toNumber(),
+          param: 200, // Rule is 1 WETH for 200 DAI
           kind: '0x80ac58cd',
         },
       })
@@ -990,7 +1023,7 @@ contract('Delegate Integration Tests', async accounts => {
         sender: {
           wallet: aliceTradeWallet,
           token: tokenDAI.address,
-          param: quote.toNumber(),
+          param: 200, // Rule is 1 WETH for 200 DAI
         },
       })
 
@@ -1012,10 +1045,11 @@ contract('Delegate Integration Tests', async accounts => {
         sender: {
           wallet: aliceTradeWallet,
           token: tokenDAI.address,
-          param: quote.toNumber(),
+          param: 200, // Rule is 1 WETH for 200 DAI
         },
       })
 
+      // Bob signs the order
       order.signature = await signatures.getWeb3Signature(
         order,
         bobAddress,
@@ -1023,11 +1057,50 @@ contract('Delegate Integration Tests', async accounts => {
         GANACHE_PROVIDER
       )
 
-      // authorize the delegate to send trades
+      // Alice authorizes the delegate to send trades
       await swapContract.authorizeSender(aliceDelegate.address, {
         from: aliceTradeWallet,
       })
 
+      // Now the trade passes
+      emitted(
+        await aliceDelegate.provideOrder(order, { from: bobAddress }),
+        'ProvideOrder'
+      )
+    })
+
+    it('Queries signerSideQuote and passes the value into an order', async () => {
+      const senderAmount = 123
+      const signerQuote = await aliceDelegate.getSignerSideQuote.call(
+        senderAmount,
+        tokenDAI.address,
+        tokenWETH.address
+      )
+
+      // Note: Delegate is the order sender.
+      const order = await orders.getOrder({
+        signer: {
+          wallet: bobAddress,
+          token: tokenWETH.address,
+          param: signerQuote.toNumber(),
+        },
+        sender: {
+          wallet: aliceTradeWallet,
+          token: tokenDAI.address,
+          param: senderAmount,
+        },
+      })
+
+      // Bob signs the order
+      order.signature = await signatures.getWeb3Signature(
+        order,
+        bobAddress,
+        swapAddress,
+        GANACHE_PROVIDER
+      )
+
+      // Alice already authorized the delegate to send trades
+      // Now the trade passes
       emitted(
         await aliceDelegate.provideOrder(order, { from: bobAddress }),
         'ProvideOrder'

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -906,7 +906,7 @@ contract('Delegate Integration Tests', async accounts => {
 
       await reverted(
         aliceDelegate.provideOrder(order, { from: bobAddress }),
-        'PRICE_INCORRECT'
+        'PRICE_INVALID'
       )
     })
 

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -3,6 +3,7 @@ const Swap = artifacts.require('Swap')
 const Types = artifacts.require('Types')
 const Indexer = artifacts.require('Indexer')
 const FungibleToken = artifacts.require('FungibleToken')
+const { takeSnapshot, revertToSnapshot } = require('@airswap/test-utils').time
 const {
   emitted,
   notEmitted,
@@ -17,6 +18,8 @@ const {
   EMPTY_ADDRESS,
   GANACHE_PROVIDER,
 } = require('@airswap/order-utils').constants
+
+let snapshotId
 
 contract('Delegate Integration Tests', async accounts => {
   const STARTING_BALANCE = 700
@@ -50,6 +53,9 @@ contract('Delegate Integration Tests', async accounts => {
   }
 
   before('Setup', async () => {
+    const snapShot = await takeSnapshot()
+    snapshotId = snapShot['result']
+
     // link types to swap
     await Swap.link('Types', (await Types.new()).address)
     // now deploy swap
@@ -68,6 +74,12 @@ contract('Delegate Integration Tests', async accounts => {
       aliceTradeWallet
     )
     aliceDelegate = await delegateContract
+  })
+
+  before('Setup', async () => {})
+
+  after(async () => {
+    await revertToSnapshot(snapshotId)
   })
 
   describe('Test the delegate constructor', async () => {

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -76,8 +76,6 @@ contract('Delegate Integration Tests', async accounts => {
     aliceDelegate = await delegateContract
   })
 
-  before('Setup', async () => {})
-
   after(async () => {
     await revertToSnapshot(snapshotId)
   })


### PR DESCRIPTION
## Description

https://github.com/airswap/airswap-protocols/issues/297

Quick description:

- [ ] N/A
- [ ] New features
- [x] Bug fixes
- [ ] Typo/small tweaks

## Changes

- Signers can now trade with any amount more than the going price. I.e. as long as the amount they send is at least the amount the delegate rule is expecting, its allowed.
- The signer side values in the contract now round up not down. This is in the delegate’s favour, and, combined with the point above, means quotes will then pass 

## Tests
  89 passing (1m)

## Test Coverage
```
-----------------------|----------|----------|----------|----------|----------------|
File                   |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-----------------------|----------|----------|----------|----------|----------------|
 contracts/            |      100 |      100 |      100 |      100 |                |
  Delegate.sol         |      100 |      100 |      100 |      100 |                |
  Imports.sol          |      100 |      100 |      100 |      100 |                |
 contracts/interfaces/ |      100 |      100 |      100 |      100 |                |
  IDelegate.sol        |      100 |      100 |      100 |      100 |                |
-----------------------|----------|----------|----------|----------|----------------|
All files              |      100 |      100 |      100 |      100 |                |
-----------------------|----------|----------|----------|----------|----------------|
```