### PR TITLE
add a delegate swap check

### DIFF
--- a/utils/pre-swap-checker/contracts/Imports.sol
+++ b/utils/pre-swap-checker/contracts/Imports.sol
@@ -4,7 +4,6 @@ import "@airswap/tokens/contracts/FungibleToken.sol";
 import "@airswap/tokens/contracts/NonFungibleToken.sol";
 import "@airswap/tokens/contracts/WETH9.sol";
 import "@airswap/swap/contracts/Swap.sol";
-import "@airswap/transfers/contracts/TransferHandlerRegistry.sol";
 import "@airswap/transfers/contracts/handlers/ERC20TransferHandler.sol";
 import "@airswap/transfers/contracts/handlers/ERC721TransferHandler.sol";
 import "@airswap/wrapper/contracts/Wrapper.sol";

--- a/utils/pre-swap-checker/contracts/Imports.sol
+++ b/utils/pre-swap-checker/contracts/Imports.sol
@@ -8,5 +8,7 @@ import "@airswap/transfers/contracts/TransferHandlerRegistry.sol";
 import "@airswap/transfers/contracts/handlers/ERC20TransferHandler.sol";
 import "@airswap/transfers/contracts/handlers/ERC721TransferHandler.sol";
 import "@airswap/wrapper/contracts/Wrapper.sol";
+import "@airswap/indexer/contracts/Indexer.sol";
+import "@airswap/delegate/contracts/Delegate.sol";
 
 contract Imports {}

--- a/utils/pre-swap-checker/contracts/PreSwapChecker.sol
+++ b/utils/pre-swap-checker/contracts/PreSwapChecker.sol
@@ -96,7 +96,17 @@ contract PreSwapChecker {
     }
 
     if (order.sender.amount > rule.maxSenderAmount) {
-      errors[errorCount] = "AMOUNT_EXCEEDS_MAX";
+      errors[errorCount] = "ORDER_AMOUNT_EXCEEDS_MAX";
+      errorCount++;
+    }
+
+    // calls the getSenderSize quote to determine how much needs to be paid
+    uint256 senderAmount = delegate.getSenderSideQuote(order.signer.amount, order.signer.token, order.sender.token);
+    if (senderAmount == 0) {
+      errors[errorCount] = "DELEGATE_UNABLE_TO_PRICE";
+      errorCount++;
+    } else if (order.sender.amount > senderAmount) {
+      errors[errorCount] = "PRICE_INVALID";
       errorCount++;
     }
 

--- a/utils/pre-swap-checker/contracts/PreSwapChecker.sol
+++ b/utils/pre-swap-checker/contracts/PreSwapChecker.sol
@@ -65,7 +65,7 @@ contract PreSwapChecker {
       }
     }
 
-    // signature must be filled in order to use the Wrapper
+    // signature must be filled in order to use the Delegate
     if (order.signature.v == 0) {
       errors[errorCount] = "SIGNATURE_MUST_BE_SENT";
       errorCount++;

--- a/utils/pre-swap-checker/contracts/PreSwapChecker.sol
+++ b/utils/pre-swap-checker/contracts/PreSwapChecker.sol
@@ -8,7 +8,6 @@ import "openzeppelin-solidity/contracts/introspection/ERC165Checker.sol";
 import "@airswap/swap/contracts/interfaces/ISwap.sol";
 import "@airswap/transfers/contracts/TransferHandlerRegistry.sol";
 import "@airswap/tokens/contracts/interfaces/IWETH.sol";
-import "@airswap/wrapper/contracts/Wrapper.sol";
 import "@airswap/delegate/contracts/interfaces/IDelegate.sol";
 
 /**

--- a/utils/pre-swap-checker/package.json
+++ b/utils/pre-swap-checker/package.json
@@ -23,13 +23,13 @@
     "@airswap/tokens": "0.1.4",
     "@airswap/types": "2.4.5",
     "openzeppelin-solidity": "2.4",
-    "@airswap/wrapper": "2.5.7",
-    "@airswap/delegate": "1.5.7",
-    "@airswap/indexer": "3.6.8"
+    "@airswap/delegate": "1.5.7"
   },
   "devDependencies": {
     "@airswap/order-utils": "0.3.19",
     "@airswap/test-utils": "0.1.4",
-    "solidity-coverage": "^0.6.3"
+    "solidity-coverage": "^0.6.3",
+    "@airswap/wrapper": "2.5.7",
+    "@airswap/indexer": "3.6.8"
   }
 }

--- a/utils/pre-swap-checker/package.json
+++ b/utils/pre-swap-checker/package.json
@@ -23,7 +23,8 @@
     "@airswap/tokens": "0.1.4",
     "@airswap/types": "2.4.5",
     "openzeppelin-solidity": "2.4",
-    "@airswap/wrapper": "2.5.7"
+    "@airswap/wrapper": "2.5.7",
+    "@airswap/delegate": "1.5.7"
   },
   "devDependencies": {
     "@airswap/order-utils": "0.3.19",

--- a/utils/pre-swap-checker/package.json
+++ b/utils/pre-swap-checker/package.json
@@ -24,7 +24,8 @@
     "@airswap/types": "2.4.5",
     "openzeppelin-solidity": "2.4",
     "@airswap/wrapper": "2.5.7",
-    "@airswap/delegate": "1.5.7"
+    "@airswap/delegate": "1.5.7",
+    "@airswap/indexer": "3.6.8"
   },
   "devDependencies": {
     "@airswap/order-utils": "0.3.19",

--- a/utils/pre-swap-checker/test/PreDelegateChecker.js
+++ b/utils/pre-swap-checker/test/PreDelegateChecker.js
@@ -112,7 +112,7 @@ contract('PreSwapChecker', async accounts => {
   })
 
   describe('Approving...', async () => {
-    it('Checks approvals (Alice 250 AST and 0 DAI, Bob 0 AST and 500 DAI)', async () => {
+    it('Checks approvals (Alice 400 AST and 0 DAI, Bob 0 AST and 1000 DAI)', async () => {
       emitted(
         await tokenAST.approve(swapAddress, 400, { from: aliceTradeWallet }),
         'Approval'

--- a/utils/pre-swap-checker/test/PreDelegateChecker.js
+++ b/utils/pre-swap-checker/test/PreDelegateChecker.js
@@ -1,0 +1,321 @@
+const Swap = artifacts.require('Swap')
+const Types = artifacts.require('Types')
+const Indexer = artifacts.require('Indexer')
+const Delegate = artifacts.require('Delegate')
+const PreSwapChecker = artifacts.require('PreSwapChecker')
+const TransferHandlerRegistry = artifacts.require('TransferHandlerRegistry')
+const ERC20TransferHandler = artifacts.require('ERC20TransferHandler')
+const FungibleToken = artifacts.require('FungibleToken')
+const WETH9 = artifacts.require('WETH9')
+
+const { emitted, equal, reverted, ok } = require('@airswap/test-utils').assert
+const { allowances, balances } = require('@airswap/test-utils').balances
+const { orders, signatures } = require('@airswap/order-utils')
+const {
+  ERC20_INTERFACE_ID,
+  GANACHE_PROVIDER,
+} = require('@airswap/order-utils').constants
+
+contract('PreSwapChecker', async accounts => {
+  const aliceAddress = accounts[0]
+  const bobAddress = accounts[1]
+  const aliceTradeWallet = accounts[4]
+  const PROTOCOL = '0x0002'
+  const UNKNOWN_KIND = '0x1234'
+  let preSwapChecker
+  let aliceDelegate
+  let swapContract
+  let swapAddress
+
+  let indexer
+
+  let tokenAST
+  let tokenDAI
+  let tokenWETH
+  let typesLib
+  let errorCodes
+
+  describe('Deploying...', async () => {
+    it('Deployed Swap contract', async () => {
+      typesLib = await Types.new()
+      await Swap.link('Types', typesLib.address)
+
+      const erc20TransferHandler = await ERC20TransferHandler.new()
+      const transferHandlerRegistry = await TransferHandlerRegistry.new()
+      await transferHandlerRegistry.addTransferHandler(
+        ERC20_INTERFACE_ID,
+        erc20TransferHandler.address
+      )
+
+      // now deploy swap
+      swapContract = await Swap.new(transferHandlerRegistry.address)
+      swapAddress = swapContract.address
+
+      orders.setVerifyingContract(swapAddress)
+    })
+
+    it('Deployed test contract "WETH"', async () => {
+      tokenWETH = await WETH9.new()
+    })
+
+    it('Deployed SwapChecker contract', async () => {
+      await PreSwapChecker.link('Types', typesLib.address)
+      preSwapChecker = await PreSwapChecker.new(tokenWETH.address)
+    })
+
+    it('Deployed test contract "AST"', async () => {
+      tokenAST = await FungibleToken.new()
+    })
+
+    it('Deployed test contract "DAI"', async () => {
+      tokenDAI = await FungibleToken.new()
+    })
+
+    it('Deployed Indexer token with AST as staking and AST/DAI index created', async () => {
+      indexer = await Indexer.new(tokenAST.address)
+      await indexer.createIndex(tokenAST.address, tokenDAI.address, PROTOCOL)
+    })
+
+    it('Deployed Delegate for Alice address AST indexer', async () => {
+      aliceDelegate = await Delegate.new(
+        swapAddress,
+        indexer.address,
+        aliceAddress,
+        aliceTradeWallet,
+        PROTOCOL
+      )
+    })
+  })
+
+  describe('Minting...', async () => {
+    it('Mints 1000 AST for Alice', async () => {
+      emitted(await tokenAST.mint(aliceTradeWallet, 1000), 'Transfer')
+      ok(
+        await balances(aliceTradeWallet, [
+          [tokenAST, 1000],
+          [tokenDAI, 0],
+        ]),
+        'Alice balances are incorrect'
+      )
+    })
+
+    it('Mints 1000 DAI for Bob', async () => {
+      emitted(await tokenDAI.mint(bobAddress, 1000), 'Transfer')
+      ok(
+        await balances(bobAddress, [
+          [tokenAST, 0],
+          [tokenDAI, 1000],
+        ]),
+        'Bob balances are incorrect'
+      )
+    })
+  })
+
+  describe('Approving...', async () => {
+    it('Checks approvals (Alice 250 AST and 0 DAI, Bob 0 AST and 500 DAI)', async () => {
+      emitted(
+        await tokenAST.approve(swapAddress, 400, { from: aliceTradeWallet }),
+        'Approval'
+      )
+      emitted(
+        await tokenDAI.approve(swapAddress, 1000, { from: bobAddress }),
+        'Approval'
+      )
+      ok(
+        await allowances(aliceTradeWallet, swapAddress, [
+          [tokenAST, 400],
+          [tokenDAI, 0],
+        ])
+      )
+      ok(
+        await allowances(bobAddress, swapAddress, [
+          [tokenAST, 0],
+          [tokenDAI, 1000],
+        ])
+      )
+    })
+  })
+
+  describe('Delegate Swaps interacting with Alice Delegate', async () => {
+    let order
+
+    before('Alice creates an order for Bob (200 AST for 50 DAI)', async () => {
+      order = await orders.getOrder({
+        sender: {
+          wallet: aliceTradeWallet,
+          token: tokenAST.address,
+          amount: 200,
+        },
+        signer: {
+          wallet: bobAddress,
+          token: tokenDAI.address,
+          amount: 50,
+        },
+      })
+
+      order.signature = await signatures.getWeb3Signature(
+        order,
+        bobAddress,
+        swapAddress,
+        GANACHE_PROVIDER
+      )
+    })
+
+    it('Checks fillable swap order to delegate without a rule', async () => {
+      const checkerOutput = await preSwapChecker.checkSwapDelegate.call(
+        order,
+        aliceDelegate.address,
+        {
+          from: bobAddress,
+        }
+      )
+      equal(web3.utils.toUtf8(checkerOutput[1][0]), 'TOKEN_PAIR_INACTIVE')
+      equal(web3.utils.toUtf8(checkerOutput[1][1]), 'ORDER_AMOUNT_EXCEEDS_MAX')
+      equal(web3.utils.toUtf8(checkerOutput[1][2]), 'DELEGATE_UNABLE_TO_PRICE')
+      equal(web3.utils.toUtf8(checkerOutput[1][3]), 'SENDER_UNAUTHORIZED')
+      equal(checkerOutput[0], 4)
+    })
+
+    it('Checks maximum delegate error generation for swap delegate', async () => {
+      const selfOrder = await orders.getOrder({
+        signer: {
+          wallet: aliceAddress,
+          token: tokenAST.address,
+          amount: 200,
+          kind: UNKNOWN_KIND,
+        },
+        sender: {
+          wallet: bobAddress,
+          token: tokenAST.address,
+          amount: 50,
+          kind: UNKNOWN_KIND,
+        },
+      })
+
+      errorCodes = await preSwapChecker.checkSwapDelegate.call(
+        selfOrder,
+        aliceDelegate.address,
+        {
+          from: bobAddress,
+        }
+      )
+      equal(errorCodes[0].toNumber(), 11)
+      equal(web3.utils.toUtf8(errorCodes[1][0]), 'SENDER_TOKEN_KIND_UNKNOWN')
+      equal(web3.utils.toUtf8(errorCodes[1][1]), 'SIGNER_TOKEN_KIND_UNKNOWN')
+      equal(web3.utils.toUtf8(errorCodes[1][2]), 'SIGNER_UNAUTHORIZED')
+      equal(web3.utils.toUtf8(errorCodes[1][3]), 'SIGNATURE_MUST_BE_SENT')
+      equal(web3.utils.toUtf8(errorCodes[1][4]), 'SENDER_WALLET_INVALID')
+      equal(web3.utils.toUtf8(errorCodes[1][5]), 'SIGNER_KIND_MUST_BE_ERC20')
+      equal(web3.utils.toUtf8(errorCodes[1][6]), 'SENDER_KIND_MUST_BE_ERC20')
+      equal(web3.utils.toUtf8(errorCodes[1][7]), 'TOKEN_PAIR_INACTIVE')
+      equal(web3.utils.toUtf8(errorCodes[1][8]), 'ORDER_AMOUNT_EXCEEDS_MAX')
+      equal(web3.utils.toUtf8(errorCodes[1][9]), 'DELEGATE_UNABLE_TO_PRICE')
+      equal(web3.utils.toUtf8(errorCodes[1][10]), 'SENDER_UNAUTHORIZED')
+    })
+
+    it('Create a rule and ensure appropriate approvals gets zero error codes', async () => {
+      const order = await orders.getOrder({
+        sender: {
+          wallet: aliceTradeWallet,
+          token: tokenAST.address,
+          amount: 200,
+        },
+        signer: {
+          wallet: bobAddress,
+          token: tokenDAI.address,
+          amount: 50,
+        },
+      })
+
+      order.signature = await signatures.getWeb3Signature(
+        order,
+        bobAddress,
+        swapAddress,
+        GANACHE_PROVIDER
+      )
+
+      // create a rule for AST/DAI for alice
+      await aliceDelegate.setRule(
+        tokenAST.address,
+        tokenDAI.address,
+        1000,
+        25,
+        2,
+        { from: aliceAddress }
+      )
+
+      // Bob authorizes swap to send orders on his behalf
+      // function also checks that msg.sender == order.sender.wallet
+      await swapContract.authorizeSender(aliceDelegate.address, {
+        from: aliceTradeWallet,
+      })
+
+      errorCodes = await preSwapChecker.checkSwapDelegate.call(
+        order,
+        aliceDelegate.address,
+        {
+          from: bobAddress,
+        }
+      )
+      equal(errorCodes[0], 0)
+      // ensure that the order then succeeds
+      emitted(
+        await aliceDelegate.provideOrder(order, { from: bobAddress }),
+        'ProvideOrder'
+      )
+    })
+
+    it('Create a rule and ensure appropriate approvals but put in an invalid price', async () => {
+      const order = await orders.getOrder({
+        sender: {
+          wallet: aliceTradeWallet,
+          token: tokenAST.address,
+          amount: 200,
+        },
+        signer: {
+          wallet: bobAddress,
+          token: tokenDAI.address,
+          amount: 5,
+        },
+      })
+
+      order.signature = await signatures.getWeb3Signature(
+        order,
+        bobAddress,
+        swapAddress,
+        GANACHE_PROVIDER
+      )
+
+      // // create a rule for AST/DAI for alice
+      // await aliceDelegate.setRule(
+      //   tokenAST.address,
+      //   tokenDAI.address,
+      //   1000,
+      //   25,
+      //   2,
+      //   { from: aliceAddress }
+      // )
+
+      // Bob authorizes swap to send orders on his behalf
+      // function also checks that msg.sender == order.sender.wallet
+      await swapContract.authorizeSender(aliceDelegate.address, {
+        from: aliceTradeWallet,
+      })
+
+      errorCodes = await preSwapChecker.checkSwapDelegate.call(
+        order,
+        aliceDelegate.address,
+        {
+          from: bobAddress,
+        }
+      )
+      equal(errorCodes[0], 1)
+      equal(web3.utils.toUtf8(errorCodes[1][0]), 'PRICE_INVALID')
+      // ensure that the order then succeeds
+      await reverted(
+        aliceDelegate.provideOrder(order, { from: bobAddress }),
+        'PRICE_INVALID'
+      )
+    })
+  })
+})

--- a/utils/pre-swap-checker/test/PreDelegateChecker.js
+++ b/utils/pre-swap-checker/test/PreDelegateChecker.js
@@ -234,7 +234,7 @@ contract('PreSwapChecker', async accounts => {
         GANACHE_PROVIDER
       )
 
-      // create a rule for AST/DAI for alice
+      // create a rule for AST/DAI for Alice delegate by Alice
       await aliceDelegate.setRule(
         tokenAST.address,
         tokenDAI.address,
@@ -244,8 +244,8 @@ contract('PreSwapChecker', async accounts => {
         { from: aliceAddress }
       )
 
-      // Bob authorizes swap to send orders on his behalf
-      // function also checks that msg.sender == order.sender.wallet
+      // Alice's trade wallet authorizes aliceDelegate swap to send orders
+      // on its behalf to Swap
       await swapContract.authorizeSender(aliceDelegate.address, {
         from: aliceTradeWallet,
       })
@@ -286,18 +286,8 @@ contract('PreSwapChecker', async accounts => {
         GANACHE_PROVIDER
       )
 
-      // // create a rule for AST/DAI for alice
-      // await aliceDelegate.setRule(
-      //   tokenAST.address,
-      //   tokenDAI.address,
-      //   1000,
-      //   25,
-      //   2,
-      //   { from: aliceAddress }
-      // )
-
-      // Bob authorizes swap to send orders on his behalf
-      // function also checks that msg.sender == order.sender.wallet
+      // Alice's trade wallet authorizes aliceDelegate swap to send orders
+      // on its behalf to Swap
       await swapContract.authorizeSender(aliceDelegate.address, {
         from: aliceTradeWallet,
       })

--- a/utils/pre-swap-checker/test/PreSwapChecker.js
+++ b/utils/pre-swap-checker/test/PreSwapChecker.js
@@ -126,7 +126,7 @@ contract('PreSwapChecker', async accounts => {
   })
 
   describe('Approving...', async () => {
-    it('Checks approvals (Alice 250 AST and 0 DAI, Bob 0 AST and 500 DAI)', async () => {
+    it('Checks approvals (Alice 250 AST and 0 DAI, Bob 100 WETH and 1000 DAI)', async () => {
       emitted(
         await tokenAST.approve(swapAddress, 250, { from: aliceAddress }),
         'Approval'


### PR DESCRIPTION
## Description

Put the preSwapDelegate check within the preSwapChecker
I separated the delegate tests into their own file as well (more forward looking for if we create a preSwapDelegateWrapper check function as well, i'll likely separate the smart contracts as well).

Quick description:
- [X] New features

## Changes

Added a prewap checker when using the delegate

## Tests

  46 passing (9s)

## Test Coverage

100%