### PR TITLE
add support for ERC721 tokens in metadata package

### DIFF
--- a/source/delegate/package.json
+++ b/source/delegate/package.json
@@ -29,7 +29,7 @@
     "openzeppelin-solidity": "2.4"
   },
   "devDependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/test-utils": "0.1.6",
     "@airswap/transfers": "1.1.3",
     "@airswap/types": "3.5.11",

--- a/source/indexer/package.json
+++ b/source/indexer/package.json
@@ -24,7 +24,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/test-utils": "0.1.6",
     "@airswap/transfers": "1.1.3",
     "@airswap/types": "3.5.11",

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -24,7 +24,7 @@
     "verify": "truffle run verify"
   },
   "devDependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/test-utils": "0.1.6",
     "@airswap/tokens": "0.1.4",
     "@airswap/utils": "0.3.12",

--- a/source/transfers/package.json
+++ b/source/transfers/package.json
@@ -14,7 +14,7 @@
     "coverage": "node_modules/.bin/solidity-coverage"
   },
   "devDependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/test-utils": "0.1.6",
     "@airswap/tokens": "0.1.4",
     "solidity-coverage": "^0.6.3"

--- a/source/types/package.json
+++ b/source/types/package.json
@@ -31,7 +31,7 @@
     "openzeppelin-solidity": "2.4"
   },
   "devDependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/tokens": "0.1.4",
     "solidity-coverage": "^0.6.3",
     "typescript": "^3.8.2"

--- a/source/validator/package.json
+++ b/source/validator/package.json
@@ -40,7 +40,7 @@
     "openzeppelin-solidity": "2.4"
   },
   "devDependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/indexer": "3.6.9",
     "@airswap/test-utils": "0.1.6",
     "@airswap/utils": "0.3.12",

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -30,7 +30,7 @@
     "@airswap/tokens": "0.1.4"
   },
   "devDependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/indexer": "3.6.9",
     "@airswap/test-utils": "0.1.6",
     "@airswap/types": "3.5.11",

--- a/tools/constants/index.ts
+++ b/tools/constants/index.ts
@@ -41,11 +41,18 @@ export const chainNames: Record<string, string> = {
   '42': 'KOVAN',
 }
 
-export const tokenKinds: Record<string, string> = {
-  ERC20: '0x36372b07',
-  ERC721: '0x80ac58cd',
-  ERC1155: '0xd9b67a26',
-  CKITTY: '0x9a20483d',
+export enum TokenKinds {
+  ERC20 = '0x36372b07',
+  ERC721 = '0x80ac58cd',
+  ERC1155 = '0xd9b67a26',
+  CKITTY = '0x9a20483d',
+}
+
+export const tokenKinds = {
+  ERC20: TokenKinds.ERC20,
+  ERC721: TokenKinds.ERC721,
+  ERC1155: TokenKinds.ERC1155,
+  CKITTY: TokenKinds.CKITTY,
 }
 
 export const tokenKindNames: Record<string, string> = {

--- a/tools/constants/package.json
+++ b/tools/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/constants",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Helpful Constants for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>"

--- a/tools/deployer/package.json
+++ b/tools/deployer/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@airswap/types": "3.5.11",
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "openzeppelin-solidity": "2.4"
   }
 }

--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -15,7 +15,7 @@ import {
   OPEN_SEA_API_URL,
 } from './src/constants'
 
-import { chainIds, ADDRESS_ZERO } from '@airswap/constants'
+import { chainIds, ADDRESS_ZERO, tokenKinds } from '@airswap/constants'
 import { getTokenName, getTokenSymbol, getTokenDecimals } from './src/helpers'
 
 export function getTrustImage(address: string): string {
@@ -44,7 +44,7 @@ function normalizeIdexToken(
     address: token.address,
     decimals: token.decimals,
     symbol: token.symbol,
-    kind: 'ERC20',
+    kind: tokenKinds.ERC20,
     image: getTrustImage(token.address),
   }
 }
@@ -60,7 +60,7 @@ function normalizeMetamaskToken(
     address: token.address,
     decimals: token.decimals,
     symbol: token.symbol,
-    kind: 'ERC20',
+    kind: tokenKinds.ERC20,
     image: getMetamaskImage(token.logo),
   }
 }
@@ -150,11 +150,11 @@ class TokenMetadata {
   }
 
   public getERC20Tokens(): NormalizedToken[] {
-    return this.getTokens().filter(token => token.kind === 'ERC20')
+    return this.getTokens().filter(token => token.kind === tokenKinds.ERC20)
   }
 
   public getERC721Tokens(): NormalizedToken[] {
-    return this.getTokens().filter(token => token.kind === 'ERC721')
+    return this.getTokens().filter(token => token.kind === tokenKinds.ERC721)
   }
 
   // get token objects in an object keyed by address
@@ -196,7 +196,7 @@ class TokenMetadata {
           openseaContractData.symbol || openseaContractData.name.toUpperCase(),
         address: openseaContractData.address,
         decimals: 0,
-        kind: 'ERC721',
+        kind: tokenKinds.ERC721,
         image: openseaContractData.image_url,
       }
 
@@ -217,7 +217,7 @@ class TokenMetadata {
       address: searchAddress,
       decimals: tokenDecimals,
       image: getTrustImage(searchAddress),
-      kind: 'ERC20',
+      kind: tokenKinds.ERC20,
     }
 
     this.tokens.push(newToken)

--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -12,6 +12,7 @@ import {
   rinkebyTokensByAddress,
   goerliTokensByAddress,
   kovanTokensByAddress,
+  OPEN_SEA_API_URL,
 } from './src/constants'
 
 import { chainIds, ADDRESS_ZERO } from '@airswap/constants'
@@ -27,6 +28,14 @@ export function getMetamaskImage(logo: string): string {
   return `${METAMASK_IMAGE_API}/${logo}`
 }
 
+function getOpenseaContractMetadata(address): Promise<Record<string, any>> {
+  return axios
+    .get(`${OPEN_SEA_API_URL}/asset_contract/${address}`)
+    .then(response => {
+      return response.data
+    })
+}
+
 function normalizeIdexToken(
   token: IdexToken & { symbol: string }
 ): NormalizedToken {
@@ -35,6 +44,7 @@ function normalizeIdexToken(
     address: token.address,
     decimals: token.decimals,
     symbol: token.symbol,
+    kind: 'ERC20',
     image: getTrustImage(token.address),
   }
 }
@@ -50,6 +60,7 @@ function normalizeMetamaskToken(
     address: token.address,
     decimals: token.decimals,
     symbol: token.symbol,
+    kind: 'ERC20',
     image: getMetamaskImage(token.logo),
   }
 }
@@ -138,6 +149,14 @@ class TokenMetadata {
     return this.tokens
   }
 
+  public getERC20Tokens(): NormalizedToken[] {
+    return this.getTokens().filter(token => token.kind === 'ERC20')
+  }
+
+  public getERC721Tokens(): NormalizedToken[] {
+    return this.getTokens().filter(token => token.kind === 'ERC721')
+  }
+
   // get token objects in an object keyed by address
   public getTokensByAddress(): { [address: string]: NormalizedToken } {
     return this.tokensByAddress
@@ -161,6 +180,31 @@ class TokenMetadata {
         `Fetching data from a contract is only available on mainnet.`
       )
     }
+
+    // check if the token is an NFT
+    let openseaContractData
+    try {
+      openseaContractData = await getOpenseaContractMetadata(searchAddress)
+    } catch (error) {
+      openseaContractData = null
+    }
+
+    if (openseaContractData && openseaContractData.schema_name === 'ERC721') {
+      const normalizedOpenSeaToken: NormalizedToken = {
+        name: openseaContractData.name,
+        symbol:
+          openseaContractData.symbol || openseaContractData.name.toUpperCase(),
+        address: openseaContractData.address,
+        decimals: 0,
+        kind: 'ERC721',
+        image: openseaContractData.image_url,
+      }
+
+      this.tokens.push(normalizedOpenSeaToken)
+      this._storeTokensByAddress()
+      return normalizedOpenSeaToken
+    }
+
     const [tokenSymbol, tokenName, tokenDecimals] = await Promise.all([
       getTokenSymbol(searchAddress),
       getTokenName(searchAddress),
@@ -173,6 +217,7 @@ class TokenMetadata {
       address: searchAddress,
       decimals: tokenDecimals,
       image: getTrustImage(searchAddress),
+      kind: 'ERC20',
     }
 
     this.tokens.push(newToken)

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/metadata",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Token Metadata Tools for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -25,7 +25,7 @@
     "test": "yarn compile; mocha -r ts-node/register test/**/*.ts"
   },
   "dependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/types": "3.5.11",
     "axios": "^0.19.2",
     "eth-contract-metadata": "^1.12.1",

--- a/tools/metadata/src/constants.ts
+++ b/tools/metadata/src/constants.ts
@@ -7,6 +7,8 @@ export const TRUST_WALLET_IMAGE_API =
 export const METAMASK_IMAGE_API =
   'https://raw.githubusercontent.com/MetaMask/eth-contract-metadata/master/images'
 
+export const OPEN_SEA_API_URL = 'https://api.opensea.io/api/v1'
+
 export const ERC20_BYTES32_ABI = [
   {
     constant: true,

--- a/tools/metadata/src/constants.ts
+++ b/tools/metadata/src/constants.ts
@@ -251,18 +251,21 @@ export const rinkebyTokensByAddress: Record<string, NormalizedToken> = {
     address: '0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea',
     decimals: 18,
     symbol: 'DAI',
+    kind: 'ERC20',
   },
   '0xc778417e063141139fce010982780140aa0cd5ab': {
     name: 'Wrapped Ether',
     address: '0xc778417e063141139fce010982780140aa0cd5ab',
     decimals: 18,
     symbol: 'WETH',
+    kind: 'ERC20',
   },
   '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8': {
     name: 'AirSwap Token',
     address: '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8',
     decimals: 4,
     symbol: 'AST',
+    kind: 'ERC20',
   },
 }
 
@@ -272,12 +275,14 @@ export const goerliTokensByAddress: Record<string, NormalizedToken> = {
     address: '0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6',
     decimals: 18,
     symbol: 'WETH',
+    kind: 'ERC20',
   },
   '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31': {
     name: 'AirSwap Token',
     address: '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31',
     decimals: 4,
     symbol: 'AST',
+    kind: 'ERC20',
   },
 }
 
@@ -287,11 +292,13 @@ export const kovanTokensByAddress: Record<string, NormalizedToken> = {
     address: '0xd0a1e359811322d97991e03f863a0c30c2cf029c',
     decimals: 18,
     symbol: 'WETH',
+    kind: 'ERC20',
   },
   '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31': {
     name: 'AirSwap Token',
     address: '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31',
     decimals: 4,
     symbol: 'AST',
+    kind: 'ERC20',
   },
 }

--- a/tools/metadata/src/constants.ts
+++ b/tools/metadata/src/constants.ts
@@ -1,4 +1,5 @@
 import { NormalizedToken } from './types'
+import { tokenKinds } from '@airswap/constants'
 
 export const IDEX_TOKEN_API = 'https://api.idex.market/returnCurrencies'
 export const TRUST_WALLET_IMAGE_API =
@@ -251,21 +252,21 @@ export const rinkebyTokensByAddress: Record<string, NormalizedToken> = {
     address: '0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea',
     decimals: 18,
     symbol: 'DAI',
-    kind: 'ERC20',
+    kind: tokenKinds.ERC20,
   },
   '0xc778417e063141139fce010982780140aa0cd5ab': {
     name: 'Wrapped Ether',
     address: '0xc778417e063141139fce010982780140aa0cd5ab',
     decimals: 18,
     symbol: 'WETH',
-    kind: 'ERC20',
+    kind: tokenKinds.ERC20,
   },
   '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8': {
     name: 'AirSwap Token',
     address: '0xcc1cbd4f67cceb7c001bd4adf98451237a193ff8',
     decimals: 4,
     symbol: 'AST',
-    kind: 'ERC20',
+    kind: tokenKinds.ERC20,
   },
 }
 
@@ -275,14 +276,14 @@ export const goerliTokensByAddress: Record<string, NormalizedToken> = {
     address: '0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6',
     decimals: 18,
     symbol: 'WETH',
-    kind: 'ERC20',
+    kind: tokenKinds.ERC20,
   },
   '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31': {
     name: 'AirSwap Token',
     address: '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31',
     decimals: 4,
     symbol: 'AST',
-    kind: 'ERC20',
+    kind: tokenKinds.ERC20,
   },
 }
 
@@ -292,13 +293,13 @@ export const kovanTokensByAddress: Record<string, NormalizedToken> = {
     address: '0xd0a1e359811322d97991e03f863a0c30c2cf029c',
     decimals: 18,
     symbol: 'WETH',
-    kind: 'ERC20',
+    kind: tokenKinds.ERC20,
   },
   '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31': {
     name: 'AirSwap Token',
     address: '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31',
     decimals: 4,
     symbol: 'AST',
-    kind: 'ERC20',
+    kind: tokenKinds.ERC20,
   },
 }

--- a/tools/metadata/src/types.ts
+++ b/tools/metadata/src/types.ts
@@ -4,6 +4,7 @@ export interface NormalizedToken {
   symbol: string
   decimals: number
   image?: string
+  kind: 'ERC20' | 'ERC721'
 }
 
 export interface IdexToken {

--- a/tools/metadata/src/types.ts
+++ b/tools/metadata/src/types.ts
@@ -1,10 +1,12 @@
+import { TokenKinds } from '@airswap/constants'
+
 export interface NormalizedToken {
   name: string
   address: string
   symbol: string
   decimals: number
   image?: string
-  kind: 'ERC20' | 'ERC721'
+  kind: TokenKinds
 }
 
 export interface IdexToken {

--- a/tools/protocols/package.json
+++ b/tools/protocols/package.json
@@ -24,7 +24,7 @@
     "test": "yarn compile; mocha -r ts-node/register test/**/*.ts"
   },
   "dependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/delegate": "2.6.9",
     "@airswap/indexer": "3.6.9",
     "@airswap/swap": "5.4.8",

--- a/tools/test-utils/package.json
+++ b/tools/test-utils/package.json
@@ -17,7 +17,7 @@
     "compile": ":"
   },
   "dependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "eth-sig-util": "^2.2.0",
     "ethereumjs-util": "^6.1.0",
     "ethers": "^4.0.45",

--- a/tools/utils/package.json
+++ b/tools/utils/package.json
@@ -24,7 +24,7 @@
     "test": "yarn compile; mocha -r ts-node/register test/**/*.ts"
   },
   "dependencies": {
-    "@airswap/constants": "0.3.8",
+    "@airswap/constants": "0.3.9",
     "@airswap/types": "3.5.11",
     "@types/ethereumjs-abi": "^0.6.3",
     "@types/ethereumjs-util": "^6.1.0",


### PR DESCRIPTION
This PR uses the OpenSea API to fetch ERC721 tokens and store them in the memory tokens store. 