### PR TITLE
Updating IDEX asset URL and response handler for @airswap/metadata

### DIFF
--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/metadata",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Token Metadata Tools for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",

--- a/tools/metadata/src/constants.ts
+++ b/tools/metadata/src/constants.ts
@@ -1,7 +1,7 @@
 import { NormalizedToken } from './types'
 import { tokenKinds } from '@airswap/constants'
 
-export const IDEX_TOKEN_API = 'https://api.idex.market/returnCurrencies'
+export const IDEX_TOKEN_API = 'https://api.idex.io/v1/assets'
 export const TRUST_WALLET_IMAGE_API =
   'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets'
 

--- a/tools/metadata/src/types.ts
+++ b/tools/metadata/src/types.ts
@@ -11,11 +11,11 @@ export interface NormalizedToken {
 
 export interface IdexToken {
   name: string
-  decimals: number
-  address: string
-  slug: string
+  assetDecimals: number
+  contractAddress: string
+  symbol: string
 }
 
-export interface IdexTokens {
-  [symbol: string]: IdexToken
+export interface IdexResponse {
+  [data: string]: Array<IdexToken>
 }


### PR DESCRIPTION
Changes to the `@airswap/metadata` package:

* IDEX asset URL has been updated
* IDEX response data format has been updated
* IDEX response is now an array

New URL: https://api.idex.io/v1/assets