### PR TITLE
Include wallet delegate quotes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     'prefer-const': 'error',
     'no-undef': 'warn',
     'no-unused-vars': 'warn',
+    '@typescript-eslint/explicit-member-accessibility': 1,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/camelcase': 0,
     '@typescript-eslint/explicit-function-return-type': 0,

--- a/tools/protocols/package.json
+++ b/tools/protocols/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/protocols",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "JavaScript Protocol Tools for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>"

--- a/tools/protocols/src/Delegate.ts
+++ b/tools/protocols/src/Delegate.ts
@@ -31,7 +31,7 @@ export class Delegate {
   private tradeWallet: string
   private contract: ethers.Contract
 
-  constructor(
+  public constructor(
     address: string,
     chainId = chainIds.RINKEBY,
     signerOrProvider?: ethers.Signer | ethers.providers.Provider
@@ -47,14 +47,17 @@ export class Delegate {
     )
   }
 
-  async getWallet(): Promise<string> {
+  public async getWallet(): Promise<string> {
     if (this.tradeWallet === '') {
       this.tradeWallet = await this.contract.tradeWallet()
     }
     return this.tradeWallet
   }
 
-  async getMaxQuote(signerToken: string, senderToken: string): Promise<Quote> {
+  public async getMaxQuote(
+    signerToken: string,
+    senderToken: string
+  ): Promise<Quote> {
     const { senderAmount, signerAmount } = await this.contract.getMaxQuote(
       senderToken,
       signerToken
@@ -67,7 +70,7 @@ export class Delegate {
     )
   }
 
-  async getSignerSideQuote(
+  public async getSignerSideQuote(
     senderAmount: string,
     senderToken: string,
     signerToken: string
@@ -89,7 +92,7 @@ export class Delegate {
     )
   }
 
-  async getSenderSideQuote(
+  public async getSenderSideQuote(
     signerAmount: string,
     signerToken: string,
     senderToken: string
@@ -111,7 +114,10 @@ export class Delegate {
     )
   }
 
-  async provideOrder(order: Order, signer?: ethers.Signer): Promise<string> {
+  public async provideOrder(
+    order: Order,
+    signer?: ethers.Signer
+  ): Promise<string> {
     let contract = this.contract
     if (!this.contract.signer) {
       if (signer === undefined) {
@@ -125,7 +131,7 @@ export class Delegate {
     return tx.hash
   }
 
-  async getQuotedOrMaxAvailable(
+  public async getQuotedOrMaxAvailable(
     senderToken: string,
     senderAmount: string,
     signerToken: string,

--- a/tools/protocols/src/Delegate.ts
+++ b/tools/protocols/src/Delegate.ts
@@ -26,10 +26,10 @@ const DelegateInterface = new ethers.utils.Interface(
 )
 
 export class Delegate {
-  chainId: string
-  address: string
-  tradeWallet: string
-  contract: ethers.Contract
+  public chainId: string
+  public address: string
+  private tradeWallet: string
+  private contract: ethers.Contract
 
   constructor(
     address: string,

--- a/tools/protocols/src/Delegate.ts
+++ b/tools/protocols/src/Delegate.ts
@@ -131,7 +131,7 @@ export class Delegate {
     return tx.hash
   }
 
-  public async getQuotedOrMaxAvailable(
+  private async getQuotedOrMaxAvailable(
     senderToken: string,
     senderAmount: string,
     signerToken: string,

--- a/tools/protocols/src/Delegate.ts
+++ b/tools/protocols/src/Delegate.ts
@@ -48,7 +48,7 @@ export class Delegate {
   }
 
   async getWallet(): Promise<string> {
-    if (this.tradeWallet === undefined) {
+    if (this.tradeWallet === '') {
       this.tradeWallet = await this.contract.tradeWallet()
     }
     return this.tradeWallet

--- a/tools/protocols/src/ERC20.ts
+++ b/tools/protocols/src/ERC20.ts
@@ -22,9 +22,9 @@ import * as IERC20 from '@airswap/tokens/build/contracts/IERC20.json'
 const IERC20Interface = new ethers.utils.Interface(JSON.stringify(IERC20.abi))
 
 export class ERC20 {
-  chainId: string
-  address: string
-  contract: ethers.Contract
+  public chainId: string
+  public address: string
+  private contract: ethers.Contract
 
   constructor(
     address: string,

--- a/tools/protocols/src/ERC20.ts
+++ b/tools/protocols/src/ERC20.ts
@@ -22,8 +22,8 @@ import * as IERC20 from '@airswap/tokens/build/contracts/IERC20.json'
 const IERC20Interface = new ethers.utils.Interface(JSON.stringify(IERC20.abi))
 
 export class ERC20 {
-  address: string
   chainId: string
+  address: string
   contract: ethers.Contract
 
   constructor(
@@ -31,8 +31,8 @@ export class ERC20 {
     chainId = chainIds.RINKEBY,
     signerOrProvider?: ethers.Signer | ethers.providers.Provider
   ) {
-    this.address = address
     this.chainId = chainId
+    this.address = address
     this.contract = new ethers.Contract(
       address,
       IERC20Interface,

--- a/tools/protocols/src/ERC20.ts
+++ b/tools/protocols/src/ERC20.ts
@@ -26,7 +26,7 @@ export class ERC20 {
   public address: string
   private contract: ethers.Contract
 
-  constructor(
+  public constructor(
     address: string,
     chainId = chainIds.RINKEBY,
     signerOrProvider?: ethers.Signer | ethers.providers.Provider
@@ -41,7 +41,7 @@ export class ERC20 {
     )
   }
 
-  async balanceOf(address: string): Promise<BigNumber> {
+  public async balanceOf(address: string): Promise<BigNumber> {
     return await this.contract.balanceOf(address)
   }
 }

--- a/tools/protocols/src/Indexer.ts
+++ b/tools/protocols/src/Indexer.ts
@@ -55,7 +55,7 @@ export class Indexer {
       cursor,
       limit
     )
-    const locators = []
+    const locators: Array<string> = []
     for (const locator of result.locators) {
       try {
         switch (protocol) {

--- a/tools/protocols/src/Indexer.ts
+++ b/tools/protocols/src/Indexer.ts
@@ -28,7 +28,7 @@ export class Indexer {
   public chainId: string
   private contract: ethers.Contract
 
-  constructor(
+  public constructor(
     chainId = chainIds.RINKEBY,
     signerOrProvider?: ethers.Signer | ethers.providers.Provider
   ) {
@@ -41,7 +41,7 @@ export class Indexer {
     )
   }
 
-  async getLocators(
+  public async getLocators(
     signerToken: string,
     senderToken: string,
     protocol = '0x0000',

--- a/tools/protocols/src/Indexer.ts
+++ b/tools/protocols/src/Indexer.ts
@@ -25,8 +25,8 @@ const IndexerInterface = new ethers.utils.Interface(
 )
 
 export class Indexer {
-  chainId: string
-  contract: ethers.Contract
+  public chainId: string
+  private contract: ethers.Contract
 
   constructor(
     chainId = chainIds.RINKEBY,

--- a/tools/protocols/src/Server.ts
+++ b/tools/protocols/src/Server.ts
@@ -21,7 +21,7 @@ import { parseUrl } from '@airswap/utils'
 import { Quote, Order } from '@airswap/types'
 
 export class Server {
-  _client: jayson.Client
+  private _client: jayson.Client
 
   constructor(locator: string) {
     const locatorUrl = parseUrl(locator)

--- a/tools/protocols/src/Server.ts
+++ b/tools/protocols/src/Server.ts
@@ -43,7 +43,7 @@ export class Server {
     senderToken: string
   ): Promise<Quote> {
     return new Promise((resolve, reject) => {
-      this._generateRequest(
+      this.generateRequest(
         'getMaxQuote',
         {
           signerToken,
@@ -61,7 +61,7 @@ export class Server {
     senderToken: string
   ): Promise<Quote> {
     return new Promise((resolve, reject) => {
-      this._generateRequest(
+      this.generateRequest(
         'getSignerSideQuote',
         {
           senderAmount: senderAmount.toString(),
@@ -80,7 +80,7 @@ export class Server {
     senderToken: string
   ): Promise<Quote> {
     return new Promise((resolve, reject) => {
-      this._generateRequest(
+      this.generateRequest(
         'getSenderSideQuote',
         {
           signerAmount: signerAmount.toString(),
@@ -100,7 +100,7 @@ export class Server {
     senderWallet: string
   ): Promise<Order> {
     return new Promise((resolve, reject) => {
-      this._generateRequest(
+      this.generateRequest(
         'getSignerSideOrder',
         {
           senderAmount: senderAmount.toString(),
@@ -121,7 +121,7 @@ export class Server {
     senderWallet: string
   ): Promise<Order> {
     return new Promise((resolve, reject) => {
-      this._generateRequest(
+      this.generateRequest(
         'getSenderSideOrder',
         {
           signerAmount: signerAmount.toString(),
@@ -135,7 +135,7 @@ export class Server {
     })
   }
 
-  private _generateRequest(
+  private generateRequest(
     method: string,
     params: Record<string, string>,
     resolve: Function,

--- a/tools/protocols/src/Server.ts
+++ b/tools/protocols/src/Server.ts
@@ -23,7 +23,7 @@ import { Quote, Order } from '@airswap/types'
 export class Server {
   private _client: jayson.Client
 
-  constructor(locator: string) {
+  public constructor(locator: string) {
     const locatorUrl = parseUrl(locator)
     const options = {
       protocol: locatorUrl.protocol,
@@ -38,7 +38,10 @@ export class Server {
     }
   }
 
-  async getMaxQuote(signerToken: string, senderToken: string): Promise<Quote> {
+  public async getMaxQuote(
+    signerToken: string,
+    senderToken: string
+  ): Promise<Quote> {
     return new Promise((resolve, reject) => {
       this._generateRequest(
         'getMaxQuote',
@@ -52,7 +55,7 @@ export class Server {
     })
   }
 
-  async getSignerSideQuote(
+  public async getSignerSideQuote(
     senderAmount: string,
     signerToken: string,
     senderToken: string
@@ -71,7 +74,7 @@ export class Server {
     })
   }
 
-  async getSenderSideQuote(
+  public async getSenderSideQuote(
     signerAmount: string,
     signerToken: string,
     senderToken: string
@@ -90,7 +93,7 @@ export class Server {
     })
   }
 
-  async getSignerSideOrder(
+  public async getSignerSideOrder(
     senderAmount: string,
     signerToken: string,
     senderToken: string,
@@ -111,7 +114,7 @@ export class Server {
     })
   }
 
-  async getSenderSideOrder(
+  public async getSenderSideOrder(
     signerAmount: string | BigNumber,
     signerToken: string,
     senderToken: string,
@@ -132,7 +135,7 @@ export class Server {
     })
   }
 
-  _generateRequest(
+  private _generateRequest(
     method: string,
     params: Record<string, string>,
     resolve: Function,

--- a/tools/protocols/src/Swap.ts
+++ b/tools/protocols/src/Swap.ts
@@ -25,8 +25,8 @@ const SwapInterface = new ethers.utils.Interface(
 )
 
 export class Swap {
-  chainId: string
-  contract: ethers.Contract
+  public chainId: string
+  private contract: ethers.Contract
 
   constructor(
     chainId = chainIds.RINKEBY,

--- a/tools/protocols/src/Swap.ts
+++ b/tools/protocols/src/Swap.ts
@@ -28,7 +28,7 @@ export class Swap {
   public chainId: string
   private contract: ethers.Contract
 
-  constructor(
+  public constructor(
     chainId = chainIds.RINKEBY,
     signerOrProvider?: ethers.Signer | ethers.providers.Provider
   ) {
@@ -41,14 +41,14 @@ export class Swap {
     )
   }
 
-  static getAddress(chainId = chainIds.RINKEBY): string {
+  public static getAddress(chainId = chainIds.RINKEBY): string {
     if (chainId in swapDeploys) {
       return swapDeploys[chainId]
     }
     throw new Error(`Swap deploy not found for chainId ${chainId}`)
   }
 
-  async swap(order: Order, signer?: ethers.Signer): Promise<string> {
+  public async swap(order: Order, signer?: ethers.Signer): Promise<string> {
     let contract = this.contract
     if (!this.contract.signer) {
       if (signer === undefined) {

--- a/tools/protocols/tsconfig.json
+++ b/tools/protocols/tsconfig.json
@@ -7,9 +7,10 @@
     "esModuleInterop": true,
     "skipLibCheck": false,
     "resolveJsonModule": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "noImplicitAny": false,
     "sourceMap": true,
     "declaration": true,
-    "outDir": "./build"
+    "outDir": "./build",
+    "strict": true
   }
 }


### PR DESCRIPTION
Includes `wallet` on delegate quotes, on the sender side, using the delegate tradeWallet. This allows a taker to pull down many quotes, sort to determine the best, and, given the best quote, to provide an order to the winning delegate.