### PR TITLE
Change pool withdraw functions to signatures, update tests and tools

### DIFF
--- a/source/converter/contracts/Converter.sol
+++ b/source/converter/contracts/Converter.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./TokenPaymentSplitter.sol";
@@ -23,7 +22,6 @@ interface IUniswapV2Router02 {
  * @notice https://www.airswap.io/
  */
 contract Converter is Ownable, ReentrancyGuard, TokenPaymentSplitter {
-  using SafeMath for uint256;
   using SafeERC20 for IERC20;
 
   address public wETH;
@@ -145,15 +143,14 @@ contract Converter is Ownable, ReentrancyGuard, TokenPaymentSplitter {
     uint256 totalPayeeAmount = _balanceOfErc20(swapToToken);
     // Calculates trigger reward amount and transfers to msg.sender.
     if (triggerFee > 0) {
-      uint256 triggerFeeAmount = totalPayeeAmount.mul(triggerFee).div(100);
+      uint256 triggerFeeAmount = (totalPayeeAmount * triggerFee) / 100;
       _transferErc20(msg.sender, swapToToken, triggerFeeAmount);
-      totalPayeeAmount = totalPayeeAmount.sub(triggerFeeAmount);
+      totalPayeeAmount = totalPayeeAmount - triggerFeeAmount;
     }
     // Transfers remaining amount to reward payee address(es).
     for (uint256 i = 0; i < _payees.length; i++) {
-      uint256 payeeAmount = (totalPayeeAmount.mul(_shares[_payees[i]])).div(
-        _totalShares
-      );
+      uint256 payeeAmount = (totalPayeeAmount * _shares[_payees[i]]) /
+        _totalShares;
       _transferErc20(_payees[i], swapToToken, payeeAmount);
     }
     emit ConvertAndTransfer(

--- a/source/converter/contracts/TokenPaymentSplitter.sol
+++ b/source/converter/contracts/TokenPaymentSplitter.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 /**
  * @title TokenPaymentSplitter

--- a/source/pool/contracts/Pool.sol
+++ b/source/pool/contracts/Pool.sol
@@ -6,8 +6,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@airswap/staking/contracts/interfaces/IStaking.sol";
 import "./interfaces/IPool.sol";
 
@@ -19,6 +17,34 @@ contract Pool is IPool, Ownable {
   using SafeERC20 for IERC20;
   using SafeMath for uint256;
 
+  bytes32 public constant DOMAIN_TYPEHASH =
+    keccak256(
+      abi.encodePacked(
+        "EIP712Domain(",
+        "string name,",
+        "string version,",
+        "uint256 chainId,",
+        "address verifyingContract",
+        ")"
+      )
+    );
+
+  bytes32 public constant CLAIM_TYPEHASH =
+    keccak256(
+      abi.encodePacked(
+        "Claim(",
+        "uint256 nonce,",
+        "address participant,",
+        "uint256 score",
+        ")"
+      )
+    );
+
+  bytes32 public constant DOMAIN_NAME = keccak256("POOL");
+  bytes32 public constant DOMAIN_VERSION = keccak256("1");
+  uint256 public immutable DOMAIN_CHAIN_ID;
+  bytes32 public immutable DOMAIN_SEPARATOR;
+
   uint256 internal constant MAX_PERCENTAGE = 100;
   uint256 internal constant MAX_SCALE = 77;
 
@@ -28,17 +54,11 @@ contract Pool is IPool, Ownable {
   // Max percentage for a claim with infinite score
   uint256 public max;
 
-  // Mapping of tree root to boolean to enable claims
-  mapping(bytes32 => bool) public roots;
-
   // Mapping of address to boolean to enable admin accounts
   mapping(address => bool) public admins;
 
-  // Mapping of tree root to account to mark as claimed
-  mapping(bytes32 => mapping(address => bool)) public claimed;
-
-  // Mapping of signed hash to boolean to mark as claimed
-  mapping(bytes32 => bool) public hashClaimed;
+  // Mapping of participant addresses to nonces to boolean to mark as claimed
+  mapping(address => mapping(uint256 => bool)) public noncesClaimed;
 
   // Staking contract address
   address public stakingContract;
@@ -66,15 +86,20 @@ contract Pool is IPool, Ownable {
     stakingContract = _stakingContract;
     stakingToken = _stakingToken;
     admins[msg.sender] = true;
-    IERC20(stakingToken).approve(stakingContract, 2**256 - 1);
-  }
 
-  /**
-   * @dev Throws if called by any account other than the admin.
-   */
-  modifier multiAdmin() {
-    require(admins[msg.sender] == true, "NOT_ADMIN");
-    _;
+    uint256 currentChainId = getChainId();
+    DOMAIN_CHAIN_ID = currentChainId;
+    DOMAIN_SEPARATOR = keccak256(
+      abi.encode(
+        DOMAIN_TYPEHASH,
+        DOMAIN_NAME,
+        DOMAIN_VERSION,
+        currentChainId,
+        this
+      )
+    );
+
+    IERC20(stakingToken).approve(stakingContract, 2**256 - 1);
   }
 
   /**
@@ -146,38 +171,6 @@ contract Pool is IPool, Ownable {
   }
 
   /**
-   * @notice Set claims from previous pool contract
-   * @dev Only owner
-   * @param root bytes32
-   * @param accounts address[]
-   */
-  function setClaimed(bytes32 root, address[] memory accounts)
-    external
-    override
-    multiAdmin
-  {
-    if (roots[root] == false) {
-      roots[root] = true;
-    }
-    for (uint256 i = 0; i < accounts.length; i++) {
-      address account = accounts[i];
-      require(!claimed[root][account], "CLAIM_ALREADY_MADE");
-      claimed[root][account] = true;
-    }
-    emit Enable(root);
-  }
-
-  /**
-   * @notice Enables claims for a merkle tree of a set of scores
-   * @param root bytes32
-   */
-  function enable(bytes32 root) external override multiAdmin {
-    require(roots[root] == false, "ROOT_EXISTS");
-    roots[root] = true;
-    emit Enable(root);
-  }
-
-  /**
    * @notice Admin function to migrate funds
    * @dev Only owner
    * @param tokens address[]
@@ -197,161 +190,147 @@ contract Pool is IPool, Ownable {
 
   /**
    * @notice Withdraw tokens from the pool using claims
-   * @param claims Claim[]
    * @param token address
+   * @param nonce uint256
+   * @param score uint256
+   * @param v uint8 "v" value of the ECDSA signature
+   * @param r bytes32 "r" value of the ECDSA signature
+   * @param s bytes32 "s" value of the ECDSA signature
    */
-  function withdraw(Claim[] memory claims, address token) external override {
-    withdrawProtected(claims, token, 0, msg.sender);
+  function withdraw(
+    address token,
+    uint256 nonce,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external override {
+    withdrawProtected(0, msg.sender, token, nonce, msg.sender, score, v, r, s);
   }
 
   /**
    * @notice Withdraw tokens from the pool using claims and send to recipient
-   * @param claims Claim[]
+   * @param minimumAmount uint256
    * @param token address
    * @param recipient address
+   * @param nonce uint256
+   * @param score uint256
+   * @param v uint8 "v" value of the ECDSA signature
+   * @param r bytes32 "r" value of the ECDSA signature
+   * @param s bytes32 "s" value of the ECDSA signature
    */
   function withdrawWithRecipient(
-    Claim[] memory claims,
-    address token,
     uint256 minimumAmount,
-    address recipient
+    address token,
+    address recipient,
+    uint256 nonce,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
   ) external override {
-    withdrawProtected(claims, token, minimumAmount, recipient);
+    withdrawProtected(
+      minimumAmount,
+      recipient,
+      token,
+      nonce,
+      msg.sender,
+      score,
+      v,
+      r,
+      s
+    );
   }
 
   /**
    * @notice Withdraw tokens from the pool using claims and stake
-   * @param claims Claim[]
+   * @param minimumAmount uint256
    * @param token address
+   * @param nonce uint256
+   * @param score uint256
+   * @param v uint8 "v" value of the ECDSA signature
+   * @param r bytes32 "r" value of the ECDSA signature
+   * @param s bytes32 "s" value of the ECDSA signature
    */
   function withdrawAndStake(
-    Claim[] memory claims,
+    uint256 minimumAmount,
     address token,
-    uint256 minimumAmount
+    uint256 nonce,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
   ) external override {
     require(token == address(stakingToken), "INVALID_TOKEN");
-    (uint256 amount, bytes32[] memory rootList) = _withdrawCheck(
-      claims,
-      token,
-      minimumAmount
-    );
+    _checkValidClaim(nonce, msg.sender, score, v, r, s);
+    uint256 amount = _withdrawCheck(score, token, minimumAmount);
     IStaking(stakingContract).stakeFor(msg.sender, amount);
-    emit Withdraw(rootList, msg.sender, token, amount);
+    emit Withdraw(nonce, msg.sender, token, amount);
   }
 
   /**
-   * @notice Withdraw tokens from the pool using claims and stake for another account
-   * @param claims Claim[]
+   * @notice Withdraw tokens from the pool using signature and stake for another account
+   * @param minimumAmount uint256
    * @param token address
    * @param account address
+   * @param nonce uint256
+   * @param score uint256
+   * @param v uint8 "v" value of the ECDSA signature
+   * @param r bytes32 "r" value of the ECDSA signature
+   * @param s bytes32 "s" value of the ECDSA signature
    */
   function withdrawAndStakeFor(
-    Claim[] memory claims,
-    address token,
     uint256 minimumAmount,
-    address account
+    address token,
+    address account,
+    uint256 nonce,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
   ) external override {
     require(token == address(stakingToken), "INVALID_TOKEN");
-    (uint256 amount, bytes32[] memory rootList) = _withdrawCheck(
-      claims,
-      token,
-      minimumAmount
-    );
+    _checkValidClaim(nonce, msg.sender, score, v, r, s);
+    uint256 amount = _withdrawCheck(score, token, minimumAmount);
     IERC20(stakingToken).approve(stakingContract, amount);
     IStaking(stakingContract).stakeFor(account, amount);
-    emit Withdraw(rootList, msg.sender, token, amount);
+    emit Withdraw(nonce, msg.sender, token, amount);
   }
-
-  /** @notice withdraw function that uses signature instead of claim calculated from merkle root
-    * @param v signature parameter v of one of the admins
-    * @param r signature parameter r of one of the admins
-    * @param s signature parameter s of one of the admins
-    * @param token address
-    * @param amount uint256 withdrawal amount
-    * @param nonce uint256 add nonce to the hash, nonce must be non-reusable
-    */
-    function withdrawWithSignature(
-      uint8 v,
-      bytes32 r,
-      bytes32 s,
-      address token,
-      uint256 amount,
-      uint256 nonce
-    ) external override returns (uint256) {
-      // calculate hash
-      bytes32 calculatedHash = keccak256(abi.encodePacked(token, amount, msg.sender, nonce));
-      // verify hash has not been claimed
-      require(!hashClaimed[calculatedHash], "CLAIM_ALREADY_MADE");
-      // verify hash is signed by an admin, ECDSA.recover will throw if signer is not recoverable
-      bytes32 ethSignedMessageHash = ECDSA.toEthSignedMessageHash(calculatedHash);
-      address signer = ECDSA.recover(ethSignedMessageHash, v,r,s);
-      require(admins[signer], "NOT_VERIFIED");
-      // mark the hash of (signature, hash and nonce) and recipient as true
-      hashClaimed[calculatedHash] = true;
-      IERC20(token).safeTransfer(msg.sender, amount);
-      emit WithdrawWithSignature(signer, token, amount, msg.sender, nonce);
-      return amount;
-    }
 
   /**
    * @notice Withdraw tokens from the pool using claims
-   * @param claims Claim[]
-   * @param token address
    * @param minimumAmount uint256
-   * @param recipient address
+   * @param token address
+   * @param participant address
+   * @param nonce uint256
+   * @param score uint256
+   * @param v uint8 "v" value of the ECDSA signature
+   * @param r bytes32 "r" value of the ECDSA signature
+   * @param s bytes32 "s" value of the ECDSA signature
    */
   function withdrawProtected(
-    Claim[] memory claims,
-    address token,
     uint256 minimumAmount,
-    address recipient
-  ) public override returns (uint256) {
-    (uint256 amount, bytes32[] memory rootList) = _withdrawCheck(
-      claims,
-      token,
-      minimumAmount
-    );
-    IERC20(token).safeTransfer(recipient, amount);
-    emit Withdraw(rootList, msg.sender, token, amount);
-    return amount;
-  }
-
-  /**
-   * @notice Withdraw tokens from the pool using claims
-   * @param claims Claim[]
-   * @param token address
-   * @param minimumAmount uint256
-   */
-  function _withdrawCheck(
-    Claim[] memory claims,
+    address recipient,
     address token,
-    uint256 minimumAmount
-  ) internal returns (uint256, bytes32[] memory) {
-    require(claims.length > 0, "CLAIMS_MUST_BE_PROVIDED");
-    uint256 totalScore = 0;
-    bytes32[] memory rootList = new bytes32[](claims.length);
-    Claim memory claim;
-    for (uint256 i = 0; i < claims.length; i++) {
-      claim = claims[i];
-      require(roots[claim.root], "ROOT_NOT_ENABLED");
-      require(!claimed[claim.root][msg.sender], "CLAIM_ALREADY_MADE");
-      require(
-        verify(msg.sender, claim.root, claim.score, claim.proof),
-        "PROOF_INVALID"
-      );
-      totalScore = totalScore.add(claim.score);
-      claimed[claim.root][msg.sender] = true;
-      rootList[i] = claim.root;
-    }
-    uint256 amount = calculate(totalScore, token);
-    require(amount >= minimumAmount, "INSUFFICIENT_AMOUNT");
-    return (amount, rootList);
+    uint256 nonce,
+    address participant,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) public override returns (uint256) {
+    _checkValidClaim(nonce, participant, score, v, r, s);
+    uint256 amount = _withdrawCheck(score, token, minimumAmount);
+    IERC20(token).safeTransfer(recipient, amount);
+    emit Withdraw(nonce, participant, token, amount);
+    return amount;
   }
 
   /**
    * @notice Calculate output amount for an input score
    * @param score uint256
    * @param token address
+   * @return amount uint256 amount to claim based on balance, scale, and max
    */
   function calculate(uint256 score, address token)
     public
@@ -365,37 +344,110 @@ contract Pool is IPool, Ownable {
   }
 
   /**
-   * @notice Calculate output amount for an input score
+   * @notice Verify a signature
+   * @param nonce uint256
+   * @param participant address
    * @param score uint256
-   * @param tokens address[]
+   * @param v uint8 "v" value of the ECDSA signature
+   * @param r bytes32 "r" value of the ECDSA signature
+   * @param s bytes32 "s" value of the ECDSA signature
    */
-  function calculateMultiple(uint256 score, address[] calldata tokens)
-    public
-    view
-    override
-    returns (uint256[] memory outputAmounts)
-  {
-    outputAmounts = new uint256[](tokens.length);
-    for (uint256 i = 0; i < tokens.length; i++) {
-      uint256 output = calculate(score, tokens[i]);
-      outputAmounts[i] = output;
+  function verify(
+    uint256 nonce,
+    address participant,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) public view override returns (bool valid) {
+    require(DOMAIN_CHAIN_ID == getChainId(), "CHAIN_ID_CHANGED");
+    bytes32 claimHash = keccak256(
+      abi.encode(CLAIM_TYPEHASH, nonce, participant, score)
+    );
+    address signatory = ecrecover(
+      keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, claimHash)),
+      v,
+      r,
+      s
+    );
+    admins[signatory] && !noncesClaimed[participant][nonce]
+      ? valid = true
+      : valid = false;
+  }
+
+  /**
+   * @notice Returns the current chainId using the chainid opcode
+   * @return id uint256 The chain id
+   */
+  function getChainId() public view returns (uint256 id) {
+    // no-inline-assembly
+    assembly {
+      id := chainid()
     }
   }
 
   /**
-   * @notice Verify a claim proof
+   * @notice Checks Claim Nonce, Participant, Score, Signature
+   * @param nonce uint256
    * @param participant address
-   * @param root bytes32
    * @param score uint256
-   * @param proof bytes32[]
+   * @param v uint8 "v" value of the ECDSA signature
+   * @param r bytes32 "r" value of the ECDSA signature
+   * @param s bytes32 "s" value of the ECDSA signature
    */
-  function verify(
+  function _checkValidClaim(
+    uint256 nonce,
     address participant,
-    bytes32 root,
     uint256 score,
-    bytes32[] memory proof
-  ) public pure override returns (bool valid) {
-    bytes32 leaf = keccak256(abi.encodePacked(participant, score));
-    return MerkleProof.verify(proof, root, leaf);
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) internal {
+    require(DOMAIN_CHAIN_ID == getChainId(), "CHAIN_ID_CHANGED");
+    bytes32 claimHash = keccak256(
+      abi.encode(CLAIM_TYPEHASH, nonce, participant, score)
+    );
+    address signatory = ecrecover(
+      keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, claimHash)),
+      v,
+      r,
+      s
+    );
+    require(admins[signatory], "UNAUTHORIZED");
+    require(_markNonceAsUsed(participant, nonce), "NONCE_ALREADY_USED");
+  }
+
+  /**
+   * @notice Marks a nonce as used for the given participant
+   * @param participant address
+   * @param nonce uint256
+   * @return bool True if nonce was not marked as used already
+   */
+  function _markNonceAsUsed(address participant, uint256 nonce)
+    internal
+    returns (bool)
+  {
+    // If it is already used, return false
+    if (noncesClaimed[participant][nonce]) {
+      return false;
+    }
+    return noncesClaimed[participant][nonce] = true;
+  }
+
+  /**
+   * @notice Withdraw tokens from the pool using a score
+   * @param score uint256
+   * @param token address
+   * @param minimumAmount uint256
+   */
+  function _withdrawCheck(
+    uint256 score,
+    address token,
+    uint256 minimumAmount
+  ) internal view returns (uint256) {
+    require(score > 0, "SCORE_MUST_BE_PROVIDED");
+    uint256 amount = calculate(score, token);
+    require(amount >= minimumAmount, "INSUFFICIENT_AMOUNT");
+    return amount;
   }
 }

--- a/source/pool/contracts/interfaces/IPool.sol
+++ b/source/pool/contracts/interfaces/IPool.sol
@@ -3,29 +3,10 @@
 pragma solidity ^0.8.0;
 
 interface IPool {
-  struct Claim {
-    bytes32 root;
-    uint256 score;
-    bytes32[] proof;
-  }
-
-  event Enable(bytes32 root);
-  event Withdraw(
-    bytes32[] roots,
-    address account,
-    address token,
-    uint256 amount
-  );
+  event Withdraw(uint256 nonce, address account, address token, uint256 amount);
   event SetScale(uint256 scale);
   event SetMax(uint256 max);
   event DrainTo(address[] tokens, address dest);
-  event WithdrawWithSignature(
-    address signer,
-    address token,
-    uint256 amount,
-    address account,
-    uint256 nonce
-  );
 
   function setScale(uint256 _scale) external;
 
@@ -39,48 +20,59 @@ interface IPool {
 
   function setStakingToken(address _stakingToken) external;
 
-  function setClaimed(bytes32 root, address[] memory accounts) external;
-
-  function enable(bytes32 root) external;
-
   function drainTo(address[] calldata tokens, address dest) external;
 
-  function withdraw(Claim[] memory claims, address token) external;
+  function withdraw(
+    address token,
+    uint256 nonce,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external;
 
   function withdrawWithRecipient(
-    Claim[] memory claims,
-    address token,
     uint256 minimumAmount,
-    address recipient
+    address token,
+    address recipient,
+    uint256 nonce,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
   ) external;
 
   function withdrawAndStake(
-    Claim[] memory claims,
+    uint256 minimumAmount,
     address token,
-    uint256 minimumAmount
+    uint256 nonce,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
   ) external;
 
   function withdrawAndStakeFor(
-    Claim[] memory claims,
-    address token,
     uint256 minimumAmount,
-    address account
-  ) external;
-
-  function withdrawWithSignature(
+    address token,
+    address account,
+    uint256 nonce,
+    uint256 score,
     uint8 v,
     bytes32 r,
-    bytes32 s,
-    address token,
-    uint256 amount,
-    uint256 nonce
-  ) external returns (uint256);
+    bytes32 s
+  ) external;
 
   function withdrawProtected(
-    Claim[] memory claims,
-    address token,
     uint256 minimumAmount,
-    address recipient
+    address recipient,
+    address token,
+    uint256 nonce,
+    address participant,
+    uint256 score,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
   ) external returns (uint256);
 
   function calculate(uint256 score, address token)
@@ -88,15 +80,12 @@ interface IPool {
     view
     returns (uint256 amount);
 
-  function calculateMultiple(uint256 score, address[] calldata tokens)
-    external
-    view
-    returns (uint256[] memory outputAmounts);
-
   function verify(
+    uint256 nonce,
     address participant,
-    bytes32 root,
     uint256 score,
-    bytes32[] memory proof
-  ) external pure returns (bool valid);
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external view returns (bool valid);
 }

--- a/source/pool/contracts/interfaces/IPool.sol
+++ b/source/pool/contracts/interfaces/IPool.sol
@@ -88,4 +88,9 @@ interface IPool {
     bytes32 r,
     bytes32 s
   ) external view returns (bool valid);
+
+  function nonceUsed(address participant, uint256 nonce)
+    external
+    view
+    returns (bool);
 }

--- a/source/pool/package.json
+++ b/source/pool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@airswap/pool",
   "version": "1.2.4",
-  "description": "Tokens pooled and claimable using merkle proofs",
+  "description": "Tokens pooled and claimable using signatures",
   "contributors": [
     "Don Mosites",
     "Martin Sterlicchi"

--- a/source/pool/test/integration.js
+++ b/source/pool/test/integration.js
@@ -96,7 +96,7 @@ describe('Pool Integration Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, claim.nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, claim.nonce)
       expect(isClaimed).to.equal(true)
     })
 
@@ -150,8 +150,8 @@ describe('Pool Integration Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      expect(await pool.noncesClaimed(alice.address, nonce)).to.equal(true)
-      expect(await pool.noncesClaimed(bob.address, nonce)).to.equal(true)
+      expect(await pool.nonceUsed(alice.address, nonce)).to.equal(true)
+      expect(await pool.nonceUsed(bob.address, nonce)).to.equal(true)
     })
 
     it('withdraw success with new admin', async () => {
@@ -177,7 +177,7 @@ describe('Pool Integration Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, claim.nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, claim.nonce)
       expect(isClaimed).to.equal(true)
     })
 
@@ -205,7 +205,7 @@ describe('Pool Integration Tests', () => {
           )
       ).to.be.revertedWith('UNAUTHORIZED')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, claim.nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, claim.nonce)
       expect(isClaimed).to.equal(false)
     })
 
@@ -322,7 +322,7 @@ describe('Pool Integration Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, claim.nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, claim.nonce)
       expect(isClaimed).to.equal(true)
     })
 
@@ -379,7 +379,7 @@ describe('Pool Integration Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, claim.nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, claim.nonce)
       expect(isClaimed).to.equal(true)
 
       const balance = await stakeContract
@@ -440,7 +440,7 @@ describe('Pool Integration Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, claim.nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, claim.nonce)
       expect(isClaimed).to.equal(true)
 
       const balance = await stakeContract.connect(bob).balanceOf(bob.address)

--- a/source/pool/test/unit.js
+++ b/source/pool/test/unit.js
@@ -152,7 +152,7 @@ describe('Pool Unit Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, nonce)
       expect(isClaimed).to.equal(true)
     })
 
@@ -301,7 +301,7 @@ describe('Pool Unit Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, claim.nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, claim.nonce)
       expect(isClaimed).to.equal(true)
     })
 
@@ -363,7 +363,7 @@ describe('Pool Unit Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, claim.nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, claim.nonce)
       expect(isClaimed).to.equal(true)
 
       const balance = await stakeContract
@@ -428,7 +428,7 @@ describe('Pool Unit Tests', () => {
           )
       ).to.emit(pool, 'Withdraw')
 
-      const isClaimed = await pool.noncesClaimed(alice.address, claim.nonce)
+      const isClaimed = await pool.nonceUsed(alice.address, claim.nonce)
       expect(isClaimed).to.equal(true)
 
       const balance = await stakeContract.connect(bob).balanceOf(bob.address)

--- a/source/staking/test/unit.js
+++ b/source/staking/test/unit.js
@@ -94,7 +94,7 @@ describe('Staking Unit', () => {
 
       await expect(
         staking.connect(deployer).setDuration(DEFAULTDURATION)
-        ).to.be.revertedWith("TIMELOCKED")
+      ).to.be.revertedWith('TIMELOCKED')
     })
 
     it('owner can set unstaking duration', async () => {
@@ -116,7 +116,7 @@ describe('Staking Unit', () => {
 
     it('owner cannot set timelock to be less than minimum delay', async () => {
       await expect(
-          staking.connect(deployer).scheduleDurationChange(0)
+        staking.connect(deployer).scheduleDurationChange(0)
       ).to.be.revertedWith('INVALID_DELAY')
     })
 
@@ -126,7 +126,7 @@ describe('Staking Unit', () => {
       ).to.emit(staking, 'ScheduleDurationChange')
 
       await expect(
-          staking.connect(deployer).scheduleDurationChange(DEFAULTDELAY)
+        staking.connect(deployer).scheduleDurationChange(DEFAULTDELAY)
       ).to.be.revertedWith('TIMELOCK_ACTIVE')
     })
 
@@ -162,8 +162,8 @@ describe('Staking Unit', () => {
     it('Owner cannot cancel timelock before it is set', async () => {
       expect(
         staking.connect(deployer).cancelDurationChange()
-        ).to.be.revertedWith('TIMELOCK_INACTIVE')
-      })
+      ).to.be.revertedWith('TIMELOCK_INACTIVE')
+    })
   })
 
   describe('Stake', async () => {

--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -4,7 +4,6 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "./interfaces/ISwap.sol";
@@ -15,7 +14,6 @@ import "./interfaces/ISwap.sol";
  */
 contract Swap is ISwap, Ownable {
   using SafeERC20 for IERC20;
-  using SafeMath for uint256;
 
   bytes32 public constant DOMAIN_TYPEHASH =
     keccak256(
@@ -260,7 +258,7 @@ contract Swap is ISwap, Ownable {
     IERC20(signerToken).safeTransferFrom(
       signerWallet,
       protocolFeeWallet,
-      signerAmount.mul(protocolFeeLight).div(FEE_DIVISOR)
+      (signerAmount * protocolFeeLight) / FEE_DIVISOR
     );
 
     // Emit a Swap event
@@ -651,7 +649,7 @@ contract Swap is ISwap, Ownable {
       address(this)
     );
 
-    uint256 feeAmount = order.signerAmount.mul(protocolFee).div(FEE_DIVISOR);
+    uint256 feeAmount = (order.signerAmount * protocolFee) / FEE_DIVISOR;
 
     if (signerAllowance < order.signerAmount + feeAmount) {
       errors[errCount] = "SIGNER_ALLOWANCE_LOW";
@@ -675,8 +673,8 @@ contract Swap is ISwap, Ownable {
     view
     returns (uint256)
   {
-    uint256 divisor = (uint256(10)**rebateScale).add(stakingBalance);
-    return rebateMax.mul(stakingBalance).mul(feeAmount).div(divisor).div(100);
+    uint256 divisor = (uint256(10)**rebateScale) + stakingBalance;
+    return (rebateMax * stakingBalance * feeAmount) / divisor / 100;
   }
 
   /**
@@ -691,7 +689,7 @@ contract Swap is ISwap, Ownable {
     returns (uint256)
   {
     // Transfer fee from signer to feeWallet
-    uint256 feeAmount = amount.mul(protocolFee).div(FEE_DIVISOR);
+    uint256 feeAmount = (amount * protocolFee) / FEE_DIVISOR;
     if (feeAmount > 0) {
       uint256 discountAmount = calculateDiscount(
         IERC20(stakingToken).balanceOf(wallet),
@@ -881,7 +879,7 @@ contract Swap is ISwap, Ownable {
     uint256 amount
   ) internal {
     // Transfer fee from signer to feeWallet
-    uint256 feeAmount = amount.mul(protocolFee).div(FEE_DIVISOR);
+    uint256 feeAmount = (amount * protocolFee) / FEE_DIVISOR;
     if (feeAmount > 0) {
       uint256 discountAmount = calculateDiscount(
         IERC20(stakingToken).balanceOf(msg.sender),

--- a/source/swap/test/integration.js
+++ b/source/swap/test/integration.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const {
   createOrder,
   orderToParams,
-  createSignature,
+  createSwapSignature,
 } = require('@airswap/utils')
 const { ethers, waffle } = require('hardhat')
 const { deployMockContract } = waffle
@@ -39,7 +39,7 @@ describe('Swap Integration Tests', () => {
     })
     return orderToParams({
       ...unsignedOrder,
-      ...(await createSignature(unsignedOrder, signer, swap.address, CHAIN_ID)),
+      ...(await createSwapSignature(unsignedOrder, signer, swap.address, CHAIN_ID)),
     })
   }
 

--- a/source/swap/test/unit.js
+++ b/source/swap/test/unit.js
@@ -3,7 +3,7 @@ const { ADDRESS_ZERO } = require('@airswap/constants')
 const {
   createOrder,
   orderToParams,
-  createSignature,
+  createSwapSignature,
 } = require('@airswap/utils')
 const { ethers, waffle } = require('hardhat')
 const { deployMockContract } = waffle
@@ -47,7 +47,7 @@ describe('Swap Unit Tests', () => {
     })
     return orderToParams({
       ...unsignedOrder,
-      ...(await createSignature(
+      ...(await createSwapSignature(
         unsignedOrder,
         signatory,
         swap.address,

--- a/source/wrapper/test/integration.js
+++ b/source/wrapper/test/integration.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const {
   createOrder,
   orderToParams,
-  createSignature,
+  createSwapSignature,
 } = require('@airswap/utils')
 const { ethers, waffle } = require('hardhat')
 const { deployMockContract } = waffle
@@ -51,7 +51,7 @@ describe('Wrapper Integration Tests', () => {
     })
     return orderToParams({
       ...unsignedOrder,
-      ...(await createSignature(unsignedOrder, signer, swap.address, CHAIN_ID)),
+      ...(await createSwapSignature(unsignedOrder, signer, swap.address, CHAIN_ID)),
     })
   }
 

--- a/source/wrapper/test/unit.js
+++ b/source/wrapper/test/unit.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const {
   createOrder,
   orderToParams,
-  createSignature,
+  createSwapSignature,
 } = require('@airswap/utils')
 const { ethers, waffle } = require('hardhat')
 const { deployMockContract } = waffle
@@ -48,7 +48,7 @@ describe('Wrapper Unit Tests', () => {
     })
     return orderToParams({
       ...unsignedOrder,
-      ...(await createSignature(unsignedOrder, signer, swap.address, CHAIN_ID)),
+      ...(await createSwapSignature(unsignedOrder, signer, swap.address, CHAIN_ID)),
     })
   }
 

--- a/tools/constants/index.ts
+++ b/tools/constants/index.ts
@@ -1,5 +1,7 @@
-export const DOMAIN_NAME = 'SWAP'
-export const DOMAIN_VERSION = '3'
+export const DOMAIN_NAME_SWAP = 'SWAP'
+export const DOMAIN_VERSION_SWAP = '3'
+export const DOMAIN_NAME_POOL = 'POOL'
+export const DOMAIN_VERSION_POOL = '1'
 export const INDEX_HEAD = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
 export const LOCATOR_ZERO =

--- a/tools/typescript/index.ts
+++ b/tools/typescript/index.ts
@@ -26,6 +26,18 @@ export type Order = {
   senderAmount: string
 } & Signature
 
+export type UnsignedClaim = {
+  nonce: string
+  participant: string
+  score: string
+}
+
+export type Claim = {
+  nonce: string
+  participant: string
+  score: string
+} & Signature
+
 export type Token = {
   address: string
   symbol: string
@@ -38,7 +50,7 @@ export type LocatorResult = {
   nextCursor: string
 }
 
-export const EIP712 = {
+export const EIP712Swap = {
   EIP712Domain: [
     { name: 'name', type: 'string' },
     { name: 'version', type: 'string' },
@@ -55,6 +67,20 @@ export const EIP712 = {
     { name: 'senderWallet', type: 'address' },
     { name: 'senderToken', type: 'address' },
     { name: 'senderAmount', type: 'uint256' },
+  ],
+}
+
+export const EIP712Claim = {
+  EIP712Domain: [
+    { name: 'name', type: 'string' },
+    { name: 'version', type: 'string' },
+    { name: 'chainId', type: 'uint256' },
+    { name: 'verifyingContract', type: 'address' },
+  ],
+  Claim: [
+    { name: 'nonce', type: 'uint256' },
+    { name: 'participant', type: 'address' },
+    { name: 'score', type: 'uint256' },
   ],
 }
 

--- a/tools/utils/test/utils.ts
+++ b/tools/utils/test/utils.ts
@@ -5,9 +5,12 @@ import { Levels } from '@airswap/typescript'
 
 import {
   isValidOrder,
+  isValidClaim,
   calculateCostFromLevels,
-  createSignature,
-  getSignerFromSignature,
+  createSwapSignature,
+  createClaimSignature,
+  getSignerFromSwapSignature,
+  getSignerFromClaimSignature,
 } from '../index'
 
 const signerPrivateKey =
@@ -28,13 +31,13 @@ describe('Utils', async () => {
       senderToken: ADDRESS_ZERO,
       senderAmount: '0',
     }
-    const { v, r, s } = await createSignature(
+    const { v, r, s } = await createSwapSignature(
       unsignedOrder,
       wallet.privateKey,
       ADDRESS_ZERO,
       1
     )
-    const signerWallet = getSignerFromSignature(
+    const signerWallet = getSignerFromSwapSignature(
       unsignedOrder,
       ADDRESS_ZERO,
       1,
@@ -43,6 +46,30 @@ describe('Utils', async () => {
       s
     )
     expect(isValidOrder({ ...unsignedOrder, v, r, s })).to.equal(true)
+    expect(signerWallet.toLowerCase()).to.equal(wallet.address.toLowerCase())
+  })
+
+  it('Signs and validates a claim', async () => {
+    const unsignedClaim = {
+      nonce: Date.now().toString(),
+      participant: ADDRESS_ZERO,
+      score: '300',
+    }
+    const { v, r, s } = await createClaimSignature(
+      unsignedClaim,
+      wallet.privateKey,
+      ADDRESS_ZERO,
+      1
+    )
+    const signerWallet = getSignerFromClaimSignature(
+      unsignedClaim,
+      ADDRESS_ZERO,
+      1,
+      v,
+      r,
+      s
+    )
+    expect(isValidClaim({ ...unsignedClaim, v, r, s })).to.equal(true)
     expect(signerWallet.toLowerCase()).to.equal(wallet.address.toLowerCase())
   })
 


### PR DESCRIPTION
Updated the pool contract to EIP712, and switched all withdraw functions to signature validation. Removed all merkle validation functionality. Updated tests, and updated tools (utils, typescript, constants) to include claim signatures and differentiate from order signatures. 