### PR TITLE
Upgrade and Remove All Tokens in Reverse Order

### DIFF
--- a/source/registry/contracts/Registry.sol
+++ b/source/registry/contracts/Registry.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 pragma abicoder v2;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 
@@ -13,7 +12,6 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 contract Registry {
   using SafeERC20 for IERC20;
-  using SafeMath for uint256;
   using EnumerableSet for EnumerableSet.AddressSet;
 
   event TokensAdded(address account, address[] tokens);
@@ -59,7 +57,7 @@ contract Registry {
       require(tokens.add(token), "TOKEN_EXISTS");
       supportingStakers[token].add(msg.sender);
     }
-    transferAmount = transferAmount.add(tokenCost.mul(length));
+    transferAmount += tokenCost * length;
     emit TokensAdded(msg.sender, tokenList);
     stakingToken.safeTransferFrom(msg.sender, address(this), transferAmount);
   }
@@ -78,7 +76,7 @@ contract Registry {
       );
       supportingStakers[token].remove(msg.sender);
     }
-    uint256 transferAmount = tokenCost.mul(length);
+    uint256 transferAmount = tokenCost * length;
     if (tokens.length() == 0) {
       transferAmount += obligationCost;
     }

--- a/source/registry/hardhat.config.js
+++ b/source/registry/hardhat.config.js
@@ -28,7 +28,7 @@ module.exports = {
     },
   },
   solidity: {
-    version: '0.7.6',
+    version: '0.8.4',
     settings: {
       optimizer: {
         enabled: true,

--- a/source/registry/package.json
+++ b/source/registry/package.json
@@ -23,7 +23,7 @@
     "@nomiclabs/hardhat-truffle5": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@nomiclabs/hardhat-web3": "^2.0.0",
-    "@openzeppelin/contracts": "^3.4.0",
+    "@openzeppelin/contracts": "^4.1.0",
     "chai": "^4.3.0",
     "ethereum-waffle": "^3.2.2",
     "ethers": "^5.0.31",

--- a/source/registry/test/Registry-unit.js
+++ b/source/registry/test/Registry-unit.js
@@ -211,8 +211,8 @@ describe('Registry Unit', () => {
         .to.emit(registry, 'TokensRemoved')
         .withArgs(account1.address, [
           token1.address,
-          token3.address,
           token2.address,
+          token3.address,
         ])
 
       //NOTE: Note that there are no guarantees on the ordering of values inside the array, and it may change when more values are added or removed.


### PR DESCRIPTION
#### Changes
* Caches AddressSet storage, saving linear amount of keccak map lookups
* Upgrades to latest solidity, 0.8.4
* Upgrades to latest openzeppelin-contracts, which needs solidity ^0.8.0
* Reversed removeAll order, fixing test and saving gas with https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2605
* Removes SafeMath, no-longer needed with solidity ^0.8.0


Reviewers @dmosites