### PR TITLE
Rename invalidate to clearer term cancelUpTo

### DIFF
--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -187,7 +187,7 @@ contract Swap is ISwap {
 
   /**
     * @notice Cancels all orders below a nonce value
-    * @dev Emits an cancelUpTo event
+    * @dev Emits a CancelUpTo event
     * @param minimumNonce uint256 Minimum valid nonce
     */
   function cancelUpTo(

--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -186,15 +186,15 @@ contract Swap is ISwap {
   }
 
   /**
-    * @notice Invalidate all orders below a nonce value
-    * @dev Emits an Invalidate event
+    * @notice Cancels all orders below a nonce value
+    * @dev Emits an CancelUpto event
     * @param minimumNonce uint256 Minimum valid nonce
     */
-  function invalidate(
+  function cancelUpto(
     uint256 minimumNonce
   ) external {
     signerMinimumNonce[msg.sender] = minimumNonce;
-    emit Invalidate(minimumNonce, msg.sender);
+    emit CancelUpto(minimumNonce, msg.sender);
   }
 
   /**

--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -187,14 +187,14 @@ contract Swap is ISwap {
 
   /**
     * @notice Cancels all orders below a nonce value
-    * @dev Emits an CancelUpto event
+    * @dev Emits an cancelUpTo event
     * @param minimumNonce uint256 Minimum valid nonce
     */
-  function cancelUpto(
+  function cancelUpTo(
     uint256 minimumNonce
   ) external {
     signerMinimumNonce[msg.sender] = minimumNonce;
-    emit CancelUpto(minimumNonce, msg.sender);
+    emit CancelUpTo(minimumNonce, msg.sender);
   }
 
   /**

--- a/source/swap/contracts/interfaces/ISwap.sol
+++ b/source/swap/contracts/interfaces/ISwap.sol
@@ -40,7 +40,7 @@ interface ISwap {
     address indexed signerWallet
   );
 
-  event CancelUpto(
+  event CancelUpTo(
     uint256 indexed nonce,
     address indexed signerWallet
   );
@@ -89,10 +89,10 @@ interface ISwap {
 
   /**
     * @notice Cancels all orders below a nonce value
-    * @dev These orders can be made active by reducing nonce
+    * @dev These orders can be made active by reducing the minimum nonce
     * @param minimumNonce uint256
     */
-  function cancelUpto(
+  function cancelUpTo(
     uint256 minimumNonce
   ) external;
 

--- a/source/swap/contracts/interfaces/ISwap.sol
+++ b/source/swap/contracts/interfaces/ISwap.sol
@@ -40,7 +40,7 @@ interface ISwap {
     address indexed signerWallet
   );
 
-  event Invalidate(
+  event CancelUpto(
     uint256 indexed nonce,
     address indexed signerWallet
   );
@@ -88,10 +88,11 @@ interface ISwap {
   ) external;
 
   /**
-    * @notice Invalidate all orders below a nonce value
+    * @notice Cancels all orders below a nonce value
+    * @dev These orders can be made active by reducing nonce
     * @param minimumNonce uint256
     */
-  function invalidate(
+  function cancelUpto(
     uint256 minimumNonce
   ) external;
 

--- a/source/swap/test/Swap-unit.js
+++ b/source/swap/test/Swap-unit.js
@@ -70,7 +70,7 @@ contract('Swap Unit Tests', async accounts => {
         signature,
       ]
 
-      await swap.invalidate(5, { from: mockSigner })
+      await swap.cancelUpto(5, { from: mockSigner })
       await reverted(swap.swap(order), 'NONCE_TOO_LOW')
     })
 
@@ -250,22 +250,22 @@ contract('Swap Unit Tests', async accounts => {
     })
   })
 
-  describe('Test invalidate', async () => {
+  describe('Test cancelUpTo functionality', async () => {
     it('test that given a minimum nonce for a signer is set', async () => {
       const minNonceForSigner = await swap.signerMinimumNonce.call(mockSigner)
       equal(minNonceForSigner, 0, 'mock signer should have min nonce of 0')
 
-      const trx = await swap.invalidate(5, { from: mockSigner })
+      const trx = await swap.cancelUpto(5, { from: mockSigner })
 
       const newNonceForSigner = await swap.signerMinimumNonce.call(mockSigner)
       equal(newNonceForSigner, 5, 'mock signer should have a min nonce of 5')
 
-      emitted(trx, 'Invalidate', e => {
+      emitted(trx, 'CancelUpto', e => {
         return e.nonce.toNumber() === 5 && e.signerWallet === mockSigner
       })
     })
 
-    it('test that given a minimum nonce that all orders below a nonce value are invalidated', async () => {})
+    it('test that given a minimum nonce that all orders below a nonce value are cancelled', async () => {})
   })
 
   describe('Test authorize signer', async () => {

--- a/source/swap/test/Swap-unit.js
+++ b/source/swap/test/Swap-unit.js
@@ -70,7 +70,7 @@ contract('Swap Unit Tests', async accounts => {
         signature,
       ]
 
-      await swap.cancelUpto(5, { from: mockSigner })
+      await swap.cancelUpTo(5, { from: mockSigner })
       await reverted(swap.swap(order), 'NONCE_TOO_LOW')
     })
 
@@ -255,12 +255,12 @@ contract('Swap Unit Tests', async accounts => {
       const minNonceForSigner = await swap.signerMinimumNonce.call(mockSigner)
       equal(minNonceForSigner, 0, 'mock signer should have min nonce of 0')
 
-      const trx = await swap.cancelUpto(5, { from: mockSigner })
+      const trx = await swap.cancelUpTo(5, { from: mockSigner })
 
       const newNonceForSigner = await swap.signerMinimumNonce.call(mockSigner)
       equal(newNonceForSigner, 5, 'mock signer should have a min nonce of 5')
 
-      emitted(trx, 'CancelUpto', e => {
+      emitted(trx, 'CancelUpTo', e => {
         return e.nonce.toNumber() === 5 && e.signerWallet === mockSigner
       })
     })

--- a/source/swap/test/Swap.js
+++ b/source/swap/test/Swap.js
@@ -42,7 +42,7 @@ contract('Swap', async accounts => {
 
   let swap
   let cancel
-  let invalidate
+  let cancelUpto
 
   // One big snapshot - not snapshotting every test
   before('Setup', async () => {
@@ -63,7 +63,7 @@ contract('Swap', async accounts => {
 
       swap = swapContract.swap
       cancel = swapContract.methods['cancel(uint256[])']
-      invalidate = swapContract.methods['invalidate(uint256)']
+      cancelUpto = swapContract.methods['cancelUpto(uint256)']
 
       orders.setVerifyingContract(swapAddress)
     })
@@ -837,7 +837,7 @@ contract('Swap', async accounts => {
     })
 
     it('Checks that Alice is able to set a minimum nonce of 4', async () => {
-      emitted(await invalidate(4, { from: aliceAddress }), 'Invalidate')
+      emitted(await cancelUpto(4, { from: aliceAddress }), 'CancelUpto')
     })
 
     it('Checks that Bob is unable to take an order with nonce 2', async () => {

--- a/source/swap/test/Swap.js
+++ b/source/swap/test/Swap.js
@@ -42,7 +42,7 @@ contract('Swap', async accounts => {
 
   let swap
   let cancel
-  let cancelUpto
+  let cancelUpTo
 
   // One big snapshot - not snapshotting every test
   before('Setup', async () => {
@@ -63,7 +63,7 @@ contract('Swap', async accounts => {
 
       swap = swapContract.swap
       cancel = swapContract.methods['cancel(uint256[])']
-      cancelUpto = swapContract.methods['cancelUpto(uint256)']
+      cancelUpTo = swapContract.methods['cancelUpTo(uint256)']
 
       orders.setVerifyingContract(swapAddress)
     })
@@ -837,7 +837,7 @@ contract('Swap', async accounts => {
     })
 
     it('Checks that Alice is able to set a minimum nonce of 4', async () => {
-      emitted(await cancelUpto(4, { from: aliceAddress }), 'CancelUpto')
+      emitted(await cancelUpTo(4, { from: aliceAddress }), 'CancelUpTo')
     })
 
     it('Checks that Bob is unable to take an order with nonce 2', async () => {


### PR DESCRIPTION
## Description

Quick description:

- [X] Typo/small tweaks

## Changes

Rename invalidate to cancelUpto
Put in a dev note to indicate that cancelUpto can be reversible in that it's not a hard cancel

## Tests
All Passing

## Test Coverage

Just renaming and still at 100%