### PR TITLE
Affiliate check of amount not address

### DIFF
--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -155,7 +155,7 @@ contract Swap is ISwap {
     );
 
     // Transfer token from signer to affiliate if specified.
-    if (order.affiliate.wallet != address(0)) {
+    if (order.affiliate.amount != 0) {
       transferToken(
         order.signer.wallet,
         order.affiliate.wallet,


### PR DESCRIPTION
## Description

When we create trades on airswap trader we fill in the affiliate address so that we can track how many trades were originated by airswap. The token and amount are left as 0. This fails on the contracts as an empty affiliate was checked using `address(0)`.
