### PR TITLE
Update ERC20_INTERFACE_ID in Delegate and constants.js and upgraded o…

### DIFF
--- a/source/delegate-factory/package.json
+++ b/source/delegate-factory/package.json
@@ -21,7 +21,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.6",
+    "@airswap/order-utils": "0.3.7",
     "@airswap/test-utils": "0.1.1",
     "solidity-coverage": "^0.6.3"
   },

--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -49,7 +49,7 @@ contract Delegate is IDelegate, Ownable {
   mapping (address => mapping (address => Rule)) public rules;
 
   // ERC-20 (fungible token) interface identifier (ERC-165)
-  bytes4 constant internal ERC20_INTERFACE_ID = 0x277f8169;
+  bytes4 constant internal ERC20_INTERFACE_ID = 0x36372b07;
 
   /**
     * @notice Contract Constructor

--- a/source/delegate/package.json
+++ b/source/delegate/package.json
@@ -21,7 +21,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.6",
+    "@airswap/order-utils": "0.3.7",
     "@airswap/test-utils": "0.1.1",
     "solidity-coverage": "^0.6.3"
   },

--- a/source/index/package.json
+++ b/source/index/package.json
@@ -21,7 +21,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.6",
+    "@airswap/order-utils": "0.3.7",
     "@airswap/test-utils": "0.1.1",
     "@airswap/tokens": "0.1.2",
     "bignumber.js": "^9.0.0",

--- a/source/indexer/package.json
+++ b/source/indexer/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@airswap/index": "0.3.1",
-    "@airswap/order-utils": "0.3.6",
+    "@airswap/order-utils": "0.3.7",
     "@airswap/test-utils": "0.1.1",
     "@airswap/types": "0.3.2",
     "bignumber.js": "^9.0.0",

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@airswap/tokens": "0.1.2",
-    "@airswap/order-utils": "0.3.6",
+    "@airswap/order-utils": "0.3.7",
     "@airswap/test-utils": "0.1.1",
     "truffle": "^5.0.32",
     "@gnosis.pm/mock-contract": "^3.0.7",

--- a/source/types/package.json
+++ b/source/types/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@airswap/tokens": "0.1.2",
-    "@airswap/order-utils": "0.3.6",
+    "@airswap/order-utils": "0.3.7",
     "solidity-coverage": "^0.6.3"
   },
   "dependencies": {

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -22,7 +22,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.6",
+    "@airswap/order-utils": "0.3.7",
     "@airswap/test-utils": "0.1.1",
     "solidity-coverage": "^0.6.3"
   },

--- a/utils/order-utils/package.json
+++ b/utils/order-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/order-utils",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "JavaScript utilities for orders, hashes, and signatures in the Swap Protocol",
   "license": "Apache-2.0",
   "repository": {

--- a/utils/order-utils/src/constants.js
+++ b/utils/order-utils/src/constants.js
@@ -26,7 +26,7 @@ module.exports = {
   NEXTID: 2,
   ONE_ETH: 1000000000000000000,
   ERC721_INTERFACE_ID: '0x80ac58cd',
-  ERC20_INTERFACE_ID: '0x277f8169',
+  ERC20_INTERFACE_ID: '0x36372b07',
   GANACHE_PROVIDER: 'http://127.0.0.1:8545',
   signatures: {
     INTENDED_VALIDATOR: '0x00',
@@ -55,7 +55,7 @@ module.exports = {
   },
   defaults: {
     Party: {
-      kind: '0x277f8169',
+      kind: '0x36372b07',
       wallet: '0x0000000000000000000000000000000000000000',
       token: '0x0000000000000000000000000000000000000000',
       param: '0',

--- a/utils/order-utils/test/orders.js
+++ b/utils/order-utils/test/orders.js
@@ -146,7 +146,7 @@ describe('Orders', async () => {
       GANACHE_PROVIDER
     )
 
-    order.signature.v += 1
+    order.signature.v -= 1
     const errors = await orders.checkOrder(order, 'rinkeby')
     assert.equal(errors.length, 2)
     assert.equal(errors[1], 'Signature invalid')

--- a/utils/order-utils/test/signatures.js
+++ b/utils/order-utils/test/signatures.js
@@ -44,11 +44,11 @@ describe('Signatures', async () => {
       version: '0x45',
       signatory: signerWallet,
       r: Buffer.from(
-        '6ce2f4c1d5f21f9b101a8043ae1e9fecf93972720399a65237abd70e43cc05d8',
+        'a35bc1432b2f643462a2b800c8169635a4c047062a7f4623b72ecd6a770d0dab',
         'hex'
       ),
       s: Buffer.from(
-        '39c1efa6505ef3e87c09e9105f63e449d9c29d11c50dc968f0070a5a860bfd49',
+        '51b4c9d0a807e46ffba56c75e3ca88b4fdb266bb8ebb8582df7e90c5a8a63db1',
         'hex'
       ),
       v: 28,
@@ -84,14 +84,14 @@ describe('Signatures', async () => {
       version: '0x01',
       signatory: signerWallet,
       r: Buffer.from(
-        '3d884c1025eb35ec6f6d4305bebe65416ee7e8acb48ceefece3a585f74e44030',
+        '04c094132c9d0a1d2f4472fdaaed033b941d374c5d202503023d2fc0a2657123',
         'hex'
       ),
       s: Buffer.from(
-        '31f3161d9a3451841ff3fe6bd16738e17a284ea2f8c235ea769d04bf6aa12855',
+        '3299ec88d83eda85a93c724d9ac9e05ddc674ad8d34f9ee7e1e6939d0a79b817',
         'hex'
       ),
-      v: 27,
+      v: 28,
     })
   })
 })


### PR DESCRIPTION
## Description

Quick description:
- [X] Typo/small tweaks

## Changes

Changed ERC20_INTERFACE_ID bytes4 to include function approve and totalSupply which update the hash to 0x36372b07.
Only Solidity contract that used ERC20_INTERFACE_ID was Delegate which was updated as well.
Updated order-utils version as the constants.js needed to be updated since all tests rely on this.

The new hash represents:
bytes4(keccak256('transfer(address,uint256)')) ^ bytes4(keccak256('transferFrom(address,address,uint256)')) ^
bytes4(keccak256('balanceOf(address)')) ^ bytes4(keccak256('allowance(address,address)'))
    ^ bytes4(keccak256('approve(address,uint256)')) ^ bytes4(keccak256('totalSupply'))

Only other usage of this ID can be see:
https://github.com/0xcert/framework/blob/master/packages/0xcert-ethereum-erc20-contracts/src/contracts/token.sol

## Tests

All pass

## Test Coverage

Just a rename, and everything still covered.