### PR TITLE
Renaming guide to readme for deployer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ Packages are versioned based on deploys. Major versions e.g. `1.x.x` are mainnet
 
 ## Deployments
 
-To deploy, please follow [this guide](./utils/deployer/DEPLOYMENT_GUIDE.md)
+To deploy, please follow [this guide](./utils/deployer)

--- a/utils/deployer/README.md
+++ b/utils/deployer/README.md
@@ -1,4 +1,4 @@
-# Deployment Guide
+# Deployer
 
 This guide walks through the process of deploying contracts to public Ethereum networks and verifying contracts on Etherscan. The process requires an Ethereum mnemonic phrase, Etherscan API key, and Infura API key.
 


### PR DESCRIPTION
Small change to rename the guide to readme for the deployer package.