### PR TITLE
Add registry to ISwap interface

### DIFF
--- a/source/delegate/package.json
+++ b/source/delegate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/delegate",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Deployable Trading Rules for the AirSwap Network",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@airswap/indexer": "3.6.8",
-    "@airswap/swap": "4.3.6",
+    "@airswap/swap": "4.3.7",
     "openzeppelin-solidity": "2.4"
   }
 }

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -72,14 +72,13 @@ contract('Delegate Integration Tests', async accounts => {
     await setupTokens()
     await setupIndexer()
 
-    const delegateContract = await Delegate.new(
+    aliceDelegate = await Delegate.new(
       swapAddress,
       indexer.address,
       aliceAddress,
       aliceTradeWallet,
       PROTOCOL
     )
-    aliceDelegate = await delegateContract
   })
 
   describe('Test the delegate constructor', async () => {

--- a/source/swap/contracts/Imports.sol
+++ b/source/swap/contracts/Imports.sol
@@ -5,8 +5,6 @@ import "@airswap/tokens/contracts/OMGToken.sol";
 import "@airswap/tokens/contracts/NonFungibleToken.sol";
 import "@airswap/tokens/contracts/AdaptedKittyERC721.sol";
 import "@airswap/tokens/contracts/MintableERC1155Token.sol";
-import "@airswap/types/contracts/Types.sol";
-import "@airswap/transfers/contracts/TransferHandlerRegistry.sol";
 import "@airswap/transfers/contracts/handlers/ERC20TransferHandler.sol";
 import "@airswap/transfers/contracts/handlers/ERC721TransferHandler.sol";
 import "@airswap/transfers/contracts/handlers/ERC1155TransferHandler.sol";

--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -18,7 +18,6 @@ pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/transfers/contracts/interfaces/ITransferHandler.sol";
-import "@airswap/transfers/contracts/TransferHandlerRegistry.sol";
 import "@airswap/swap/contracts/interfaces/ISwap.sol";
 
 /**

--- a/source/swap/contracts/interfaces/ISwap.sol
+++ b/source/swap/contracts/interfaces/ISwap.sol
@@ -18,6 +18,7 @@ pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@airswap/types/contracts/Types.sol";
+import "@airswap/transfers/contracts/TransferHandlerRegistry.sol";
 
 interface ISwap {
 
@@ -131,5 +132,7 @@ interface ISwap {
 
   function signerNonceStatus(address, uint256) external view returns (byte);
   function signerMinimumNonce(address) external view returns (uint256);
+
+  function registry() external view returns (TransferHandlerRegistry);
 
 }

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/swap",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "description": "Trustlessly swap tokens on the AirSwap Network",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/wrapper",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "Wraps and unwraps ether for WETH trades on the AirSwap Network",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",
@@ -34,8 +34,8 @@
     "solidity-coverage": "^0.6.3"
   },
   "dependencies": {
-    "@airswap/delegate": "1.5.7",
-    "@airswap/swap": "4.3.6",
+    "@airswap/delegate": "1.5.8",
+    "@airswap/swap": "4.3.7",
     "@airswap/tokens": "0.1.4"
   }
 }

--- a/source/wrapper/test/Wrapper.js
+++ b/source/wrapper/test/Wrapper.js
@@ -8,7 +8,6 @@ const WETH9 = artifacts.require('WETH9')
 const FungibleToken = artifacts.require('FungibleToken')
 const TransferHandlerRegistry = artifacts.require('TransferHandlerRegistry')
 const ERC20TransferHandler = artifacts.require('ERC20TransferHandler')
-
 const {
   emitted,
   reverted,

--- a/utils/debugger/package.json
+++ b/utils/debugger/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@airswap/order-utils": "0.3.19",
-    "@airswap/swap": "4.3.6",
+    "@airswap/swap": "4.3.7",
     "@airswap/tokens": "0.1.4",
     "ethers": "^5.0.0-beta.159"
   }

--- a/utils/pre-swap-checker/package.json
+++ b/utils/pre-swap-checker/package.json
@@ -19,11 +19,11 @@
   },
   "dependencies": {
     "@airswap/transfers": "0.0.2",
-    "@airswap/swap": "4.3.6",
+    "@airswap/swap": "4.3.7",
     "@airswap/tokens": "0.1.4",
     "@airswap/types": "2.4.5",
     "openzeppelin-solidity": "2.4",
-    "@airswap/wrapper": "2.5.7"
+    "@airswap/wrapper": "2.5.8"
   },
   "devDependencies": {
     "@airswap/order-utils": "0.3.19",


### PR DESCRIPTION
## Description

Realized we were missing `registry()` from `ISwap` when I was writing the `preSwapChecker` functions. I've added it as an external view in `ISwap` but continue to keep it was public in `Swap.sol`

Quick description:

- [X] Typo/small tweaks

## Changes
 
- Added abstract function to ISwap.sol 
- Cleaned up `Imports.sol`
- Removed `TokenTransferRegistry` import from swap and added it to `ISwap`
- cleaned up an unused variables in `Delegate.js`
- some linting fixes were found in `Wrapper.js` 
- Updated `package.json` patch versions throughout

## Tests
 no change
## Test Coverage
no change
