### PR TITLE
Add util functions to sum up quote values

### DIFF
--- a/tools/utils/src/quotes.ts
+++ b/tools/utils/src/quotes.ts
@@ -1,0 +1,36 @@
+import { BigNumber, bigNumberify } from 'ethers/utils'
+import { Quote } from '@airswap/types'
+
+export function createQuote(
+  signerToken: string,
+  signerAmount: string,
+  senderToken: string,
+  senderAmount: string
+): Quote {
+  return {
+    signer: {
+      token: signerToken,
+      amount: signerAmount,
+    },
+    sender: {
+      token: senderToken,
+      amount: senderAmount,
+    },
+  }
+}
+
+export function getTotalBySignerAmount(quotes: Array<Quote>): BigNumber {
+  let total = new BigNumber(0)
+  for (const order of quotes) {
+    total = bigNumberify(order.signer.amount).add(total)
+  }
+  return total
+}
+
+export function getTotalBySenderAmount(quotes: Array<Quote>): BigNumber {
+  let total = new BigNumber(0)
+  for (const order of quotes) {
+    total = bigNumberify(order.sender.amount).add(total)
+  }
+  return total
+}

--- a/tools/utils/test/orders.ts
+++ b/tools/utils/test/orders.ts
@@ -7,7 +7,7 @@ import {
 } from '../src/orders'
 
 describe('Orders', async () => {
-  it('Checks best order by lowest sender', async () => {
+  it('Best by lowest sender', async () => {
     const orders = []
     let count = 5
     const lowestAmount = 50
@@ -27,7 +27,7 @@ describe('Orders', async () => {
     expect(best.sender.amount).to.equal(String(lowestAmount))
   })
 
-  it('Checks best order by highest signer', async () => {
+  it('Best by highest signer', async () => {
     const orders = []
     const highestAmount = 5
     let count = 0

--- a/tools/utils/test/quotes.ts
+++ b/tools/utils/test/quotes.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai'
+
+import {
+  createQuote,
+  getTotalBySignerAmount,
+  getTotalBySenderAmount,
+} from '../src/quotes'
+
+describe('Quotes', async () => {
+  it('Total by signer amount', async () => {
+    const quotes = []
+    let amount = 0
+    for (let i = 0; i < 100; i++) {
+      quotes.push(createQuote('', String(i), '', String(0)))
+      amount += i
+    }
+    expect(getTotalBySignerAmount(quotes).toString()).to.equal(String(amount))
+  })
+
+  it('Total by sender amount', async () => {
+    const quotes = []
+    let amount = 0
+    for (let i = 0; i < 100; i++) {
+      quotes.push(createQuote('', String(0), '', String(i)))
+      amount += i
+    }
+    expect(getTotalBySenderAmount(quotes).toString()).to.equal(String(amount))
+  })
+})


### PR DESCRIPTION
Adds functions:
- `getTotalBySignerAmount` to sum up signer-side liquidity given a list of quotes
- `getTotalBySenderAmount` to sum up sender-side liquidity given a list of quotes