### PR TITLE
Compare results to corresponding requests (Server)

### DIFF
--- a/tools/protocols/package.json
+++ b/tools/protocols/package.json
@@ -29,6 +29,7 @@
     "@airswap/swap": "5.4.7",
     "@airswap/tokens": "0.1.4",
     "@airswap/types": "3.5.9",
+    "@airswap/utils": "0.3.9",
     "@airswap/validator": "1.2.5",
     "bignumber.js": "^9.0.0",
     "ethers": "^4.0.45",

--- a/tools/protocols/package.json
+++ b/tools/protocols/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/protocols",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Protocol Libraries for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>"

--- a/tools/protocols/src/Delegate.ts
+++ b/tools/protocols/src/Delegate.ts
@@ -148,7 +148,10 @@ export class Delegate {
         .mul(balance)
     }
     if (finalSenderAmount.isZero() || finalSignerAmount.isZero()) {
-      throw new Error('Not quoting for requested amount or token pair')
+      throw {
+        code: -33601,
+        message: 'Not quoting for requested amount or token pair',
+      }
     }
     return {
       timestamp: getTimestamp(),

--- a/tools/protocols/src/Server.ts
+++ b/tools/protocols/src/Server.ts
@@ -17,7 +17,7 @@
 import * as jayson from 'jayson'
 import { BigNumber } from 'ethers/utils'
 import { REQUEST_TIMEOUT } from '@airswap/constants'
-import { parseUrl } from '@airswap/utils'
+import { parseUrl, flattenObject } from '@airswap/utils'
 import { Quote, Order } from '@airswap/types'
 
 export class Server {
@@ -135,29 +135,13 @@ export class Server {
     })
   }
 
-  /**
-   * Compare request params to a corresponding result
-   * Request params are camelCase, results are nested.objects
-   */
   private compare(params: any, result: any): Array<string> {
     const errors: Array<string> = []
+    const flat: any = flattenObject(result)
     for (const param in params) {
-      // Split param name by camelCase
-      const path = param.match(/([a-z]+)|([A-Z][a-z]+)/g)
-      // Only compare values at first or second level
-      // Always lowercase values (address comparison)
       if (
-        path[0] &&
-        typeof result[path[0]] === 'string' &&
-        result[path[0]].toLowerCase() !== params[param].toLowerCase()
-      ) {
-        errors.push(param)
-      } else if (
-        path[1] &&
-        typeof result[path[0]] === 'object' &&
-        typeof result[path[0]][path[1].toLowerCase()] === 'string' &&
-        result[path[0]][path[1].toLowerCase()].toLowerCase() !==
-          params[param].toLowerCase()
+        param in flat &&
+        flat[param].toLowerCase() !== params[param].toLowerCase()
       ) {
         errors.push(param)
       }

--- a/tools/protocols/src/Server.ts
+++ b/tools/protocols/src/Server.ts
@@ -147,13 +147,17 @@ export class Server {
       // Only compare values at first or second level
       // Always lowercase values (address comparison)
       if (
+        path[0] &&
         typeof result[path[0]] === 'string' &&
         result[path[0]].toLowerCase() !== params[param].toLowerCase()
       ) {
         errors.push(param)
       } else if (
+        path[1] &&
+        typeof result[path[0]] === 'object' &&
+        typeof result[path[0]][path[1].toLowerCase()] === 'string' &&
         result[path[0]][path[1].toLowerCase()].toLowerCase() !==
-        params[param].toLowerCase()
+          params[param].toLowerCase()
       ) {
         errors.push(param)
       }

--- a/tools/utils/index.ts
+++ b/tools/utils/index.ts
@@ -96,3 +96,24 @@ export function parseUrl(locator: string): url.UrlWithStringQuery {
 export function getEtherscanURL(chainId: string, hash: string) {
   return `https://${etherscanDomains[chainId]}/tx/${hash}`
 }
+
+function flattenRecurse(obj, propName, result) {
+  if (Object(obj) !== obj) {
+    result[propName] = obj
+  } else {
+    for (const prop in obj) {
+      flattenRecurse(
+        obj[prop],
+        propName
+          ? propName + prop.charAt(0).toUpperCase() + prop.slice(1)
+          : prop,
+        result
+      )
+    }
+  }
+  return result
+}
+
+export function flattenObject(obj: any) {
+  return flattenRecurse(obj, '', {})
+}

--- a/tools/utils/index.ts
+++ b/tools/utils/index.ts
@@ -97,12 +97,12 @@ export function getEtherscanURL(chainId: string, hash: string) {
   return `https://${etherscanDomains[chainId]}/tx/${hash}`
 }
 
-function flattenRecurse(obj, propName, result) {
+export function flattenObject(obj: any, propName = '', result = {}) {
   if (Object(obj) !== obj) {
     result[propName] = obj
   } else {
     for (const prop in obj) {
-      flattenRecurse(
+      flattenObject(
         obj[prop],
         propName
           ? propName + prop.charAt(0).toUpperCase() + prop.slice(1)
@@ -112,8 +112,4 @@ function flattenRecurse(obj, propName, result) {
     }
   }
   return result
-}
-
-export function flattenObject(obj: any) {
-  return flattenRecurse(obj, '', {})
 }

--- a/tools/utils/package.json
+++ b/tools/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/utils",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Utilities for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>"


### PR DESCRIPTION
* Adds util function to flatten an object into camelCase e.g. `order.signer.wallet` to `order.signerWallet`
* Uses this function in the Server client to compare results to corresponding requests
* E.g. if an amount is requested and the resulting order includes a lower or higher amount than requested an error is returned
* If a request param is not found in the response it is ignored because results are separately validated