### PR TITLE
Parallelize Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,6 @@ jobs:
             sudo apt install python3-pip
             pip3 install -r requirements.txt
             python3 scripts/dependency_checker.py
-      - run:
-          name: Compile
-          command: yarn compile
       - save_cache:
           paths:
             - node_modules
@@ -62,6 +59,18 @@ jobs:
       - run:
           name: Solhint
           command: yarn hint
+
+  compile:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Compile
+          command: yarn compile
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
 
   swap_tests:
     <<: *container_config
@@ -227,34 +236,39 @@ workflows:
           context: Development
           requires:
             - setup
+      - compile:
+          context: Development
+          requires: 
+            - eslint
+            - solhint
       - swap_tests:
           context: Development
           requires:
-            - setup
+            - compile
       - indexer_tests:
           context: Development
           requires:
-            - setup
+            - compile
       - index_tests:
           context: Development
           requires:
-            - setup
+            - compile
       - delegate_tests:
           context: Development
           requires:
-            - setup
+            - compile
       - delegate_factory_tests:
           context: Development
           requires:
-            - setup
+            - compile
       - types_tests:
           context: Development
           requires:
-            - setup
+            - compile
       - wrapper_tests:
           context: Development
           requires:
-            - setup
+            - compile
       - deploy:
           context: NPM_Publish
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,35 +239,46 @@ workflows:
       - compile:
           context: Development
           requires: 
-            - eslint
-            - solhint
+            - setup
       - swap_tests:
           context: Development
           requires:
-            - compile
+            - eslint
       - indexer_tests:
           context: Development
           requires:
+            - eslint
+            - solhint
             - compile
       - index_tests:
           context: Development
           requires:
+            - eslint
+            - solhint
             - compile
       - delegate_tests:
           context: Development
           requires:
+            - eslint
+            - solhint
             - compile
       - delegate_factory_tests:
           context: Development
           requires:
+            - eslint
+            - solhint
             - compile
       - types_tests:
           context: Development
           requires:
+            - eslint
+            - solhint
             - compile
       - wrapper_tests:
           context: Development
           requires:
+            - eslint
+            - solhint
             - compile
       - deploy:
           context: NPM_Publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           root: *working_directory
           paths: .
 
-  run_swap_tests:
+  swap_tests:
     <<: *container_config
     steps:
       - attach_workspace:
@@ -65,7 +65,7 @@ jobs:
           root: *working_directory
           paths: .
 
-  run_indexer_tests:
+  indexer_tests:
     <<: *container_config
     steps:
       - attach_workspace:
@@ -75,6 +75,90 @@ jobs:
           command: |
             yarn ganache > /dev/null &
             cd source/indexer && yarn test
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
+
+  index_tests:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Run Tests
+          command: |
+            yarn ganache > /dev/null &
+            cd source/index && yarn test
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
+
+  delegate_tests:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Run Tests
+          command: |
+            yarn ganache > /dev/null &
+            cd source/delegate && yarn test
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
+
+  delegate_factory_tests:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Run Tests
+          command: |
+            yarn ganache > /dev/null &
+            cd source/delegate-factory && yarn test
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
+
+  tokens_tests:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Run Tests
+          command: |
+            yarn ganache > /dev/null &
+            cd source/tokens && yarn test
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
+
+  types_tests:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Run Tests
+          command: |
+            yarn ganache > /dev/null &
+            cd source/types && yarn test
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
+
+  wrapper_tests:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Run Tests
+          command: |
+            yarn ganache > /dev/null &
+            cd source/wrapper && yarn test
       - persist_to_workspace:
           root: *working_directory
           paths: .
@@ -137,19 +221,49 @@ workflows:
     jobs:
       - setup:
           context: Development
-      - run_swap_tests:
+      - swap_tests:
           context: Development
           requires:
             - setup
-      - run_indexer_tests:
+      - indexer_tests:
+          context: Development
+          requires:
+            - setup
+      - index_tests:
+          context: Development
+          requires:
+            - setup
+      - delegate_tests:
+          context: Development
+          requires:
+            - setup
+      - delegate_factory_tests:
+          context: Development
+          requires:
+            - setup
+      - tokens_tests:
+          context: Development
+          requires:
+            - setup
+      - types_tests:
+          context: Development
+          requires:
+            - setup
+      - wrapper_tests:
           context: Development
           requires:
             - setup
       - deploy:
           context: NPM_Publish
           requires:
-            - run_swap_tests
-            - run_indexer_tests
+            - swap_tests
+            - indexer_tests
+            - index_tests
+            - delegate_tests
+            - delegate_factory_tests
+            - tokens_tests
+            - types_tests
+            - wrapper_tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,14 @@ orbs:
   datadog: airswap/datadog@volatile
 
 references:
+  working_directory: &working_directory
+    working_directory: ~/repo
+
   container_config: &container_config
     docker:
       - image: circleci/node:10
     working_directory: *working_directory
 
-  working_directory: &working_directory
-    working_directory: ~/repo
 
 jobs:
   run_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           root: *working_directory
           paths: .
 
-  run_tests:
+  run_swap_tests:
     <<: *container_config
     steps:
       - attach_workspace:
@@ -61,6 +61,20 @@ jobs:
           command: |
             yarn ganache > /dev/null &
             cd source/swap && yarn test
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
+
+  run_indexer_tests:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Run Tests
+          command: |
+            yarn ganache > /dev/null &
+            cd source/indexer && yarn test
       - persist_to_workspace:
           root: *working_directory
           paths: .
@@ -123,7 +137,11 @@ workflows:
     jobs:
       - setup:
           context: Development
-      - run_tests:
+      - run_swap_tests:
+          context: Development
+          requires:
+            - setup
+      - run_indexer_tests:
           context: Development
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ references:
       - image: circleci/node:10
     working_directory: *working_directory
 
-
 jobs:
   setup:
     <<: *container_config
@@ -44,7 +43,7 @@ jobs:
       - run:
           name: Compile
           command: yarn compile
-     - save_cache:
+      - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,6 @@ jobs:
             pip3 install -r requirements.txt
             python3 scripts/dependency_checker.py
       - run:
-          name: Eslint
-          command: yarn lint
-      - run:
-          name: Solhint
-          command: yarn hint
-      - run:
           name: Compile
           command: yarn compile
       - save_cache:
@@ -50,6 +44,24 @@ jobs:
       - persist_to_workspace:
           root: *working_directory
           paths: .
+
+  eslint:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Eslint
+          command: yarn lint
+
+  solhint:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: Solhint
+          command: yarn hint
 
   swap_tests:
     <<: *container_config
@@ -207,6 +219,14 @@ workflows:
     jobs:
       - setup:
           context: Development
+      - eslint:
+          context: Development
+          requires:
+            - setup
+      - solhint:
+          context: Development
+          requires:
+            - setup
       - swap_tests:
           context: Development
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           name: Run Tests
           command: |
             yarn ganache > /dev/null &
-            cd /source/swap &
+            cd source/swap &
             yarn test
       - persist_to_workspace:
           root: *working_directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,13 @@ references:
   container_config: &container_config
     docker:
       - image: circleci/node:10
+    working_directory: *working_directory
+
+  working_directory: &working_directory
     working_directory: ~/repo
 
-  run_tests: &run_tests
+jobs:
+  run_tests:
     <<: *container_config
     steps:
       - checkout
@@ -37,6 +41,9 @@ references:
           name: Solhint
           command: yarn hint
       - run:
+          name: Compile
+          command: yarn compile
+      - run:
           name: Run Tests
           command: |
             yarn ganache > /dev/null &
@@ -46,18 +53,14 @@ references:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - persist_to_workspace:
-          root: ~/repo
+          root: *working_directory
           paths: .
-
-jobs:
-  run_tests:
-    <<: *run_tests
 
   deploy:
     <<: *container_config
     steps:
       - attach_workspace:
-          at: ~/repo
+          at: *working_directory
       - run:
           name: Install NPM non-interactive
           command: sudo npm install -g npm-login-noninteractive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,20 +121,6 @@ jobs:
           root: *working_directory
           paths: .
 
-  tokens_tests:
-    <<: *container_config
-    steps:
-      - attach_workspace:
-          at: *working_directory
-      - run:
-          name: Run Tests
-          command: |
-            yarn ganache > /dev/null &
-            cd source/tokens && yarn test
-      - persist_to_workspace:
-          root: *working_directory
-          paths: .
-
   types_tests:
     <<: *container_config
     steps:
@@ -241,10 +227,6 @@ workflows:
           context: Development
           requires:
             - setup
-      - tokens_tests:
-          context: Development
-          requires:
-            - setup
       - types_tests:
           context: Development
           requires:
@@ -261,7 +243,6 @@ workflows:
             - index_tests
             - delegate_tests
             - delegate_factory_tests
-            - tokens_tests
             - types_tests
             - wrapper_tests
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ jobs:
             - v1-dependencies-{{ checksum "package.json" }}
             - v1-dependencies-
       - run:
+          name: Eslint
+          command: yarn lint
+      - run:
+          name: Solhint
+          command: yarn hint
+      - run:
           name: yarn install and dependencies
           command: |
             yarn install
@@ -34,40 +40,13 @@ jobs:
             sudo apt install python3-pip
             pip3 install -r requirements.txt
             python3 scripts/dependency_checker.py
+      - run:
+          name: Compile
+          command: yarn compile
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-      - persist_to_workspace:
-          root: *working_directory
-          paths: .
-
-  eslint:
-    <<: *container_config
-    steps:
-      - attach_workspace:
-          at: *working_directory
-      - run:
-          name: Eslint
-          command: yarn lint
-
-  solhint:
-    <<: *container_config
-    steps:
-      - attach_workspace:
-          at: *working_directory
-      - run:
-          name: Solhint
-          command: yarn hint
-
-  compile:
-    <<: *container_config
-    steps:
-      - attach_workspace:
-          at: *working_directory
-      - run:
-          name: Compile
-          command: yarn compile
       - persist_to_workspace:
           root: *working_directory
           paths: .
@@ -243,45 +222,31 @@ workflows:
       - swap_tests:
           context: Development
           requires:
-            - eslint
-            - solhint
-            - compile
+            - setup
       - indexer_tests:
           context: Development
           requires:
-            - eslint
-            - solhint
-            - compile
+            - setup
       - index_tests:
           context: Development
           requires:
-            - eslint
-            - solhint
-            - compile
+            - setup
       - delegate_tests:
           context: Development
           requires:
-            - eslint
-            - solhint
-            - compile
+            - setup
       - delegate_factory_tests:
           context: Development
           requires:
-            - eslint
-            - solhint
-            - compile
+            - setup
       - types_tests:
           context: Development
           requires:
-            - eslint
-            - solhint
-            - compile
+            - setup
       - wrapper_tests:
           context: Development
           requires:
-            - eslint
-            - solhint
-            - compile
+            - setup
       - deploy:
           context: NPM_Publish
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,10 @@ orbs:
   datadog: airswap/datadog@volatile
 
 references:
-  working_directory: &working_directory
-    working_directory: ~/repo
-
   container_config: &container_config
     docker:
       - image: circleci/node:10
-    working_directory: *working_directory
+    working_directory: ~/repo
 
 
 jobs:
@@ -54,14 +51,14 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - persist_to_workspace:
-          root: *working_directory
+          root: ~/repo
           paths: .
 
   deploy:
     <<: *container_config
     steps:
       - attach_workspace:
-          at: *working_directory
+          at: ~/repo
       - run:
           name: Install NPM non-interactive
           command: sudo npm install -g npm-login-noninteractive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
     <<: *container_config
     steps:
       - attach_workspace:
-        at: *working_directory
+          at: *working_directory
       - run:
           name: Run Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,8 @@ workflows:
           context: Development
       - run_tests:
           context: Development
+          requires:
+            - setup
       - deploy:
           context: NPM_Publish
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,8 @@ jobs:
           name: Run Tests
           command: |
             yarn ganache > /dev/null &
-            yarn test /source/swap/test
+            cd /source/swap &
+            yarn test
       - persist_to_workspace:
           root: *working_directory
           paths: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,18 +207,6 @@ workflows:
     jobs:
       - setup:
           context: Development
-      - eslint:
-          context: Development
-          requires:
-            - setup
-      - solhint:
-          context: Development
-          requires:
-            - setup
-      - compile:
-          context: Development
-          requires: 
-            - setup
       - swap_tests:
           context: Development
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ references:
 
 
 jobs:
-  run_tests:
+  setup:
     <<: *container_config
     steps:
       - checkout
@@ -44,15 +44,24 @@ jobs:
       - run:
           name: Compile
           command: yarn compile
+     - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
+
+  run_tests:
+    <<: *container_config
+    steps:
+      - attach_workspace:
+        at: *working_directory
       - run:
           name: Run Tests
           command: |
             yarn ganache > /dev/null &
             yarn test
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
       - persist_to_workspace:
           root: *working_directory
           paths: .
@@ -113,6 +122,8 @@ jobs:
 workflows:
   smart_contract:
     jobs:
+      - setup:
+          context: Development
       - run_tests:
           context: Development
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,8 @@ workflows:
       - deploy:
           context: NPM_Publish
           requires:
-            - run_tests
+            - run_swap_tests
+            - run_indexer_tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,7 @@ jobs:
           name: Run Tests
           command: |
             yarn ganache > /dev/null &
-            cd source/swap &
-            yarn test
+            cd source/swap && yarn test
       - persist_to_workspace:
           root: *working_directory
           paths: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,13 @@ orbs:
   datadog: airswap/datadog@volatile
 
 references:
+  working_directory: &working_directory
+    ~/repo
+
   container_config: &container_config
     docker:
       - image: circleci/node:10
-    working_directory: ~/repo
+    working_directory: *working_directory
 
 
 jobs:
@@ -51,14 +54,14 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - persist_to_workspace:
-          root: ~/repo
+          root: *working_directory
           paths: .
 
   deploy:
     <<: *container_config
     steps:
       - attach_workspace:
-          at: ~/repo
+          at: *working_directory
       - run:
           name: Install NPM non-interactive
           command: sudo npm install -g npm-login-noninteractive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,8 @@ workflows:
           context: Development
           requires:
             - eslint
+            - solhint
+            - compile
       - indexer_tests:
           context: Development
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           name: Run Tests
           command: |
             yarn ganache > /dev/null &
-            yarn test
+            yarn test /source/swap/test
       - persist_to_workspace:
           root: *working_directory
           paths: .

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "lint": "yarn eslint \"./**/*.js\"",
     "ganache": "ganache-cli -p 8545 --gasLimit 0xfffffffffff --time '2017-05-10T00:00:00+00:00' -s 0",
     "publish": "lerna publish",
-    "test-local": "yarn clean && yarn compile && lerna run test --concurrency=1",
-    "test": "lerna run test --concurrency=1",
+    "test": "yarn clean && yarn compile && lerna run test --concurrency=1",
     "check_dep_graph": "source venv/bin/activate && pip3 install -r requirements.txt && python scripts/dependency_checker.py"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "yarn eslint \"./**/*.js\"",
     "ganache": "ganache-cli -p 8545 --gasLimit 0xfffffffffff --time '2017-05-10T00:00:00+00:00' -s 0",
     "publish": "lerna publish",
-    "test": "yarn clean && yarn compile && lerna run test --concurrency=1",
+    "test-local": "yarn clean && yarn compile && lerna run test --concurrency=1",
+    "test": "lerna run test --concurrency=1",
     "check_dep_graph": "source venv/bin/activate && pip3 install -r requirements.txt && python scripts/dependency_checker.py"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
https://github.com/airswap/airswap-protocols/issues/337
I wanted to be identify a failing test in parallel with other tests. The total time it takes for the circle job to pass is roughly a minute and a half faster*; lowers average time waiting for a test to be run.

*In some instances it's 50% faster

Quick description:

- [ ] N/A
- [ ] New features
- [ ] Bug fixes
- [ X ] Typo/small tweaks

## Changes

- circle ci script is updated to save the compiled state to a workspace and then all tests in parallel on that workspace.
- npm publish now requires all the tests to pass in order to deploy 

## Tests

<img width="758" alt="Screen Shot 2019-12-06 at 4 54 04 PM" src="https://user-images.githubusercontent.com/3590816/70365145-fb939600-185d-11ea-9bb0-07ad439c4291.png">

![Screen Shot 2019-12-06 at 5 10 12 PM](https://user-images.githubusercontent.com/3590816/70365159-0e0dcf80-185e-11ea-97db-1a11af78d099.png)

