### PR TITLE
adding empty compile script

### DIFF
--- a/tools/debugger/package.json
+++ b/tools/debugger/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/airswap/airswap-protocols"
   },
   "scripts": {
+    "compile": ":",
     "ganache": "ganache-cli -p 8545 --gasLimit 0xfffffffffff --time '2017-05-10T00:00:00+00:00' -s 0",
     "test": "mocha test --timeout 3000 --exit"
   },


### PR DESCRIPTION
## Description

Quick description:

- [ ] N/A
- [ ] New features
- [X] Bug fixes
- [ ] Typo/small tweaks

## Changes

Empty compile script as the NPM deployer calls `compile` in every directory before deploying
