### PR TITLE
Add websocket support to parseUrl

### DIFF
--- a/tools/utils/index.ts
+++ b/tools/utils/index.ts
@@ -127,7 +127,7 @@ export function getTimestamp(): string {
 }
 
 export function parseUrl(locator: string): url.UrlWithStringQuery {
-  if (!/^http:\/\//.test(locator) && !/^https:\/\//.test(locator)) {
+  if (!/(http|ws)s?:\/\//.test(locator)) {
     locator = `https://${locator}`
   }
   return url.parse(locator)

--- a/tools/utils/package.json
+++ b/tools/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/utils",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Utilities for AirSwap Development",
   "contributors": [
     "Don Mosites"


### PR DESCRIPTION
`parseUrl` takes a server locator and defaults it to `https` if neither http or https is specified.

This PR updates the test so that websocket locator urls aren't prepended with `https`. Required for #672 