### PR TITLE
move start block backwards for mainnet subgraph

### DIFF
--- a/tools/subgraph/config/mainnet.json
+++ b/tools/subgraph/config/mainnet.json
@@ -3,5 +3,5 @@
   "swap_address": "0x4572f2554421Bd64Bef1c22c8a81840E8D496BeA",
   "indexer_address" : "0xbA9aB9710Bd461F30C247f4cA2Cb7f453C22570e",
   "delegateFactory_address" : "0x072073f78a2d58610Ee3d5e170CA7AC9CB58a345",
-  "startBlock": 9371103
+  "startBlock": 9132138
 }


### PR DESCRIPTION
## Description

it appears I started indexing at a block much later than I originally thought.

this was detected by looking at the amount of AST staked on the indexer in etherscan https://etherscan.io/address/0xbA9aB9710Bd461F30C247f4cA2Cb7f453C22570e
versus querying against the playground and seeing the amounts not equal one another.

Quick description:

- [X] N/A
- [ ] New features
- [ ] Bug fixes
- [ ] Typo/small tweaks

## Changes

Implementation details. These are mainly to help your fellow developers.

## Tests


## Test Coverage
