### PR TITLE
Remove snapshots from integration tests

### DIFF
--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -3,7 +3,6 @@ const Swap = artifacts.require('Swap')
 const Types = artifacts.require('Types')
 const Indexer = artifacts.require('Indexer')
 const FungibleToken = artifacts.require('FungibleToken')
-const { takeSnapshot, revertToSnapshot } = require('@airswap/test-utils').time
 const {
   emitted,
   notEmitted,
@@ -18,8 +17,6 @@ const {
   EMPTY_ADDRESS,
   GANACHE_PROVIDER,
 } = require('@airswap/order-utils').constants
-
-let snapshotId
 
 contract('Delegate Integration Tests', async accounts => {
   const STARTING_BALANCE = 100000000
@@ -53,9 +50,6 @@ contract('Delegate Integration Tests', async accounts => {
   }
 
   before('Setup', async () => {
-    const snapShot = await takeSnapshot()
-    snapshotId = snapShot['result']
-
     // link types to swap
     await Swap.link('Types', (await Types.new()).address)
     // now deploy swap
@@ -74,10 +68,6 @@ contract('Delegate Integration Tests', async accounts => {
       aliceTradeWallet
     )
     aliceDelegate = await delegateContract
-  })
-
-  after(async () => {
-    await revertToSnapshot(snapshotId)
   })
 
   describe('Test the delegate constructor', async () => {

--- a/source/indexer/test/Indexer.js
+++ b/source/indexer/test/Indexer.js
@@ -12,7 +12,6 @@ const {
   passes,
 } = require('@airswap/test-utils').assert
 const { balances } = require('@airswap/test-utils').balances
-const { takeSnapshot, revertToSnapshot } = require('@airswap/test-utils').time
 const {
   EMPTY_ADDRESS,
   HEAD,
@@ -21,8 +20,6 @@ const {
   NEXTID,
 } = require('@airswap/order-utils').constants
 const { padAddressToLocator } = require('@airswap/test-utils').padding
-
-let snapshotId
 
 contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
   let indexer
@@ -43,15 +40,6 @@ contract('Indexer', async ([ownerAddress, aliceAddress, bobAddress]) => {
   const emptyLocator = padAddressToLocator(EMPTY_ADDRESS)
 
   let whitelistedLocator
-
-  before('Setup', async () => {
-    const snapShot = await takeSnapshot()
-    snapshotId = snapShot['result']
-  })
-
-  after(async () => {
-    await revertToSnapshot(snapshotId)
-  })
 
   describe('Deploying...', async () => {
     it('Deployed staking token "AST"', async () => {

--- a/source/swap/test/Swap.js
+++ b/source/swap/test/Swap.js
@@ -3,7 +3,6 @@ const Types = artifacts.require('Types')
 const FungibleToken = artifacts.require('FungibleToken')
 const NonFungibleToken = artifacts.require('NonFungibleToken')
 const OMGToken = artifacts.require('OMGToken')
-const { takeSnapshot, revertToSnapshot } = require('@airswap/test-utils').time
 
 const {
   emitted,
@@ -24,8 +23,6 @@ const {
   GANACHE_PROVIDER,
 } = require('@airswap/order-utils').constants
 
-let snapshotId
-
 contract('Swap', async accounts => {
   const aliceAddress = accounts[0]
   const bobAddress = accounts[1]
@@ -43,16 +40,6 @@ contract('Swap', async accounts => {
   let swap
   let cancel
   let cancelUpTo
-
-  // One big snapshot - not snapshotting every test
-  before('Setup', async () => {
-    const snapShot = await takeSnapshot()
-    snapshotId = snapShot['result']
-  })
-
-  after(async () => {
-    await revertToSnapshot(snapshotId)
-  })
 
   describe('Deploying...', async () => {
     it('Deployed Swap contract', async () => {

--- a/source/wrapper/test/Wrapper.js
+++ b/source/wrapper/test/Wrapper.js
@@ -14,7 +14,6 @@ const {
   ok,
 } = require('@airswap/test-utils').assert
 const { balances } = require('@airswap/test-utils').balances
-const { takeSnapshot, revertToSnapshot } = require('@airswap/test-utils').time
 const { orders, signatures } = require('@airswap/order-utils')
 const { GANACHE_PROVIDER } = require('@airswap/order-utils').constants
 
@@ -30,12 +29,9 @@ let wrappedSwap
 let tokenAST
 let tokenDAI
 let tokenWETH
-let snapshotId
 
 contract('Wrapper', async ([aliceAddress, bobAddress, carolAddress]) => {
   before('Setup', async () => {
-    const snapShot = await takeSnapshot()
-    snapshotId = snapShot['result']
     // link types to swap
     await Swap.link('Types', (await Types.new()).address)
     // now deploy swap
@@ -54,10 +50,6 @@ contract('Wrapper', async ([aliceAddress, bobAddress, carolAddress]) => {
 
     orders.setVerifyingContract(swapAddress)
     wrappedSwap = wrapperContract.swap
-  })
-
-  after('Cleanup', async () => {
-    await revertToSnapshot(snapshotId)
   })
 
   describe('Setup', async () => {


### PR DESCRIPTION
## Description

Removing snapshots from integration tests as truffle already does this/ This is a remnant from when lerna was set up differently.
