### PR TITLE
Metadata providers

### DIFF
--- a/tools/metadata/README.md
+++ b/tools/metadata/README.md
@@ -26,6 +26,11 @@ Import into your application:
 
 ```TypeScript
 import TokenMetadata from '@airswap/metadata';
+import * as ethers from 'ethers';
+
+const provider = ethers.getDefaultProvider('mainnet');
+const metadata = new TokenMetadata(provider);
+const tokens = await metadata.fetchKnownTokens();
 ```
 
 ## Commands

--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -73,29 +73,29 @@ function normalizeMetamaskToken(
 }
 
 class TokenMetadata {
-  public chainId: string
+  public provider: ethers.providers.BaseProvider
   public ready: Promise<NormalizedToken[]>
   private tokens: NormalizedToken[]
   private tokensByAddress: { [address: string]: NormalizedToken }
 
-  public constructor(chainId = chainIds.MAINNET) {
-    this.chainId = String(chainId)
+  public constructor(provider = ethers.getDefaultProvider()) {
+    this.provider = provider
     this.tokens = []
     this.tokensByAddress = {}
     this.ready = this.fetchKnownTokens()
   }
 
   public async fetchKnownTokens(): Promise<Array<NormalizedToken>> {
-    switch (this.chainId) {
-      case chainIds.RINKEBY:
+    switch (this.provider.network.chainId) {
+      case Number(chainIds.RINKEBY):
         this.tokensByAddress = rinkebyTokensByAddress
         this.tokens = Object.values(this.tokensByAddress)
         return this.tokens
-      case chainIds.GOERLI:
+      case Number(chainIds.GOERLI):
         this.tokensByAddress = goerliTokensByAddress
         this.tokens = Object.values(this.tokensByAddress)
         return this.tokens
-      case chainIds.KOVAN:
+      case Number(chainIds.KOVAN):
         this.tokensByAddress = kovanTokensByAddress
         this.tokens = Object.values(this.tokensByAddress)
         return this.tokens
@@ -201,10 +201,13 @@ class TokenMetadata {
     // check if the token is an NFT
     let openseaContractData = null
     try {
-      if (this.chainId === '1' || this.chainId === '4') {
+      if (
+        this.provider.network.chainId === 1 ||
+        this.provider.network.chainId === 4
+      ) {
         openseaContractData = await getOpenseaContractMetadata(
           searchAddress,
-          Number(this.chainId)
+          this.provider.network.chainId
         )
       }
     } catch (error) {
@@ -228,9 +231,9 @@ class TokenMetadata {
     }
 
     const [tokenSymbol, tokenName, tokenDecimals] = await Promise.all([
-      getTokenSymbol(searchAddress, chainNames[this.chainId]),
-      getTokenName(searchAddress, chainNames[this.chainId]),
-      getTokenDecimals(searchAddress, chainNames[this.chainId]),
+      getTokenSymbol(searchAddress, this.provider),
+      getTokenName(searchAddress, this.provider),
+      getTokenDecimals(searchAddress, this.provider),
     ])
 
     const newToken: NormalizedToken = {

--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -15,12 +15,7 @@ import {
   getOpenSeaUrl,
 } from './src/constants'
 
-import {
-  chainIds,
-  ADDRESS_ZERO,
-  tokenKinds,
-  chainNames,
-} from '@airswap/constants'
+import { chainIds, ADDRESS_ZERO, tokenKinds } from '@airswap/constants'
 import { getTokenName, getTokenSymbol, getTokenDecimals } from './src/helpers'
 
 export function getTrustImage(address: string): string {

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/metadata",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "description": "Token Metadata Tools for AirSwap Developers",
   "contributors": [
     "Don Mosites <don.mosites@fluidity.io>",

--- a/tools/metadata/src/helpers.ts
+++ b/tools/metadata/src/helpers.ts
@@ -1,6 +1,5 @@
 import * as ethers from 'ethers'
 import { ERC20_ABI, ERC20_BYTES32_ABI } from './constants'
-import { Arrayish } from 'ethers/utils'
 
 export function getContract(
   address: string,

--- a/tools/metadata/src/helpers.ts
+++ b/tools/metadata/src/helpers.ts
@@ -2,50 +2,58 @@ import * as ethers from 'ethers'
 import { ERC20_ABI, ERC20_BYTES32_ABI } from './constants'
 import { Arrayish } from 'ethers/utils'
 
-export function getContract(address: string, ABI: any, network = 'mainnet') {
-  const provider =
-    network === 'mainnet'
-      ? ethers.getDefaultProvider()
-      : ethers.getDefaultProvider(network.toLowerCase())
+export function getContract(
+  address: string,
+  ABI: any,
+  provider: ethers.providers.BaseProvider
+) {
   if (!address || !address.startsWith('0x')) {
     throw Error(`Invalid 'address' parameter '${address}'.`)
   }
-
   return new ethers.Contract(address, ABI, provider)
 }
 
-export async function getTokenName(tokenAddress: string, network: string) {
+export async function getTokenName(
+  tokenAddress: string,
+  provider: ethers.providers.BaseProvider
+) {
   if (!tokenAddress || !tokenAddress.startsWith('0x')) {
     throw Error(`Invalid 'tokenAddress' parameter`)
   }
 
-  return getContract(tokenAddress, ERC20_ABI, network)
+  return getContract(tokenAddress, ERC20_ABI, provider)
     .name()
     .catch(() =>
-      getContract(tokenAddress, ERC20_BYTES32_ABI, network)
+      getContract(tokenAddress, ERC20_BYTES32_ABI, provider)
         .name()
         .then((bytes32: Arrayish) => ethers.utils.parseBytes32String(bytes32))
     )
 }
 
-export async function getTokenSymbol(tokenAddress: string, network: string) {
+export async function getTokenSymbol(
+  tokenAddress: string,
+  provider: ethers.providers.BaseProvider
+) {
   if (!tokenAddress || !tokenAddress.startsWith('0x')) {
     throw Error(`Invalid 'tokenAddress' parameter`)
   }
 
-  return getContract(tokenAddress, ERC20_ABI, network)
+  return getContract(tokenAddress, ERC20_ABI, provider)
     .symbol()
     .catch(() =>
-      getContract(tokenAddress, ERC20_BYTES32_ABI, network)
+      getContract(tokenAddress, ERC20_BYTES32_ABI, provider)
         .symbol()
         .then((bytes32: Arrayish) => ethers.utils.parseBytes32String(bytes32))
     )
 }
 
-export async function getTokenDecimals(tokenAddress: string, network: string) {
+export async function getTokenDecimals(
+  tokenAddress: string,
+  provider: ethers.providers.BaseProvider
+) {
   if (!tokenAddress || !tokenAddress.startsWith('0x')) {
     throw Error(`Invalid 'tokenAddress' parameter`)
   }
 
-  return getContract(tokenAddress, ERC20_ABI, network).decimals()
+  return getContract(tokenAddress, ERC20_ABI, provider).decimals()
 }

--- a/tools/metadata/src/helpers.ts
+++ b/tools/metadata/src/helpers.ts
@@ -20,14 +20,13 @@ export async function getTokenName(
   if (!tokenAddress || !tokenAddress.startsWith('0x')) {
     throw Error(`Invalid 'tokenAddress' parameter`)
   }
-
-  return getContract(tokenAddress, ERC20_ABI, provider)
-    .name()
-    .catch(() =>
-      getContract(tokenAddress, ERC20_BYTES32_ABI, provider)
-        .name()
-        .then((bytes32: Arrayish) => ethers.utils.parseBytes32String(bytes32))
+  try {
+    return await getContract(tokenAddress, ERC20_ABI, provider).name()
+  } catch {
+    return ethers.utils.parseBytes32String(
+      await getContract(tokenAddress, ERC20_BYTES32_ABI, provider).name()
     )
+  }
 }
 
 export async function getTokenSymbol(
@@ -38,13 +37,13 @@ export async function getTokenSymbol(
     throw Error(`Invalid 'tokenAddress' parameter`)
   }
 
-  return getContract(tokenAddress, ERC20_ABI, provider)
-    .symbol()
-    .catch(() =>
-      getContract(tokenAddress, ERC20_BYTES32_ABI, provider)
-        .symbol()
-        .then((bytes32: Arrayish) => ethers.utils.parseBytes32String(bytes32))
+  try {
+    return await getContract(tokenAddress, ERC20_ABI, provider).symbol()
+  } catch {
+    return ethers.utils.parseBytes32String(
+      await getContract(tokenAddress, ERC20_BYTES32_ABI, provider).symbol()
     )
+  }
 }
 
 export async function getTokenDecimals(
@@ -55,5 +54,5 @@ export async function getTokenDecimals(
     throw Error(`Invalid 'tokenAddress' parameter`)
   }
 
-  return getContract(tokenAddress, ERC20_ABI, provider).decimals()
+  return await getContract(tokenAddress, ERC20_ABI, provider).decimals()
 }

--- a/tools/metadata/src/helpers.ts
+++ b/tools/metadata/src/helpers.ts
@@ -51,7 +51,7 @@ export async function getTokenSymbol(
   }
 }
 
-export async function getTokenDecimals(
+export function getTokenDecimals(
   tokenAddress: string,
   provider: ethers.providers.BaseProvider
 ) {
@@ -59,5 +59,5 @@ export async function getTokenDecimals(
     throw Error(`Invalid 'tokenAddress' parameter`)
   }
 
-  return await getContract(tokenAddress, ERC20_ABI, provider).decimals()
+  return getContract(tokenAddress, ERC20_ABI, provider).decimals()
 }

--- a/tools/metadata/src/helpers.ts
+++ b/tools/metadata/src/helpers.ts
@@ -22,9 +22,12 @@ export async function getTokenName(
   try {
     return await getContract(tokenAddress, ERC20_ABI, provider).name()
   } catch {
-    return ethers.utils.parseBytes32String(
-      await getContract(tokenAddress, ERC20_BYTES32_ABI, provider).name()
-    )
+    const name = await getContract(
+      tokenAddress,
+      ERC20_BYTES32_ABI,
+      provider
+    ).name()
+    return ethers.utils.parseBytes32String(name)
   }
 }
 
@@ -39,9 +42,12 @@ export async function getTokenSymbol(
   try {
     return await getContract(tokenAddress, ERC20_ABI, provider).symbol()
   } catch {
-    return ethers.utils.parseBytes32String(
-      await getContract(tokenAddress, ERC20_BYTES32_ABI, provider).symbol()
-    )
+    const symbol = await getContract(
+      tokenAddress,
+      ERC20_BYTES32_ABI,
+      provider
+    ).symbol()
+    return ethers.utils.parseBytes32String(symbol)
   }
 }
 

--- a/tools/metadata/test/metadata.ts
+++ b/tools/metadata/test/metadata.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import * as ethers from 'ethers'
 
 import TokenMetadata from '..'
 import {
@@ -9,7 +10,8 @@ import {
 } from '@airswap/constants'
 
 describe('Metadata: Mainnet', async () => {
-  const metadata = new TokenMetadata(chainIds.MAINNET)
+  const provider = ethers.getDefaultProvider('mainnet')
+  const metadata = new TokenMetadata(provider)
 
   it('fetches all known tokens', async () => {
     const tokens = await metadata.fetchKnownTokens()
@@ -35,7 +37,8 @@ describe('Metadata: Mainnet', async () => {
 })
 
 describe('Metadata: Rinkeby', async () => {
-  const metadata = new TokenMetadata(chainIds.RINKEBY)
+  const provider = ethers.getDefaultProvider('rinkeby')
+  const metadata = new TokenMetadata(provider)
 
   it('fetches all known tokens', async () => {
     metadata.fetchKnownTokens().then(tokens => {
@@ -63,7 +66,8 @@ describe('Metadata: Rinkeby', async () => {
 })
 
 describe('Metadata: Goerli', async () => {
-  const metadata = new TokenMetadata(chainIds.GOERLI)
+  const provider = ethers.getDefaultProvider('goerli')
+  const metadata = new TokenMetadata(provider)
 
   it('fetches all known tokens', async () => {
     metadata.fetchKnownTokens().then(tokens => {
@@ -91,7 +95,8 @@ describe('Metadata: Goerli', async () => {
 })
 
 describe('Metadata: Kovan', async () => {
-  const metadata = new TokenMetadata(chainIds.KOVAN)
+  const provider = ethers.getDefaultProvider('kovan')
+  const metadata = new TokenMetadata(provider)
 
   it('fetches all known tokens', async () => {
     metadata.fetchKnownTokens().then(tokens => {


### PR DESCRIPTION
Updates `@airswap/metadata` to take an ethers provider instead of a chain ID.

This makes custom providers possible. Version updated from `0.1.11` to `0.2.0`.