### PR TITLE
Add timestamp to swap entity

### DIFF
--- a/tools/subgraph/schema.graphql
+++ b/tools/subgraph/schema.graphql
@@ -15,6 +15,7 @@ type Swap @entity {
   swap: SwapContract! # address of swap contract that executed this order
   block: BigInt # The block this swap was executed at
   transactionHash: Bytes # The transaction hash the swap was executed at
+  timestamp: BigInt # The timestamp the hash was executed at
   from: Bytes # address of the originator of the transaction
   to: Bytes # who the originator sent the transaction to
   value: BigInt # value sent with the transaction

--- a/tools/subgraph/src/SwapMapping.ts
+++ b/tools/subgraph/src/SwapMapping.ts
@@ -112,6 +112,7 @@ export function handleSwap(event: SwapEvent): void {
   completedSwap.swap = swapContract.id
   completedSwap.block = event.block.number
   completedSwap.transactionHash = event.transaction.hash
+  completedSwap.timestamp = event.block.timestamp
   completedSwap.from = event.transaction.from
   completedSwap.to = event.transaction.to
   completedSwap.value = event.transaction.value


### PR DESCRIPTION
## Description
timestamp is missing on the swap

## Changes
Add the timestamp on the swap entity.

Implementation details. These are mainly to help your fellow developers.

## Tests
```
{
    "data": {
        "swaps": [
            {
                "block": "116",
                "id": "0x90f8bf6a479f320ead074411a4b0e7944ea8c9c11588862034539",
                "timestamp": "1494374850",
                "transactionHash": "0x169413eea77aa34264840bfe873059327b973f37d28a79922371ac5db3263341"
            },`
```