### PR TITLE
Remove throwing events for non-state changes in Swap and Delegate contract

### DIFF
--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -415,13 +415,15 @@ contract Delegate is IDelegate, Ownable {
     address signerToken
   ) internal {
 
-    // Delete the rule.
-    delete rules[senderToken][signerToken];
-
-    emit UnsetRule(
-      owner(),
-      senderToken,
-      signerToken
+    // using non-zero rule.priceCoef for rule existence check
+    if (rules[senderToken][signerToken].priceCoef > 0) {
+      // Delete the rule.
+      delete rules[senderToken][signerToken];
+      emit UnsetRule(
+        owner(),
+        senderToken,
+        signerToken
     );
+    }
   }
 }

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -388,6 +388,7 @@ contract Delegate is IDelegate, Ownable {
     uint256 priceCoef,
     uint256 priceExp
   ) internal {
+    require(priceCoef > 0, "REQUIRE_NONZERO_PRICE");
     rules[senderToken][signerToken] = Rule({
       maxSenderAmount: maxSenderAmount,
       priceCoef: priceCoef,

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -388,7 +388,7 @@ contract Delegate is IDelegate, Ownable {
     uint256 priceCoef,
     uint256 priceExp
   ) internal {
-    require(priceCoef > 0, "REQUIRE_NONZERO_PRICE");
+    require(priceCoef > 0, "INVALID_PRICE_COEF");
     rules[senderToken][signerToken] = Rule({
       maxSenderAmount: maxSenderAmount,
       priceCoef: priceCoef,

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -266,6 +266,17 @@ contract('Delegate Unit Tests', async accounts => {
         )
       })
     })
+
+    it('Test setRule for zero priceCoef does revert', async () => {
+      const trx = delegate.setRule(
+        SENDER_TOKEN,
+        SIGNER_TOKEN,
+        MAX_SENDER_AMOUNT,
+        0,
+        EXP
+      )
+      await reverted(trx, 'REQUIRE_NONZERO_PRICE')
+    })
   })
 
   describe('Test unsetRule', async () => {

--- a/source/delegate/test/Delegate-unit.js
+++ b/source/delegate/test/Delegate-unit.js
@@ -275,7 +275,7 @@ contract('Delegate Unit Tests', async accounts => {
         0,
         EXP
       )
-      await reverted(trx, 'REQUIRE_NONZERO_PRICE')
+      await reverted(trx, 'INVALID_PRICE_COEF')
     })
   })
 

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -163,7 +163,7 @@ contract('Delegate Integration Tests', async accounts => {
         0,
         { from: aliceAddress }
       )
-      await reverted(trx, 'REQUIRE_NONZERO_PRICE')
+      await reverted(trx, 'INVALID_PRICE_COEF')
     })
   })
 

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -153,6 +153,18 @@ contract('Delegate Integration Tests', async accounts => {
         0
       )
     })
+
+    it('Test setRule for zero priceCoef does revert', async () => {
+      const trx = aliceDelegate.setRule(
+        tokenWETH.address,
+        tokenDAI.address,
+        100000,
+        0,
+        0,
+        { from: aliceAddress }
+      )
+      await reverted(trx, 'REQUIRE_NONZERO_PRICE')
+    })
   })
 
   describe('Test setRuleAndIntent()', async () => {

--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -206,8 +206,11 @@ contract Swap is ISwap {
     address authorizedSender
   ) external {
     require(msg.sender != authorizedSender, "INVALID_AUTH_SENDER");
-    senderAuthorizations[msg.sender][authorizedSender] = true;
-    emit AuthorizeSender(msg.sender, authorizedSender);
+    if (!senderAuthorizations[msg.sender][authorizedSender]) {
+      senderAuthorizations[msg.sender][authorizedSender] = true;
+      emit AuthorizeSender(msg.sender, authorizedSender);
+    }
+
   }
 
   /**
@@ -219,8 +222,10 @@ contract Swap is ISwap {
     address authorizedSigner
   ) external {
     require(msg.sender != authorizedSigner, "INVALID_AUTH_SIGNER");
-    signerAuthorizations[msg.sender][authorizedSigner] = true;
-    emit AuthorizeSigner(msg.sender, authorizedSigner);
+    if (!signerAuthorizations[msg.sender][authorizedSigner]) {
+      signerAuthorizations[msg.sender][authorizedSigner] = true;
+      emit AuthorizeSigner(msg.sender, authorizedSigner);
+    }
   }
 
   /**
@@ -231,8 +236,10 @@ contract Swap is ISwap {
   function revokeSender(
     address authorizedSender
   ) external {
-    delete senderAuthorizations[msg.sender][authorizedSender];
-    emit RevokeSender(msg.sender, authorizedSender);
+    if (senderAuthorizations[msg.sender][authorizedSender]) {
+      delete senderAuthorizations[msg.sender][authorizedSender];
+      emit RevokeSender(msg.sender, authorizedSender);
+    }
   }
 
   /**
@@ -243,8 +250,10 @@ contract Swap is ISwap {
   function revokeSigner(
     address authorizedSigner
   ) external {
-    delete signerAuthorizations[msg.sender][authorizedSigner];
-    emit RevokeSigner(msg.sender, authorizedSigner);
+    if (signerAuthorizations[msg.sender][authorizedSigner]) {
+      delete signerAuthorizations[msg.sender][authorizedSigner];
+      emit RevokeSigner(msg.sender, authorizedSigner);
+    }
   }
 
   /**

--- a/source/swap/test/Swap-unit.js
+++ b/source/swap/test/Swap-unit.js
@@ -286,10 +286,8 @@ contract('Swap Unit Tests', async accounts => {
       const val = await swap.signerAuthorizations.call(sender, mockSigner)
       equal(val, 0, 'signer approval was not properly unset')
 
-      //check that the event was emitted
-      emitted(trx, 'RevokeSigner', e => {
-        return e.authorizerAddress === sender && e.revokedSigner === mockSigner
-      })
+      //check that the event was not emitted as the authsigner did not exist
+      notEmitted(trx, 'RevokeSigner')
     })
 
     it('test that the revokeSender is successfully removed', async () => {
@@ -299,10 +297,8 @@ contract('Swap Unit Tests', async accounts => {
       const val = await swap.senderAuthorizations.call(sender, mockSender)
       equal(val, 0, 'sender approval was not properly unset')
 
-      //check that the event was emitted
-      emitted(trx, 'RevokeSender', e => {
-        return e.authorizerAddress === sender && e.revokedSender === mockSender
-      })
+      //check that the event was was not emitted as the authsender did not exist
+      notEmitted(trx, 'RevokeSender')
     })
   })
 })

--- a/source/swap/test/Swap.js
+++ b/source/swap/test/Swap.js
@@ -487,6 +487,15 @@ contract('Swap', async accounts => {
       )
     })
 
+    it('Alice authorizes David a second time does not emit an event', async () => {
+      notEmitted(
+        await swapContract.authorizeSigner(davidAddress, {
+          from: aliceAddress,
+        }),
+        'AuthorizeSigner'
+      )
+    })
+
     it('Alice approves Swap to spend the rest of her AST', async () => {
       emitted(
         await tokenAST.approve(swapAddress, 800, { from: aliceAddress }),
@@ -595,6 +604,15 @@ contract('Swap', async accounts => {
 
     it('Bob authorizes Carol to take orders on his behalf', async () => {
       emitted(
+        await swapContract.authorizeSender(carolAddress, {
+          from: bobAddress,
+        }),
+        'AuthorizeSender'
+      )
+    })
+
+    it('Bob authorizes Carol a second time does not emit an event', async () => {
+      notEmitted(
         await swapContract.authorizeSender(carolAddress, {
           from: bobAddress,
         }),

--- a/source/wrapper/test/Wrapper.js
+++ b/source/wrapper/test/Wrapper.js
@@ -368,14 +368,6 @@ contract('Wrapper', async ([aliceAddress, bobAddress, carolAddress]) => {
       emitted(result, 'Approval')
     })
 
-    it('Bob authorizes the Wrapper to send orders on her behalf', async () => {
-      const tx = await swapContract.authorizeSender(wrapperAddress, {
-        from: bobAddress,
-      })
-      passes(tx)
-      emitted(tx, 'AuthorizeSender')
-    })
-
     it('Send order where Bob sends AST to Alice for DAI', async () => {
       const order = await orders.getOrder({
         signer: {


### PR DESCRIPTION
## Description

Quick description:
- [X] Typo/small tweaks

## Changes

Put in checks to ensure a state change was occurring before emitting events. Added some tests to ensure calling the functions duplicate times would not emit an event.

## Tests
```
  73 passing (15s)

lerna success run Ran npm script 'test' in 8 packages in 181.2s:
lerna success - @airswap/delegate-factory
lerna success - @airswap/delegate
lerna success - @airswap/index
lerna success - @airswap/indexer
lerna success - @airswap/swap
lerna success - @airswap/types
lerna success - @airswap/wrapper
lerna success - @airswap/order-utils
Done in 387.51s.


## Test Coverage

Still 100%
```