### PR TITLE
ensure quote or order has lookup key defined before attempting to evaluate amount for comparison/sorting

### DIFF
--- a/source/delegate/package.json
+++ b/source/delegate/package.json
@@ -33,7 +33,7 @@
     "@airswap/test-utils": "0.1.6",
     "@airswap/transfers": "1.1.3",
     "@airswap/types": "3.5.11",
-    "@airswap/utils": "0.3.11",
+    "@airswap/utils": "0.3.12",
     "ethers": "^4.0.45",
     "solidity-coverage": "^0.6.3"
   }

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -27,7 +27,7 @@
     "@airswap/constants": "0.3.8",
     "@airswap/test-utils": "0.1.6",
     "@airswap/tokens": "0.1.4",
-    "@airswap/utils": "0.3.11",
+    "@airswap/utils": "0.3.12",
     "ethers": "^4.0.45",
     "solidity-coverage": "^0.6.3",
     "solidity-docgen": "0.3.0-beta.3"

--- a/source/validator/package.json
+++ b/source/validator/package.json
@@ -43,7 +43,7 @@
     "@airswap/constants": "0.3.8",
     "@airswap/indexer": "3.6.9",
     "@airswap/test-utils": "0.1.6",
-    "@airswap/utils": "0.3.11",
+    "@airswap/utils": "0.3.12",
     "@airswap/wrapper": "3.6.9",
     "ethers": "^4.0.45",
     "solidity-coverage": "^0.6.3"

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -34,7 +34,7 @@
     "@airswap/indexer": "3.6.9",
     "@airswap/test-utils": "0.1.6",
     "@airswap/types": "3.5.11",
-    "@airswap/utils": "0.3.11",
+    "@airswap/utils": "0.3.12",
     "ethers": "^4.0.45",
     "solidity-coverage": "^0.6.3"
   }

--- a/tools/protocols/package.json
+++ b/tools/protocols/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/protocols",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Protocol Libraries for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>"

--- a/tools/protocols/package.json
+++ b/tools/protocols/package.json
@@ -30,7 +30,7 @@
     "@airswap/swap": "5.4.8",
     "@airswap/tokens": "0.1.4",
     "@airswap/types": "3.5.11",
-    "@airswap/utils": "0.3.11",
+    "@airswap/utils": "0.3.12",
     "@airswap/validator": "1.2.6",
     "bignumber.js": "^9.0.0",
     "ethers": "^4.0.45",

--- a/tools/utils/index.ts
+++ b/tools/utils/index.ts
@@ -27,6 +27,7 @@ export * from './src/quotes'
 function getLowest(objects: Array<Quote> | Array<Order>, key: string): any {
   let best: any
   for (const obj of objects) {
+    if (!obj[key]) continue
     if (!best || new BigNumber(obj[key].amount).lt(best[key].amount)) {
       best = obj
     }
@@ -37,6 +38,7 @@ function getLowest(objects: Array<Quote> | Array<Order>, key: string): any {
 function getHighest(objects: Array<Quote> | Array<Order>, key: string): any {
   let best: any
   for (const obj of objects) {
+    if (!obj[key]) continue
     if (!best || new BigNumber(obj[key].amount).gt(best[key].amount)) {
       best = obj
     }

--- a/tools/utils/package.json
+++ b/tools/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/utils",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Utilities for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>"


### PR DESCRIPTION
Previously, when invoking a helper function such as `getBestByLowestSenderAmount(quotesArray)`, the helper would choke and throw an error when one of the quotes in the array was actually an error response. This presents an issue in the following workflow

1. We get all locators for a token pair

```
const { locators } = await new Indexer(chainIds.MAINNET).getLocators(signerToken, senderToken)
```

2. We iterate over these locators and request quotes.

```
const quotes = []
locators.forEach(async locator => {
  const s = new Server(locator)
  quotes.push(s.getSignerSideQuote(desiredAmountAtomic, signerToken, senderToken))
```

3. We use a helper to find the best quote

```
const bestQuote = getBestByLowestSenderAmount(quotes)
```

If one of the makers queried responds with an error or malformed quote, then step 3 will throw an error. This PR adds handling for this case, such that these `getBestByX` helper functions will ignore errors/malformed quotes, allowing the sorting to continue as normal. If every single response is an error, it will just return `undefined`