### PR TITLE
Dependency revamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-utils": "^1.4.2",
-    "ethereumjs-abi": "^0.6.7",
     "ganache-cli": "^6.4.4",
     "husky": "^3.0.9",
     "lerna": "^3.15.0",
     "prettier": "^1.18.2",
     "solhint": "^2.1.0",
+    "solidity-coverage": "^0.6.3",
     "truffle": "^5.0.32",
     "truffle-flatten": "^1.0.6",
     "truffle-hdwallet-provider-privkey": "^1.0.3",
@@ -54,6 +54,5 @@
     "hooks": {
       "pre-commit": "yarn lint && yarn hint"
     }
-  },
-  "dependencies": {}
+  }
 }

--- a/source/delegate-factory/package.json
+++ b/source/delegate-factory/package.json
@@ -27,7 +27,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.13",
+    "@airswap/order-utils": "0.3.14",
     "@airswap/test-utils": "0.1.3"
   },
   "dependencies": {

--- a/source/delegate-factory/package.json
+++ b/source/delegate-factory/package.json
@@ -28,8 +28,7 @@
   },
   "devDependencies": {
     "@airswap/order-utils": "0.3.13",
-    "@airswap/test-utils": "0.1.3",
-    "solidity-coverage": "^0.6.3"
+    "@airswap/test-utils": "0.1.3"
   },
   "dependencies": {
     "@airswap/delegate": "0.5.6",

--- a/source/delegate/package.json
+++ b/source/delegate/package.json
@@ -28,8 +28,7 @@
   },
   "devDependencies": {
     "@airswap/order-utils": "0.3.13",
-    "@airswap/test-utils": "0.1.3",
-    "solidity-coverage": "^0.6.3"
+    "@airswap/test-utils": "0.1.3"
   },
   "dependencies": {
     "@airswap/indexer": "2.6.7",

--- a/source/delegate/package.json
+++ b/source/delegate/package.json
@@ -27,7 +27,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.13",
+    "@airswap/order-utils": "0.3.14",
     "@airswap/test-utils": "0.1.3"
   },
   "dependencies": {

--- a/source/index/package.json
+++ b/source/index/package.json
@@ -31,7 +31,6 @@
     "@airswap/test-utils": "0.1.3",
     "@airswap/tokens": "0.1.3",
     "bignumber.js": "^9.0.0",
-    "solidity-coverage": "^0.6.3",
     "truffle": "^5.0.24"
   },
   "dependencies": {

--- a/source/index/package.json
+++ b/source/index/package.json
@@ -27,7 +27,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.13",
+    "@airswap/order-utils": "0.3.14",
     "@airswap/test-utils": "0.1.3",
     "@airswap/tokens": "0.1.3",
     "bignumber.js": "^9.0.0",

--- a/source/indexer/package.json
+++ b/source/indexer/package.json
@@ -31,7 +31,6 @@
     "@airswap/test-utils": "0.1.3",
     "@airswap/types": "1.4.4",
     "bignumber.js": "^9.0.0",
-    "solidity-coverage": "^0.6.3",
     "truffle": "^5.0.24"
   },
   "dependencies": {

--- a/source/indexer/package.json
+++ b/source/indexer/package.json
@@ -27,7 +27,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.13",
+    "@airswap/order-utils": "0.3.14",
     "@airswap/test-utils": "0.1.3",
     "@airswap/types": "1.4.4",
     "bignumber.js": "^9.0.0",

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -32,7 +32,6 @@
     "@airswap/test-utils": "0.1.3",
     "truffle": "^5.0.32",
     "@gnosis.pm/mock-contract": "^3.0.7",
-    "solidity-coverage": "^0.6.3",
     "solidity-docgen": "0.3.0-beta.3",
     "truffle-hdwallet-provider-privkey": "1.0.3"
   },

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@airswap/tokens": "0.1.3",
-    "@airswap/order-utils": "0.3.13",
+    "@airswap/order-utils": "0.3.14",
     "@airswap/test-utils": "0.1.3",
     "truffle": "^5.0.32",
     "@gnosis.pm/mock-contract": "^3.0.7",

--- a/source/types/package.json
+++ b/source/types/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@airswap/tokens": "0.1.3",
-    "@airswap/order-utils": "0.3.13"
+    "@airswap/order-utils": "0.3.14"
   },
   "dependencies": {
     "openzeppelin-solidity": "2.3"

--- a/source/types/package.json
+++ b/source/types/package.json
@@ -28,8 +28,7 @@
   },
   "devDependencies": {
     "@airswap/tokens": "0.1.3",
-    "@airswap/order-utils": "0.3.13",
-    "solidity-coverage": "^0.6.3"
+    "@airswap/order-utils": "0.3.13"
   },
   "dependencies": {
     "openzeppelin-solidity": "2.3"

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -28,7 +28,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.13",
+    "@airswap/order-utils": "0.3.14",
     "@airswap/test-utils": "0.1.3",
     "@airswap/indexer": "2.6.7"
   },

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@airswap/order-utils": "0.3.13",
     "@airswap/test-utils": "0.1.3",
-    "solidity-coverage": "^0.6.3",
     "@airswap/indexer": "2.6.7"
   },
   "dependencies": {

--- a/utils/deployer/package.json
+++ b/utils/deployer/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@airswap/tokens": "0.1.3",
-    "@airswap/order-utils": "0.3.13",
+    "@airswap/order-utils": "0.3.14",
     "@airswap/test-utils": "0.1.3",
     "truffle": "^5.0.32",
     "@gnosis.pm/mock-contract": "^3.0.7",

--- a/utils/deployer/package.json
+++ b/utils/deployer/package.json
@@ -28,7 +28,6 @@
     "@airswap/test-utils": "0.1.3",
     "truffle": "^5.0.32",
     "@gnosis.pm/mock-contract": "^3.0.7",
-    "solidity-coverage": "^0.6.3",
     "solidity-docgen": "0.3.0-beta.3",
     "truffle-hdwallet-provider-privkey": "1.0.3",
     "truffle-flatten": "^1.0.6",

--- a/utils/order-utils/package.json
+++ b/utils/order-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/order-utils",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "JavaScript utilities for orders, hashes, and signatures in the Swap Protocol",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",

--- a/utils/order-utils/package.json
+++ b/utils/order-utils/package.json
@@ -25,6 +25,7 @@
     "@airswap/swap": "3.3.5",
     "@airswap/tokens": "0.1.3",
     "eth-sig-util": "^2.2.0",
+    "ethereumjs-abi": "^0.6.7",
     "ethereumjs-util": "^6.1.0",
     "ethers": "^5.0.0-beta.159",
     "web3": "^1.0.0-beta.55",


### PR DESCRIPTION
## Description

- `order-utils` uses `ethereumjs-abi` which was previously a devDependency. The only reason we weren't hitting a problem of it being imported was because `eth-sig-util` imports it. Considering we use a carat for eth-sig I dont think we should rely on it being there forever. Have moved this dependency into `order-utils` and made it a `dependency`
- most repos were importing `solidity-coverage` independently. I moved it to be a global `devDependency`, seeing as this is where we import all of our other test-related packages.