### PR TITLE
Adding signature check and more tests to order-utils

### DIFF
--- a/source/delegate/package.json
+++ b/source/delegate/package.json
@@ -27,7 +27,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.18",
+    "@airswap/order-utils": "0.3.19",
     "@airswap/test-utils": "0.1.4",
     "@airswap/transfers": "0.0.2",
     "solidity-coverage": "^0.6.3"

--- a/source/indexer/package.json
+++ b/source/indexer/package.json
@@ -27,7 +27,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.18",
+    "@airswap/order-utils": "0.3.19",
     "@airswap/test-utils": "0.1.4",
     "@airswap/transfers": "0.0.2",
     "@airswap/types": "2.4.5",

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -27,7 +27,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.18",
+    "@airswap/order-utils": "0.3.19",
     "@airswap/test-utils": "0.1.4",
     "@airswap/tokens": "0.1.4",
     "solidity-coverage": "^0.6.3",

--- a/source/transfers/package.json
+++ b/source/transfers/package.json
@@ -17,7 +17,7 @@
     "test": "truffle test"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.18",
+    "@airswap/order-utils": "0.3.19",
     "@airswap/test-utils": "0.1.4",
     "@airswap/tokens": "0.1.4",
     "solidity-coverage": "^0.6.3"

--- a/source/types/package.json
+++ b/source/types/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@airswap/tokens": "0.1.4",
-    "@airswap/order-utils": "0.3.18",
+    "@airswap/order-utils": "0.3.19",
     "solidity-coverage": "^0.6.3"
   },
   "dependencies": {

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -28,7 +28,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.18",
+    "@airswap/order-utils": "0.3.19",
     "@airswap/test-utils": "0.1.4",
     "@airswap/indexer": "3.6.8",
     "solidity-coverage": "^0.6.3"

--- a/utils/debugger/package.json
+++ b/utils/debugger/package.json
@@ -21,7 +21,7 @@
     "mocha": "^6.2.0"
   },
   "dependencies": {
-    "@airswap/order-utils": "0.3.18",
+    "@airswap/order-utils": "0.3.19",
     "@airswap/swap": "4.3.6",
     "@airswap/tokens": "0.1.4",
     "ethers": "^5.0.0-beta.159"

--- a/utils/debugger/src/check-order.js
+++ b/utils/debugger/src/check-order.js
@@ -20,8 +20,7 @@ const checkOrder = async (order, network) => {
 
   // Check the order has all necessary fields
   if (!orders.isValidOrder(order)) {
-    errors.push('Order structured incorrectly')
-    return errors
+    errors.push('Order structured incorrectly or signature invalid')
   }
 
   // Check swap address provided
@@ -69,7 +68,7 @@ const checkOrder = async (order, network) => {
 
 const checkOrderSignature = async (order, provider, errors) => {
   // Check signature is valid
-  const isValid = signatures.isSignatureValid(order)
+  const isValid = signatures.hasValidSignature(order)
   if (!isValid) {
     errors.push('Signature invalid')
   }

--- a/utils/debugger/src/check-order.js
+++ b/utils/debugger/src/check-order.js
@@ -26,7 +26,6 @@ const checkOrder = async (order, network) => {
   // Check swap address provided
   if (order['signature']['validator'] == EMPTY_ADDRESS) {
     errors.push('Order.signature.validator cannot be 0')
-    return errors
   }
 
   // Check signer balance and allowance

--- a/utils/debugger/test/check-order.js
+++ b/utils/debugger/test/check-order.js
@@ -256,6 +256,7 @@ describe('Orders', async () => {
     const errors = await checker.checkOrder(order, 'rinkeby')
 
     assert.equal(errors.length, 3)
+    assert.equal(errors[0], 'Order structured incorrectly or signature invalid')
     assert.equal(errors[1], 'sender no NFT approval')
     assert.equal(errors[2], 'signer is not configured to receive NFTs')
   })

--- a/utils/debugger/test/check-order.js
+++ b/utils/debugger/test/check-order.js
@@ -12,7 +12,6 @@ const checker = require('../src/check-order')
 
 describe('Orders', async () => {
   const senderWallet = '0xbabe31056c0fe1b704d811b2405f6e9f5ae5e59d'
-  const signerWallet = '0x9d2fb0bcc90c6f3fa3a98d2c760623a4f6ee59b4'
 
   // Owns a crypto kitty
   const kittyWallet = '0x7F18BB4Dd92CF2404C54CBa1A9BE4A1153bdb078'

--- a/utils/debugger/test/check-order.js
+++ b/utils/debugger/test/check-order.js
@@ -32,25 +32,6 @@ describe('Orders', async () => {
   const INVALID_KIND = '0xFFFFFF'
   orders.setVerifyingContract(rinkebySwap)
 
-  it('Check correct order without signature', async () => {
-    const order = await orders.getOrder({
-      expiry: NOV_7_2020_22_18_14,
-      nonce: '0',
-      signer: {
-        wallet: signerWallet,
-        token: ASTAddress,
-        amount: '0',
-      },
-      sender: {
-        wallet: senderWallet,
-        token: WETHAddress,
-        amount: '0',
-      },
-    })
-    const errors = await checker.checkOrder(order, 'rinkeby')
-    assert.equal(errors.length, 0)
-  })
-
   it('Check correct order with signature', async () => {
     const order = await orders.getOrder({
       expiry: NOV_7_2020_22_18_14,
@@ -131,8 +112,9 @@ describe('Orders', async () => {
 
     order.signature.v -= 1
     const errors = await checker.checkOrder(order, 'rinkeby')
-    assert.equal(errors.length, 2)
-    assert.equal(errors[1], 'Signature invalid')
+
+    assert.equal(errors.length, 3)
+    assert.equal(errors[2], 'Signature invalid')
   })
 
   it('Check order without allowance', async () => {
@@ -274,9 +256,9 @@ describe('Orders', async () => {
 
     const errors = await checker.checkOrder(order, 'rinkeby')
 
-    assert.equal(errors.length, 2)
-    assert.equal(errors[0], 'sender no NFT approval')
-    assert.equal(errors[1], 'signer is not configured to receive NFTs')
+    assert.equal(errors.length, 3)
+    assert.equal(errors[1], 'sender no NFT approval')
+    assert.equal(errors[2], 'signer is not configured to receive NFTs')
   })
 
   it('Check NFT order to a valid contract', async () => {
@@ -300,8 +282,8 @@ describe('Orders', async () => {
     const errors = await checker.checkOrder(order, 'rinkeby')
 
     // length 1 showing the contract was accepted
-    assert.equal(errors.length, 1)
-    assert.equal(errors[0], 'sender no NFT approval')
+    assert.equal(errors.length, 2)
+    assert.equal(errors[1], 'sender no NFT approval')
   })
 
   it('Check order without balance', async () => {

--- a/utils/deployer/package.json
+++ b/utils/deployer/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@airswap/tokens": "0.1.4",
-    "@airswap/order-utils": "0.3.18",
+    "@airswap/order-utils": "0.3.19",
     "@airswap/test-utils": "0.1.4",
     "solidity-docgen": "0.3.0-beta.3"
   },

--- a/utils/order-utils/package.json
+++ b/utils/order-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/order-utils",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "JavaScript utilities for orders, hashes, and signatures on the AirSwap Network",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",

--- a/utils/order-utils/src/orders.js
+++ b/utils/order-utils/src/orders.js
@@ -21,11 +21,14 @@ const signatures = require('./signatures')
 let nonce = 100
 
 const getLatestTimestamp = async () => {
-  return (await web3.eth.getBlock('latest')).timestamp
+  if (typeof web3 !== 'undefined') {
+    return (await web3.eth.getBlock('latest')).timestamp
+  }
+  return new Date().getTime() / 1000
 }
 
 const isValidOrder = order => {
-  return (
+  if (
     'nonce' in order &&
     'expiry' in order &&
     'signer' in order &&
@@ -49,7 +52,10 @@ const isValidOrder = order => {
     'r' in order['signature'] &&
     's' in order['signature'] &&
     'v' in order['signature']
-  )
+  ) {
+    return signatures.isSignatureValid(order)
+  }
+  return false
 }
 
 function lowerCaseAddresses(order) {

--- a/utils/order-utils/src/orders.js
+++ b/utils/order-utils/src/orders.js
@@ -53,7 +53,7 @@ const isValidOrder = order => {
     's' in order['signature'] &&
     'v' in order['signature']
   ) {
-    return signatures.isSignatureValid(order)
+    return signatures.hasValidSignature(order)
   }
   return false
 }

--- a/utils/order-utils/src/signatures.js
+++ b/utils/order-utils/src/signatures.js
@@ -117,12 +117,17 @@ module.exports = {
     const prefixedOrderHash = ethUtil.keccak256(
       Buffer.concat([prefix, Buffer.from(String(orderHash.length)), orderHash])
     )
-    const signingPubKey = ethUtil.ecrecover(
-      prefixedOrderHash,
-      signature['v'],
-      signature['r'],
-      signature['s']
-    )
+    let signingPubKey
+    try {
+      signingPubKey = ethUtil.ecrecover(
+        prefixedOrderHash,
+        signature['v'],
+        signature['r'],
+        signature['s']
+      )
+    } catch (e) {
+      return false
+    }
     const signingAddress = ethUtil.bufferToHex(
       ethUtil.pubToAddress(signingPubKey)
     )

--- a/utils/order-utils/src/signatures.js
+++ b/utils/order-utils/src/signatures.js
@@ -110,17 +110,23 @@ module.exports = {
       s: '0x0',
     }
   },
-  isSignatureValid(order) {
+  hasValidSignature(order) {
     const signature = order['signature']
-    const orderHash = hashes.getOrderHash(order, signature['validator'])
-    const prefix = Buffer.from('\x19Ethereum Signed Message:\n')
-    const prefixedOrderHash = ethUtil.keccak256(
-      Buffer.concat([prefix, Buffer.from(String(orderHash.length)), orderHash])
-    )
+    let orderHash = hashes.getOrderHash(order, signature['validator'])
+    if (signature.version === '0x45') {
+      const prefix = Buffer.from('\x19Ethereum Signed Message:\n')
+      orderHash = ethUtil.keccak256(
+        Buffer.concat([
+          prefix,
+          Buffer.from(String(orderHash.length)),
+          orderHash,
+        ])
+      )
+    }
     let signingPubKey
     try {
       signingPubKey = ethUtil.ecrecover(
-        prefixedOrderHash,
+        orderHash,
         signature['v'],
         signature['r'],
         signature['s']

--- a/utils/order-utils/test/orders.js
+++ b/utils/order-utils/test/orders.js
@@ -1,36 +1,61 @@
 var expect = require('chai').expect
 
-const { orders } = require('@airswap/order-utils')
+const { orders, signatures } = require('@airswap/order-utils')
 
 describe('Orders', async () => {
-  const senderWallet = '0xbabe31056c0fe1b704d811b2405f6e9f5ae5e59d'
-  const signerWallet = '0x9d2fb0bcc90c6f3fa3a98d2c760623a4f6ee59b4'
-
-  // rinkeby addresses
-  const ASTAddress = '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8'
-  const WETHAddress = '0xc778417e063141139fce010982780140aa0cd5ab'
+  const signerPrivKey = Buffer.from(
+    '4934d4ff925f39f91e3729fbce52ef12f25fdf93e014e291350f7d314c1a096b',
+    'hex'
+  )
 
   const rinkebySwap = '0x43f18D371f388ABE40b9dDaac44D1C9c9185a078'
 
-  const MAY_11_2017_00_00_00 = '1494460800'
-
   orders.setVerifyingContract(rinkebySwap)
 
-  it('Checks that a generated order is valid', async () => {
+  it('Checks that a signed order is valid', async () => {
     const order = await orders.getOrder({
-      expiry: MAY_11_2017_00_00_00,
-      nonce: '101',
-      signer: {
-        wallet: signerWallet,
-        token: ASTAddress,
-        amount: '0',
-      },
-      sender: {
-        wallet: senderWallet,
-        token: WETHAddress,
-        amount: '0',
-      },
+      nonce: '1',
     })
+    order.signature = signatures.getPersonalSignature(
+      order,
+      signerPrivKey,
+      rinkebySwap
+    )
     expect(orders.isValidOrder(order)).to.equal(true)
+  })
+
+  it('Checks that an unsigned order is invalid', async () => {
+    const order = await orders.getOrder({
+      nonce: '2',
+    })
+    expect(orders.isValidOrder(order)).to.equal(false)
+  })
+
+  it('Checks that an incorrectly signed order is invalid', async () => {
+    const order = await orders.getOrder({
+      nonce: '3',
+    })
+    order.signature = signatures.getPersonalSignature(
+      await orders.getOrder({}),
+      signerPrivKey,
+      rinkebySwap
+    )
+    expect(orders.isValidOrder(order)).to.equal(false)
+  })
+
+  it('Checks that an order missing sender wallet is invalid', async () => {
+    const order = await orders.getOrder({
+      nonce: '4',
+    })
+    delete order.sender.wallet
+    expect(orders.isValidOrder(order)).to.equal(false)
+  })
+
+  it('Checks that an order missing affiliate is invalid', async () => {
+    const order = await orders.getOrder({
+      nonce: '5',
+    })
+    delete order.affiliate
+    expect(orders.isValidOrder(order)).to.equal(false)
   })
 })

--- a/utils/order-utils/test/signatures.js
+++ b/utils/order-utils/test/signatures.js
@@ -31,13 +31,14 @@ describe('Signatures', async () => {
       },
     })
 
-    const signature = signatures.getPersonalSignature(
+    order.signature = signatures.getPersonalSignature(
       order,
       signerPrivKey,
       swapAddress
     )
 
-    expect(signature).to.deep.include({
+    expect(signatures.hasValidSignature(order)).to.equal(true)
+    expect(order.signature).to.deep.include({
       version: '0x45',
       signatory: signerWallet,
       r: Buffer.from(
@@ -71,13 +72,14 @@ describe('Signatures', async () => {
       true
     )
 
-    const signature = signatures.getTypedDataSignature(
+    order.signature = signatures.getTypedDataSignature(
       order,
       signerPrivKey,
       swapAddress
     )
 
-    expect(signature).to.deep.include({
+    expect(signatures.hasValidSignature(order)).to.equal(true)
+    expect(order.signature).to.deep.include({
       version: '0x01',
       signatory: signerWallet,
       r: Buffer.from(

--- a/utils/pre-swap-checker/package.json
+++ b/utils/pre-swap-checker/package.json
@@ -25,7 +25,7 @@
     "openzeppelin-solidity": "2.4"
   },
   "devDependencies": {
-    "@airswap/order-utils": "0.3.18",
+    "@airswap/order-utils": "0.3.19",
     "@airswap/test-utils": "0.1.4",
     "chai": "^4.2.0"
   }


### PR DESCRIPTION
- `orders.isValidOrder` now includes a call to `signatures.hasValidSignature`
- Adding tests to cover more variety of invalidity