### PR TITLE
Function to find token by symbol for @airswap/metadata

### DIFF
--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -170,7 +170,7 @@ class TokenMetadata {
   }
 
   // get token objects with symbols that match a query
-  public findBySymbol(query: string): NormalizedToken[] {
+  public findTokensBySymbol(query: string): NormalizedToken[] {
     const tokens = []
     this.tokens.forEach(token => {
       if (token.symbol.toUpperCase() === query.toUpperCase()) {

--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -169,6 +169,17 @@ class TokenMetadata {
     return this.tokensByAddress
   }
 
+  // get token objects with symbols that match a query
+  public findBySymbol(query: string): NormalizedToken[] {
+    const tokens = []
+    this.tokens.forEach(token => {
+      if (token.symbol.toUpperCase() === query.toUpperCase()) {
+        tokens.push(token)
+      }
+    })
+    return tokens
+  }
+
   // this will fail if the token you search isn't present in the Trust Wallet metadata, or if the letter casing doesn't match Trust's metadata
   public fetchImageBinaryUnstable = (address: string): Promise<string> => {
     return axios.get(getTrustImage(address))

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/metadata",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Token Metadata Tools for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",

--- a/tools/metadata/src/constants.ts
+++ b/tools/metadata/src/constants.ts
@@ -287,9 +287,9 @@ export const goerliTokensByAddress: Record<string, NormalizedToken> = {
     symbol: 'WETH',
     kind: tokenKinds.ERC20,
   },
-  '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31': {
+  '0x1a1ec25dc08e98e5e93f1104b5e5cdd298707d31': {
     name: 'AirSwap Token',
-    address: '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31',
+    address: '0x1a1ec25dc08e98e5e93f1104b5e5cdd298707d31',
     decimals: 4,
     symbol: 'AST',
     kind: tokenKinds.ERC20,
@@ -304,9 +304,9 @@ export const kovanTokensByAddress: Record<string, NormalizedToken> = {
     symbol: 'WETH',
     kind: tokenKinds.ERC20,
   },
-  '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31': {
+  '0x1a1ec25dc08e98e5e93f1104b5e5cdd298707d31': {
     name: 'AirSwap Token',
-    address: '0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31',
+    address: '0x1a1ec25dc08e98e5e93f1104b5e5cdd298707d31',
     decimals: 4,
     symbol: 'AST',
     kind: tokenKinds.ERC20,

--- a/tools/metadata/test/metadata.ts
+++ b/tools/metadata/test/metadata.ts
@@ -28,6 +28,10 @@ describe('Metadata: Mainnet', async () => {
       expect(token.symbol).to.equal('AST')
     })
   })
+  it('finds the airswap token', async () => {
+    const tokens = metadata.findBySymbol('AST')
+    expect(tokens[0].address).to.equal(stakingTokenAddresses[chainIds.MAINNET])
+  })
 })
 
 describe('Metadata: Rinkeby', async () => {
@@ -51,6 +55,10 @@ describe('Metadata: Rinkeby', async () => {
       stakingTokenAddresses[chainIds.RINKEBY]
     )
     expect(token.symbol).to.equal('AST')
+  })
+  it('finds the airswap token', async () => {
+    const tokens = metadata.findBySymbol('AST')
+    expect(tokens[0].address).to.equal(stakingTokenAddresses[chainIds.RINKEBY])
   })
 })
 
@@ -76,6 +84,10 @@ describe('Metadata: Goerli', async () => {
     )
     expect(token.symbol).to.equal('AST')
   })
+  it('finds the airswap token', async () => {
+    const tokens = metadata.findBySymbol('AST')
+    expect(tokens[0].address).to.equal(stakingTokenAddresses[chainIds.GOERLI])
+  })
 })
 
 describe('Metadata: Kovan', async () => {
@@ -99,5 +111,9 @@ describe('Metadata: Kovan', async () => {
       stakingTokenAddresses[chainIds.KOVAN]
     )
     expect(token.symbol).to.equal('AST')
+  })
+  it('finds the airswap token', async () => {
+    const tokens = metadata.findBySymbol('AST')
+    expect(tokens[0].address).to.equal(stakingTokenAddresses[chainIds.KOVAN])
   })
 })

--- a/tools/metadata/test/metadata.ts
+++ b/tools/metadata/test/metadata.ts
@@ -29,7 +29,7 @@ describe('Metadata: Mainnet', async () => {
     })
   })
   it('finds the airswap token', async () => {
-    const tokens = metadata.findBySymbol('AST')
+    const tokens = metadata.findTokensBySymbol('AST')
     expect(tokens[0].address).to.equal(stakingTokenAddresses[chainIds.MAINNET])
   })
 })
@@ -57,7 +57,7 @@ describe('Metadata: Rinkeby', async () => {
     expect(token.symbol).to.equal('AST')
   })
   it('finds the airswap token', async () => {
-    const tokens = metadata.findBySymbol('AST')
+    const tokens = metadata.findTokensBySymbol('AST')
     expect(tokens[0].address).to.equal(stakingTokenAddresses[chainIds.RINKEBY])
   })
 })
@@ -85,7 +85,7 @@ describe('Metadata: Goerli', async () => {
     expect(token.symbol).to.equal('AST')
   })
   it('finds the airswap token', async () => {
-    const tokens = metadata.findBySymbol('AST')
+    const tokens = metadata.findTokensBySymbol('AST')
     expect(tokens[0].address).to.equal(stakingTokenAddresses[chainIds.GOERLI])
   })
 })
@@ -113,7 +113,7 @@ describe('Metadata: Kovan', async () => {
     expect(token.symbol).to.equal('AST')
   })
   it('finds the airswap token', async () => {
-    const tokens = metadata.findBySymbol('AST')
+    const tokens = metadata.findTokensBySymbol('AST')
     expect(tokens[0].address).to.equal(stakingTokenAddresses[chainIds.KOVAN])
   })
 })


### PR DESCRIPTION
Adds a function to return all tokens sharing a symbol. For example:

```
await new TokenMetadata().fetchKnownTokens()
const DAI = metadata.findTokensBySymbol('DAI').shift()
```