### PR TITLE
Update locator function

### DIFF
--- a/source/indexer/contracts/Index.sol
+++ b/source/indexer/contracts/Index.sol
@@ -110,6 +110,16 @@ contract Index is Ownable {
     emit UnsetLocator(identifier);
   }
 
+  function updateLocator(
+    address identifier,
+    uint256 score,
+    bytes32 locator
+  ) external onlyOwner {
+    // Don't need to update length as it is not used in set/unset logic
+    _unsetLocator(identifier);
+    _setLocator(identifier, score, locator);
+  }
+
   /**
     * @notice Get a Score
     * @param identifier address On-chain address identifying the owner of a locator

--- a/source/indexer/contracts/Index.sol
+++ b/source/indexer/contracts/Index.sol
@@ -66,6 +66,12 @@ contract Index is Ownable {
     address indexed identifier
   );
 
+  event UpdateLocator(
+    address indexed identifier,
+    uint256 score,
+    bytes32 indexed locator
+  );
+
   /**
     * @notice Contract Constructor
     */
@@ -110,6 +116,13 @@ contract Index is Ownable {
     emit UnsetLocator(identifier);
   }
 
+  /**
+    * @notice Update a Locator
+    * @dev score and/or locator do not need to be different from old values
+    * @param identifier address On-chain address identifying the owner of a locator
+    * @param score uint256 Score for the locator being set
+    * @param locator bytes32 Locator
+    */
   function updateLocator(
     address identifier,
     uint256 score,
@@ -118,6 +131,8 @@ contract Index is Ownable {
     // Don't need to update length as it is not used in set/unset logic
     _unsetLocator(identifier);
     _setLocator(identifier, score, locator);
+
+    emit UpdateLocator(identifier, score, locator)
   }
 
   /**
@@ -192,6 +207,12 @@ contract Index is Ownable {
     return (locators, scores, identifier);
   }
 
+  /**
+    * @notice Internal function to set a Locator
+    * @param identifier address On-chain address identifying the owner of a locator
+    * @param score uint256 Score for the locator being set
+    * @param locator bytes32 Locator
+    */
   function _setLocator(
     address identifier,
     uint256 score,
@@ -210,6 +231,10 @@ contract Index is Ownable {
     entries[identifier] = Entry(locator, score, prevEntry, nextEntry);
   }
 
+  /**
+    * @notice Internal function to unset a Locator
+    * @param identifier address On-chain address identifying the owner of a locator
+    */
   function _unsetLocator(
     address identifier
   ) internal {

--- a/source/indexer/contracts/Index.sol
+++ b/source/indexer/contracts/Index.sol
@@ -126,7 +126,7 @@ contract Index is Ownable {
     _unsetLocator(identifier);
     _setLocator(identifier, score, locator);
 
-    emit SetLocator(identifier, score, locator)
+    emit SetLocator(identifier, score, locator);
   }
 
   /**

--- a/source/indexer/contracts/Index.sol
+++ b/source/indexer/contracts/Index.sol
@@ -66,12 +66,6 @@ contract Index is Ownable {
     address indexed identifier
   );
 
-  event UpdateLocator(
-    address indexed identifier,
-    uint256 score,
-    bytes32 indexed locator
-  );
-
   /**
     * @notice Contract Constructor
     */
@@ -132,7 +126,7 @@ contract Index is Ownable {
     _unsetLocator(identifier);
     _setLocator(identifier, score, locator);
 
-    emit UpdateLocator(identifier, score, locator)
+    emit SetLocator(identifier, score, locator)
   }
 
   /**

--- a/source/indexer/contracts/Indexer.sol
+++ b/source/indexer/contracts/Indexer.sol
@@ -265,9 +265,8 @@ contract Indexer is IIndexer, Ownable {
       require(stakingToken.transfer(user, oldAmount - newAmount));
     }
 
-    // Unset their old intent, and set their new intent.
-    indexes[signerToken][senderToken][protocol].unsetLocator(user);
-    indexes[signerToken][senderToken][protocol].setLocator(user, newAmount, newLocator);
+    // Update their intent.
+    indexes[signerToken][senderToken][protocol].updateLocator(user, newAmount, newLocator);
 
     emit Stake(user, signerToken, senderToken, protocol, newAmount);
   }

--- a/source/indexer/test/Index-unit.js
+++ b/source/indexer/test/Index-unit.js
@@ -244,7 +244,7 @@ contract('Index Unit Tests', async accounts => {
 
     it('should allow an entry to be updated by the owner', async () => {
       // set an entry from the owner
-      let result = await index.setLocator(aliceAddress, 2000, aliceLocator, {
+      let result = await index.setLocator(aliceAddress, 2000, bobLocator, {
         from: owner,
       })
 
@@ -253,12 +253,12 @@ contract('Index Unit Tests', async accounts => {
         return (
           event.identifier === aliceAddress &&
           event.score.toNumber() === 2000 &&
-          event.locator === aliceLocator
+          event.locator === bobLocator
         )
       })
 
       // now update the locator
-      result = await index.updateLocator(aliceAddress, 200, bobLocator, {
+      result = await index.updateLocator(aliceAddress, 200, aliceLocator, {
         from: owner,
       })
 
@@ -267,7 +267,7 @@ contract('Index Unit Tests', async accounts => {
         return (
           event.identifier === aliceAddress &&
           event.score.toNumber() === 200 &&
-          event.locator === bobLocator
+          event.locator === aliceLocator
         )
       })
 
@@ -275,7 +275,7 @@ contract('Index Unit Tests', async accounts => {
       result = await index.getLocators(EMPTY_ADDRESS, 10)
 
       equal(result[LOCATORS].length, 1, 'locators list should have 1 slots')
-      equal(result[LOCATORS][0], bobLocator, 'Alice should be in list')
+      equal(result[LOCATORS][0], aliceLocator, 'Alice should be in list')
 
       equal(result[SCORES].length, 1, 'scores list should have 1 slots')
       equal(result[SCORES][0], 200, 'Alices score is incorrect')
@@ -285,6 +285,36 @@ contract('Index Unit Tests', async accounts => {
       // check the length has increased
       const listLength = await index.length()
       equal(listLength, 1, 'list length should be 1')
+    })
+
+    it('should update the list order on updated score', async () => {
+      // set an entry from the owner
+      await index.setLocator(aliceAddress, 2000, aliceLocator, {
+        from: owner,
+      })
+      // set an entry from the owner
+      await index.setLocator(bobAddress, 1000, bobLocator, {
+        from: owner,
+      })
+
+      // Check its been updated correctly
+      result = await index.getLocators(EMPTY_ADDRESS, 10)
+
+      equal(result[LOCATORS].length, 2, 'locators list should have 2 slots')
+      equal(result[LOCATORS][0], aliceLocator, 'Alice should be first in list')
+      equal(result[LOCATORS][1], bobLocator, 'Bob should be second in list')
+
+      // now update the locator for alice to a lower score
+      await index.updateLocator(aliceAddress, 500, aliceLocator, {
+        from: owner,
+      })
+
+      result = await index.getLocators(EMPTY_ADDRESS, 10)
+
+      // Alice is now AFTER Bob
+      equal(result[LOCATORS].length, 2, 'locators list should have 2 slots')
+      equal(result[LOCATORS][0], bobLocator, 'Bob should be first in list')
+      equal(result[LOCATORS][1], aliceLocator, 'Alice should be second in list')
     })
   })
 


### PR DESCRIPTION
## Description

Adding an update locator function to the index to avoid emitting `UnsetLocator` and `SetLocator` every time an update occurs.

Quick description:

- [ ] N/A
- [X] New features
- [ ] Bug fixes
- [ ] Typo/small tweaks

## Changes

- Common setLocator and unsetLocator logic pulled out into internal functions
- Index.updateLocator function added
- Index unit test for this function

## Tests
  106 passing (18s)

## Test Coverage
```
------------------------|----------|----------|----------|----------|----------------|
File                    |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
------------------------|----------|----------|----------|----------|----------------|
 contracts/             |      100 |      100 |      100 |      100 |                |
  Imports.sol           |      100 |      100 |      100 |      100 |                |
  Index.sol             |      100 |      100 |      100 |      100 |                |
  Indexer.sol           |      100 |      100 |      100 |      100 |                |
 contracts/interfaces/  |      100 |      100 |      100 |      100 |                |
  IIndexer.sol          |      100 |      100 |      100 |      100 |                |
  ILocatorWhitelist.sol |      100 |      100 |      100 |      100 |                |
------------------------|----------|----------|----------|----------|----------------|
All files               |      100 |      100 |      100 |      100 |                |
------------------------|----------|----------|----------|----------|----------------|
```