### PR TITLE
Add `@airswap/clients` for JS Developers

### DIFF
--- a/utils/clients/index.ts
+++ b/utils/clients/index.ts
@@ -1,0 +1,21 @@
+/*
+  Copyright 2020 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export { Swap } from './src/Swap'
+export { Indexer } from './src/Indexer'
+export { Server } from './src/Server'
+export { Delegate } from './src/Delegate'
+export { ERC20 } from './src/ERC20'

--- a/utils/clients/package.json
+++ b/utils/clients/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@airswap/clients",
+  "version": "0.1.0",
+  "description": "JavaScript Clients for AirSwap Protocols",
+  "main": "src/index.ts",
+  "contributors": [
+    "Don Mosites <don.mosites@fluidity.io>"
+  ],
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@airswap/indexer": "^3.6.8",
+    "@airswap/order-utils": "^0.3.20",
+    "@airswap/swap": "^5.4.7",
+    "bignumber.js": "^9.0.0",
+    "ethers": "^4.0.44",
+    "jayson": "^3.2.0"
+  },
+  "devDependencies": {
+    "eslint": "^6.8.0"
+  }
+}

--- a/utils/clients/package.json
+++ b/utils/clients/package.json
@@ -8,9 +8,9 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@airswap/indexer": "^3.6.8",
-    "@airswap/order-utils": "^0.3.20",
-    "@airswap/swap": "^5.4.7",
+    "@airswap/indexer": "3.6.8",
+    "@airswap/order-utils": "0.3.20",
+    "@airswap/swap": "5.4.7",
     "bignumber.js": "^9.0.0",
     "ethers": "^4.0.44",
     "jayson": "^3.2.0"

--- a/utils/clients/src/Delegate.ts
+++ b/utils/clients/src/Delegate.ts
@@ -1,0 +1,97 @@
+/*
+  Copyright 2020 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ethers } from 'ethers'
+import { chainIds, chainNames, MIN_CONFIRMATIONS } from '@airswap/constants'
+
+const DelegateContract = require('@airswap/delegate/build/contracts/Delegate.json')
+
+export class Delegate {
+  locator: string
+  chainId: string
+  contract: any
+
+  constructor(
+    locator: string,
+    chainId = chainIds.RINKEBY,
+    signerOrProvider?: ethers.Signer | ethers.providers.Provider
+  ) {
+    this.locator = locator
+    this.chainId = chainId
+    this.contract = new ethers.Contract(
+      locator,
+      DelegateContract.abi,
+      signerOrProvider ||
+        ethers.getDefaultProvider(chainNames[chainId].toLowerCase())
+    )
+  }
+
+  async getWallet(): Promise<string> {
+    return await this.contract.tradeWallet()
+  }
+
+  async getMaxQuote(signerToken: string, senderToken: string): Promise<any> {
+    const result = await this.contract.getMaxQuote(signerToken, senderToken)
+    return {
+      signer: {
+        token: signerToken,
+        amount: result.signerAmount.toString(),
+      },
+      sender: {
+        token: senderToken,
+        amount: result.senderAmount.toString(),
+      },
+    }
+  }
+
+  async getSignerSideQuote(
+    senderAmount: string,
+    senderToken: string,
+    signerToken: string
+  ): Promise<any> {
+    const signerAmount = await this.contract.getSignerSideQuote(
+      senderAmount,
+      senderToken,
+      signerToken
+    )
+    if (signerAmount.isZero()) {
+      throw new Error('Not quoting for the requested pair')
+    }
+    return {
+      signer: {
+        token: signerToken,
+        amount: signerAmount.toString(),
+      },
+      sender: {
+        token: senderToken,
+        amount: senderAmount,
+      },
+    }
+  }
+
+  async provideOrder(order: any, signer?: ethers.Signer): Promise<string> {
+    let contract = this.contract
+    if (!this.contract.signer) {
+      if (signer === null) {
+        throw new Error('Signer must be provided')
+      }
+      contract = new ethers.Contract(this.locator, DelegateContract.abi, signer)
+    }
+    const tx = await contract.provideOrder(order)
+    await tx.wait(MIN_CONFIRMATIONS)
+    return tx.hash
+  }
+}

--- a/utils/clients/src/ERC20.ts
+++ b/utils/clients/src/ERC20.ts
@@ -1,0 +1,45 @@
+/*
+  Copyright 2020 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ethers } from 'ethers'
+import { chainIds, chainNames, MIN_CONFIRMATIONS } from '@airswap/constants'
+import { BigNumber } from 'ethers/utils'
+
+const IERC20 = require('@airswap/tokens/build/contracts/IERC20.json')
+
+export class ERC20 {
+  address: string
+  chainId: string
+  contract: any
+
+  constructor(
+    address: string,
+    chainId = chainIds.RINKEBY,
+    signerOrProvider?: ethers.Signer | ethers.providers.Provider
+  ) {
+    this.address = address
+    this.contract = new ethers.Contract(
+      address,
+      IERC20.abi,
+      signerOrProvider ||
+        ethers.getDefaultProvider(chainNames[chainId].toLowerCase())
+    )
+  }
+
+  async balanceOf(address: string): Promise<BigNumber> {
+    return await this.contract.balanceOf(address)
+  }
+}

--- a/utils/clients/src/Indexer.ts
+++ b/utils/clients/src/Indexer.ts
@@ -1,0 +1,78 @@
+/*
+  Copyright 2020 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ethers } from 'ethers'
+import { chainIds, chainNames, protocols, INDEX_HEAD } from '@airswap/constants'
+
+const IndexerContract = require('@airswap/indexer/build/contracts/Indexer.json')
+const indexerDeploys = require('@airswap/indexer/deploys.json')
+
+export class Indexer {
+  chainId: string
+  contract: any
+
+  constructor(
+    chainId = chainIds.RINKEBY,
+    signerOrProvider?: ethers.Signer | ethers.providers.Provider
+  ) {
+    this.contract = new ethers.Contract(
+      indexerDeploys[chainId],
+      IndexerContract.abi,
+      signerOrProvider ||
+        ethers.getDefaultProvider(chainNames[chainId].toLowerCase())
+    )
+  }
+
+  async getLocators(
+    signerToken: string,
+    senderToken: string,
+    protocol = '0x0000',
+    limit = 10,
+    cursor = INDEX_HEAD
+  ) {
+    const result = await this.contract.getLocators(
+      signerToken,
+      senderToken,
+      protocol,
+      cursor,
+      limit
+    )
+    let locator
+    const locators = []
+    for (let i = 0; i < result.locators.length; i++) {
+      try {
+        switch (protocol) {
+          case protocols.SERVER:
+            locator = ethers.utils.parseBytes32String(result.locators[i])
+            break
+          case protocols.DELEGATE:
+            locator = ethers.utils.getAddress(result.locators[i].slice(0, 42))
+            break
+          default:
+            locator = result.locators[i]
+        }
+        locators.push(locator)
+      } catch (e) {
+        continue
+      }
+    }
+    return {
+      locators,
+      scores: result.scores,
+      nextCursor: result.nextCursor,
+    }
+  }
+}

--- a/utils/clients/src/Server.ts
+++ b/utils/clients/src/Server.ts
@@ -1,0 +1,157 @@
+/*
+  Copyright 2020 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import * as url from 'url'
+import * as jayson from 'jayson'
+import { BigNumber } from 'ethers/utils'
+import { REQUEST_TIMEOUT } from '@airswap/constants'
+
+export class Server {
+  _client: any
+
+  constructor(locator: string) {
+    if (!/^http:\/\//.test(locator) && !/^https:\/\//.test(locator)) {
+      locator = `https://${locator}`
+    }
+
+    const locatorUrl = url.parse(locator)
+    const options = {
+      protocol: locatorUrl.protocol,
+      hostname: locatorUrl.hostname,
+      port: locatorUrl.port,
+      timeout: REQUEST_TIMEOUT,
+    }
+
+    if (options.protocol === 'http:') {
+      this._client = jayson.Client.http(options)
+    } else if (options.protocol === 'https:') {
+      this._client = jayson.Client.https(options)
+    }
+  }
+
+  async getMaxQuote(signerToken: string, senderToken: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this._generateRequest(
+        'getMaxQuote',
+        {
+          signerToken,
+          senderToken,
+        },
+        resolve,
+        reject
+      )
+    })
+  }
+
+  async getSignerSideQuote(
+    senderAmount: string,
+    signerToken: string,
+    senderToken: string
+  ) {
+    return new Promise((resolve, reject) => {
+      this._generateRequest(
+        'getSignerSideQuote',
+        {
+          senderAmount: senderAmount.toString(),
+          signerToken,
+          senderToken,
+        },
+        resolve,
+        reject
+      )
+    })
+  }
+
+  async getSenderSideQuote(
+    signerAmount: string,
+    signerToken: string,
+    senderToken: string
+  ) {
+    return new Promise((resolve, reject) => {
+      this._generateRequest(
+        'getSenderSideQuote',
+        {
+          signerAmount: signerAmount.toString(),
+          signerToken,
+          senderToken,
+        },
+        resolve,
+        reject
+      )
+    })
+  }
+
+  async getSignerSideOrder(
+    senderAmount: string,
+    signerToken: string,
+    senderToken: string,
+    senderWallet: string
+  ) {
+    return new Promise((resolve, reject) => {
+      this._generateRequest(
+        'getSignerSideOrder',
+        {
+          senderAmount: senderAmount.toString(),
+          signerToken,
+          senderToken,
+          senderWallet,
+        },
+        resolve,
+        reject
+      )
+    })
+  }
+
+  async getSenderSideOrder(
+    signerAmount: string | BigNumber,
+    signerToken: string,
+    senderToken: string,
+    senderWallet: string
+  ) {
+    return new Promise((resolve, reject) => {
+      this._generateRequest(
+        'getSenderSideOrder',
+        {
+          signerAmount,
+          signerToken,
+          senderToken,
+          senderWallet,
+        },
+        resolve,
+        reject
+      )
+    })
+  }
+
+  _generateRequest(
+    method: string,
+    params: any,
+    resolve: Function,
+    reject: Function
+  ) {
+    this._client.request(
+      method,
+      params,
+      (err: any, error: any, result: any) => {
+        if (err || error) {
+          reject(err || error)
+        } else {
+          resolve(result)
+        }
+      }
+    )
+  }
+}

--- a/utils/clients/src/Swap.ts
+++ b/utils/clients/src/Swap.ts
@@ -1,0 +1,63 @@
+/*
+  Copyright 2020 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ethers } from 'ethers'
+import { chainIds, chainNames, MIN_CONFIRMATIONS } from '@airswap/constants'
+
+const SwapContract = require('@airswap/swap/build/contracts/Swap.json')
+const swapDeploys = require('@airswap/swap/deploys.json')
+
+export class Swap {
+  chainId: string
+  contract: any
+
+  constructor(
+    chainId = chainIds.RINKEBY,
+    signerOrProvider?: ethers.Signer | ethers.providers.Provider
+  ) {
+    this.chainId = chainId
+    this.contract = new ethers.Contract(
+      Swap.getAddress(chainId),
+      SwapContract.abi,
+      signerOrProvider ||
+        ethers.getDefaultProvider(chainNames[chainId].toLowerCase())
+    )
+  }
+
+  static getAddress(chainId = chainIds.RINKEBY): string {
+    if (chainId in swapDeploys) {
+      return swapDeploys[chainId]
+    }
+    throw new Error(`Swap deploy not found for chainId ${chainId}`)
+  }
+
+  async swap(order: any, signer?: ethers.Signer): Promise<string> {
+    let contract = this.contract
+    if (!this.contract.signer) {
+      if (signer === null) {
+        throw new Error('Signer must be provided')
+      }
+      contract = new ethers.Contract(
+        Swap.getAddress(this.chainId),
+        SwapContract.abi,
+        signer
+      )
+    }
+    const tx = await contract.swap(order)
+    await tx.wait(MIN_CONFIRMATIONS)
+    return tx.hash
+  }
+}

--- a/utils/clients/tsconfig.json
+++ b/utils/clients/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "importHelpers": true,
+    "module": "commonjs",
+    "target": "es2017",
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["index.ts"]
+}

--- a/utils/constants/index.ts
+++ b/utils/constants/index.ts
@@ -1,0 +1,114 @@
+/*
+  Copyright 2020 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export const chainIds: { [key: string]: string } = {
+  MAINNET: '1',
+  RINKEBY: '4',
+}
+
+export const chainNames: { [key: string]: string } = {
+  '1': 'MAINNET',
+  '4': 'RINKEBY',
+}
+
+export const tokenKinds: { [key: string]: string } = {
+  ERC20: '0x36372b07',
+  ERC721: '0x80ac58cd',
+  ERC1155: '0xd9b67a26',
+  CKITTY: '0x9a20483d',
+}
+
+export const tokenKindNames: { [key: string]: string } = {
+  '0x36372b07': 'ERC20',
+  '0x80ac58cd': 'ERC721',
+  '0xd9b67a26': 'ERC1155',
+  '0x9a20483d': 'CKITTY',
+}
+
+export const protocols: { [key: string]: string } = {
+  SERVER: '0x0000',
+  DELEGATE: '0x0001',
+}
+
+export const protocolNames: { [key: string]: string } = {
+  '0x0000': 'SERVER',
+  '0x0001': 'DELEGATE',
+}
+
+export const signatureTypes: { [key: string]: string } = {
+  INTENDED_VALIDATOR: '0x00',
+  SIGN_TYPED_DATA: '0x01',
+  PERSONAL_SIGN: '0x45',
+}
+
+export const rinkebyTokens: { [key: string]: any } = {
+  DAI: {
+    address: '0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea',
+    decimals: 18,
+  },
+  WETH: {
+    address: '0xc778417e063141139fce010982780140aa0cd5ab',
+    decimals: 18,
+  },
+  AST: {
+    address: '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8',
+    decimals: 4,
+  },
+}
+
+export const stakingTokenAddresses: { [key: string]: any } = {
+  '1': '0x27054b13b1b798b345b591a4d22e6562d47ea75a',
+  '4': '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8',
+}
+
+export const deltaBalanceAddresses: { [key: string]: any } = {
+  '1': '0x5dfe850d4b029c25c7ef9531ec9986c97d90300f',
+  '4': '0xa1e2c4132cbd33c3876e1254143a850466c97e32',
+}
+
+export const etherscanDomains: { [key: string]: any } = {
+  '1': 'etherscan.io',
+  '4': 'rinkeby.etherscan.io',
+}
+
+export const defaults: { [key: string]: any } = {
+  Party: {
+    kind: '0x36372b07',
+    wallet: '0x0000000000000000000000000000000000000000',
+    token: '0x0000000000000000000000000000000000000000',
+    amount: '0',
+    id: '0',
+  },
+}
+
+export const INDEX_HEAD = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
+
+export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
+
+export const LOCATOR_ZERO =
+  '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+export const MAX_LOCATORS = 10
+
+export const MAX_APPROVAL_AMOUNT = '90071992547409910000000000'
+
+export const MIN_CONFIRMATIONS = 2
+
+export const DEFAULT_PORT = 3000
+
+export const REQUEST_TIMEOUT = 4000
+
+export const SECONDS_IN_DAY = 86400

--- a/utils/constants/package.json
+++ b/utils/constants/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@airswap/constants",
+  "version": "0.1.0",
+  "description": "Helpful Constants for AirSwap Developers",
+  "main": "index.ts",
+  "contributors": [
+    "Don Mosites <don.mosites@fluidity.io>"
+  ],
+  "license": "Apache-2.0"
+}

--- a/utils/constants/tsconfig.json
+++ b/utils/constants/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "importHelpers": true,
+    "module": "commonjs",
+    "target": "es2017",
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["index.ts"]
+}

--- a/utils/utils/index.ts
+++ b/utils/utils/index.ts
@@ -1,0 +1,100 @@
+/*
+  Copyright 2020 Swap Holdings Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+import { ethers } from 'ethers'
+import { BigNumber } from 'ethers/utils'
+import { defaults, signatureTypes, SECONDS_IN_DAY } from '@airswap/constants'
+import { hashes } from '@airswap/order-utils'
+
+function lowerCaseAddresses(obj) {
+  for (let key in obj) {
+    if (typeof obj[key] === 'object') {
+      lowerCaseAddresses(obj[key])
+    }
+    if (typeof obj[key] === 'string' && obj[key].indexOf('0x') === 0) {
+      obj[key] = obj[key].toLowerCase()
+    }
+  }
+  return obj
+}
+
+export function createOrder({
+  expiry = Math.round(Date.now() / 1000 + SECONDS_IN_DAY).toString(),
+  nonce = Date.now(),
+  signer = defaults.Party,
+  sender = defaults.Party,
+  affiliate = defaults.Party,
+}): any {
+  return lowerCaseAddresses({
+    expiry: String(expiry),
+    nonce: String(nonce),
+    signer: { ...defaults.Party, ...signer },
+    sender: { ...defaults.Party, ...sender },
+    affiliate: { ...defaults.Party, ...affiliate },
+  })
+}
+
+export function createOrderFromQuote(
+  quote: any,
+  signerWallet: string,
+  senderWallet: string
+): any {
+  return createOrder({
+    signer: {
+      token: quote.signer.token,
+      amount: quote.signer.amount,
+      wallet: signerWallet,
+    },
+    sender: {
+      token: quote.sender.token,
+      amount: quote.sender.amount,
+      wallet: senderWallet,
+    },
+  })
+}
+
+export async function signOrder(
+  order: any,
+  signer: ethers.Signer,
+  swapContract: string
+) {
+  const orderHash = hashes.getOrderHash(order, swapContract)
+  const signedMsg = await signer.signMessage(ethers.utils.arrayify(orderHash))
+  const sig = ethers.utils.splitSignature(signedMsg)
+  const { r, s, v } = sig
+
+  return {
+    signatory: await (await signer.getAddress()).toLowerCase(),
+    validator: swapContract,
+    version: signatureTypes.PERSONAL_SIGN,
+    v: v.toString(),
+    r,
+    s,
+  }
+}
+
+export function toDecimalString(
+  value: string | BigNumber,
+  decimals: string | number
+): string {
+  return ethers.utils.formatUnits(value.toString(), decimals).toString()
+}
+
+export function toAtomicString(
+  value: string | BigNumber,
+  decimals: string | number
+) {
+  return ethers.utils.parseUnits(value.toString(), decimals).toString()
+}

--- a/utils/utils/package.json
+++ b/utils/utils/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@airswap/utils",
+  "version": "0.1.0",
+  "description": "Utilities for AirSwap Developers",
+  "main": "index.ts",
+  "contributors": [
+    "Don Mosites <don.mosites@fluidity.io>"
+  ],
+  "license": "Apache-2.0",
+  "dependencies": {
+    "ethers": "^4.0.44"
+  }
+}

--- a/utils/utils/tsconfig.json
+++ b/utils/utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "importHelpers": true,
+    "module": "commonjs",
+    "target": "es2017",
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
- Adds `@airswap/clients` containing JavaScript classes for protocol components including Swap, Indexer, Server, and Delegate. TODO: Complete remaining functionality for each component.
- Adds `@airswap/constants` to consolidate network constants into a single package. TODO: Merge more constants in from other packages.
- Adds `@airswap/utils` to consolidate JavaScript utilities into a single package. TODO: Merge more utility functions in from other packages.