### PR TITLE
feature-update/metadata-fetchtokens

### DIFF
--- a/tools/metadata/test/metadata.ts
+++ b/tools/metadata/test/metadata.ts
@@ -18,20 +18,20 @@ describe('Metadata: Mainnet', async () => {
 
   it('fetches all known tokens', async () => {
     tokens = await fetchTokens(chainIds.MAINNET)
-    expect(tokens.length).to.not.equal(0)
+    expect(tokens.tokens.length).to.not.equal(0)
   })
   it('checks that ETH does not exist', async () => {
-    expect(findTokenByAddress(ADDRESS_ZERO, tokens)).to.be.undefined
+    expect(findTokenByAddress(ADDRESS_ZERO, tokens.tokens)).to.be.undefined
   })
   it('checks that WETH exists', async () => {
-    expect(findTokenByAddress(wethAddresses[chainIds.MAINNET], tokens)).to.not
-      .be.undefined
+    expect(findTokenByAddress(wethAddresses[chainIds.MAINNET], tokens.tokens))
+      .to.not.be.undefined
   })
   it('finds the AirSwap token', async () => {
-    expect(findTokensBySymbol('AST', tokens)[0].address).to.equal(
+    expect(findTokensBySymbol('AST', tokens.tokens)[0].address).to.equal(
       stakingTokenAddresses[chainIds.MAINNET]
     )
-    expect(firstTokenBySymbol('AST', tokens).address).to.equal(
+    expect(firstTokenBySymbol('AST', tokens.tokens).address).to.equal(
       stakingTokenAddresses[chainIds.MAINNET]
     )
   })
@@ -42,20 +42,20 @@ describe('Metadata: Rinkeby', async () => {
 
   it('fetches all known tokens', async () => {
     tokens = await fetchTokens(chainIds.RINKEBY)
-    expect(tokens.length).to.not.equal(0)
+    expect(tokens.tokens.length).to.not.equal(0)
   })
   it('checks that ETH does not exist', async () => {
-    expect(findTokenByAddress(ADDRESS_ZERO, tokens)).to.be.undefined
+    expect(findTokenByAddress(ADDRESS_ZERO, tokens.tokens)).to.be.undefined
   })
   it('checks that WETH exists', async () => {
-    expect(findTokenByAddress(wethAddresses[chainIds.RINKEBY], tokens)).to.not
-      .be.undefined
+    expect(findTokenByAddress(wethAddresses[chainIds.RINKEBY], tokens.tokens))
+      .to.not.be.undefined
   })
   it('finds the AirSwap token', async () => {
-    expect(findTokensBySymbol('AST', tokens)[0].address).to.equal(
+    expect(findTokensBySymbol('AST', tokens.tokens)[0].address).to.equal(
       stakingTokenAddresses[chainIds.RINKEBY]
     )
-    expect(firstTokenBySymbol('AST', tokens).address).to.equal(
+    expect(firstTokenBySymbol('AST', tokens.tokens).address).to.equal(
       stakingTokenAddresses[chainIds.RINKEBY]
     )
   })

--- a/tools/metadata/tsconfig.json
+++ b/tools/metadata/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "lib": ["ES2020.Promise"]
   }
 }


### PR DESCRIPTION
## Description

The `fetchTokens` function in the metadata repo will currently fail if one of the urls it is fetching throws an error, because we are using `Promise.all`. 

Quick description:

- [] N/A
- [ ] New features
- [x] Bug fixes
- [x] Typo/small tweaks

## Changes

This PR changes the code from `Promise.all` -> `Promise.allSettled` and the return `Promise<Array<TokenInfo>>` -> `Promise<{tokens: TokenInfo[]; errors: string[]}>`

## Tests

Updated tests to accommodate the new return value of `fetchTokens`

## Test Coverage
