### PR TITLE
Correct last look websocket node implementation

### DIFF
--- a/tools/libraries/package.json
+++ b/tools/libraries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/libraries",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Protocol Libraries for AirSwap Developers",
   "contributors": [
     "Don Mosites",

--- a/tools/libraries/src/Server.ts
+++ b/tools/libraries/src/Server.ts
@@ -41,7 +41,7 @@ type Pricing = {
 
 if (!isBrowser) {
   JsonRpcWebsocket.setWebSocketFactory((url: string) => {
-    const ws = require('websocket').client
+    const ws = require('websocket').w3cwebsocket
     return new ws(url)
   })
 }

--- a/tools/libraries/test/test-utils.ts
+++ b/tools/libraries/test/test-utils.ts
@@ -150,7 +150,7 @@ export class MockSocketServer extends BaseMockSocketServer {
   }
 
   public static startMockingWebSocket(): void {
-    mock('websocket', { client: WebSocket })
+    mock('websocket', { w3cwebsocket: WebSocket })
   }
 
   public static stopMockingWebSocket(): void {


### PR DESCRIPTION
`0.0.1` never attempts to connect on node.
This was being covered up in the tests because the mock that was passed didn't have the same API as what it was meant to be mocking.

This PR should correct this.