### PR TITLE
made token metadata initialization optional param

### DIFF
--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -78,11 +78,13 @@ class TokenMetadata {
   private tokens: NormalizedToken[]
   private tokensByAddress: { [address: string]: NormalizedToken }
 
-  public constructor(chainId = chainIds.MAINNET) {
+  public constructor(chainId = chainIds.MAINNET, initializeTokens = true) {
     this.chainId = String(chainId)
     this.tokens = []
     this.tokensByAddress = {}
-    this.ready = this.fetchKnownTokens()
+    if (initializeTokens) {
+      this.ready = this.fetchKnownTokens()
+    }
   }
 
   public async fetchKnownTokens(): Promise<Array<NormalizedToken>> {

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/metadata",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Token Metadata Tools for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",


### PR DESCRIPTION
## Description

Quick description:

- [ ] N/A
- [X] New features
- [ ] Bug fixes
- [ ] Typo/small tweaks

## Changes

Since a client might want to cache metadata responses, and still have access to functions such as `fetchToken`, there are use cases for when a client will want to construct the class without running the rather costly initialization function. 

## Tests


## Test Coverage
