### PR TITLE
Update approval to safeApproval and safeIncreaseAllowance

### DIFF
--- a/source/converter/contracts/Converter.sol
+++ b/source/converter/contracts/Converter.sol
@@ -128,7 +128,7 @@ contract Converter is Ownable, ReentrancyGuard, TokenPaymentSplitter {
         path = getTokenPath(_swapFromToken);
       }
       // Approve token for AMM usage.
-      IERC20(_swapFromToken).safeIncreaseAllowance(address(uniRouter), tokenBalance);
+      IERC20(_swapFromToken).safeIncreaseAllowance(uniRouter, tokenBalance);
       // Calls the swap function from the on-chain AMM to swap token from fee pool into reward token.
       IUniswapV2Router02(uniRouter)
         .swapExactTokensForTokensSupportingFeeOnTransferTokens(

--- a/source/converter/contracts/Converter.sol
+++ b/source/converter/contracts/Converter.sol
@@ -128,7 +128,7 @@ contract Converter is Ownable, ReentrancyGuard, TokenPaymentSplitter {
         path = getTokenPath(_swapFromToken);
       }
       // Approve token for AMM usage.
-      _approveErc20(_swapFromToken, tokenBalance);
+      IERC20(_swapFromToken).safeIncreaseAllowance(address(uniRouter), tokenBalance);
       // Calls the swap function from the on-chain AMM to swap token from fee pool into reward token.
       IUniswapV2Router02(uniRouter)
         .swapExactTokensForTokensSupportingFeeOnTransferTokens(
@@ -209,19 +209,6 @@ contract Converter is Ownable, ReentrancyGuard, TokenPaymentSplitter {
     returns (address[] memory)
   {
     return tokenPathMapping[_token];
-  }
-
-  /**
-   * @dev Internal function to approve ERC20 for AMM calls.
-   * @param _tokenToApprove Address of ERC20 to approve.
-   * @param _amount Amount of ERC20  to be approved.
-   *
-   * */
-  function _approveErc20(address _tokenToApprove, uint256 _amount) internal {
-    require(
-      IERC20(_tokenToApprove).approve(address(uniRouter), _amount),
-      "APPROVE_FAILED"
-    );
   }
 
   /**

--- a/source/converter/test/unit.js
+++ b/source/converter/test/unit.js
@@ -314,6 +314,9 @@ describe('Converter Unit Tests', () => {
       await testAToken.mock.approve
         .withArgs(uniswapV2Router02Contract.address, testATokenStartingBalance)
         .returns(true)
+      await testAToken.mock.allowance
+        .withArgs(converter.address, uniswapV2Router02Contract.address)
+        .returns(0)
       await uniswapV2Router02Contract.mock.swapExactTokensForTokensSupportingFeeOnTransferTokens.returns()
 
       const swapToTokenReturnBalance = 25000
@@ -377,6 +380,9 @@ describe('Converter Unit Tests', () => {
       await testAToken.mock.approve
         .withArgs(uniswapV2Router02Contract.address, testATokenStartingBalance)
         .returns(true)
+      await testAToken.mock.allowance
+        .withArgs(converter.address, uniswapV2Router02Contract.address)
+        .returns(0)
       await uniswapV2Router02Contract.mock.swapExactTokensForTokensSupportingFeeOnTransferTokens.returns()
 
       const swapToTokenReturnBalance = 25000
@@ -442,6 +448,9 @@ describe('Converter Unit Tests', () => {
       await testAToken.mock.approve
         .withArgs(uniswapV2Router02Contract.address, testATokenStartingBalance)
         .returns(true)
+      await testAToken.mock.allowance
+        .withArgs(converter.address, uniswapV2Router02Contract.address)
+        .returns(0)
       await uniswapV2Router02Contract.mock.swapExactTokensForTokensSupportingFeeOnTransferTokens.returns()
 
       const swapToTokenReturnBalance = 25000
@@ -555,12 +564,15 @@ describe('Converter Unit Tests', () => {
       await testAToken.mock.approve
         .withArgs(uniswapV2Router02Contract.address, testATokenStartingBalance)
         .returns(false)
+      await testAToken.mock.allowance
+        .withArgs(converter.address, uniswapV2Router02Contract.address)
+        .returns(0)
 
       await expect(
         converter
           .connect(deployer)
           .convertAndTransfer(testAToken.address, MINAMOUNTOUT)
-      ).to.be.revertedWith('APPROVE_FAILED')
+      ).to.be.revertedWith('SafeERC20: ERC20 operation did not succeed')
     })
 
     it('user cannot convert and transfer a token with a balance of zero', async () => {

--- a/source/pool/contracts/Pool.sol
+++ b/source/pool/contracts/Pool.sol
@@ -101,7 +101,7 @@ contract Pool is IPool, Ownable {
       )
     );
 
-    IERC20(stakingToken).approve(stakingContract, 2**256 - 1);
+    IERC20(stakingToken).safeApprove(stakingContract, 2**256 - 1);
   }
 
   /**
@@ -158,9 +158,9 @@ contract Pool is IPool, Ownable {
   {
     require(_stakingContract != address(0), "INVALID_ADDRESS");
     // set allowance on old staking contract to zero
-    IERC20(stakingToken).approve(stakingContract, 0);
+    IERC20(stakingToken).safeApprove(stakingContract, 0);
     stakingContract = _stakingContract;
-    IERC20(stakingToken).approve(stakingContract, 2**256 - 1);
+    IERC20(stakingToken).safeApprove(stakingContract, 2**256 - 1);
   }
 
   /**
@@ -171,9 +171,9 @@ contract Pool is IPool, Ownable {
   function setStakingToken(address _stakingToken) external override onlyOwner {
     require(_stakingToken != address(0), "INVALID_ADDRESS");
     // set allowance on old staking token to zero
-    IERC20(stakingToken).approve(stakingContract, 0);
+    IERC20(stakingToken).safeApprove(stakingContract, 0);
     stakingToken = _stakingToken;
-    IERC20(stakingToken).approve(stakingContract, 2**256 - 1);
+    IERC20(stakingToken).safeApprove(stakingContract, 2**256 - 1);
   }
 
   /**

--- a/source/pool/test/unit.js
+++ b/source/pool/test/unit.js
@@ -54,6 +54,7 @@ describe('Pool Unit Tests', () => {
 
     feeToken = await deployMockContract(deployer, IERC20.abi)
     await feeToken.mock.approve.returns(true)
+    await feeToken.mock.allowance.returns(0)
     feeToken2 = await deployMockContract(deployer, IERC20.abi)
 
     stakeContract = await (
@@ -112,6 +113,7 @@ describe('Pool Unit Tests', () => {
 
     it('set stake token successful', async () => {
       await feeToken2.mock.approve.returns(true)
+      await feeToken2.mock.allowance.returns(0)
       await pool.connect(deployer).setStakingToken(feeToken2.address)
       expect(await pool.stakingToken()).to.equal(feeToken2.address)
     })
@@ -401,6 +403,7 @@ describe('Pool Unit Tests', () => {
     it('withdrawAndStakeFor success', async () => {
       await feeToken.mock.balanceOf.returns('100000')
       await feeToken.mock.approve.returns(true)
+      await feeToken.mock.allowance.returns(0)
       await feeToken.mock.transferFrom.returns(true)
 
       const claim = await createUnsignedClaim({})


### PR DESCRIPTION
Updated pool contract to use safeApprove. The reasoning to use this function instead of safeIncreaseAllowance & safeDecreaseAllowance is because we are only initializing an allowance to max approval value or resetting an existing allowance to zero, which aligns with the appropriate usage in the OpenZeppelin docs. Also, if we used safeDecreaseAllowance, then there may need to be an additional external call to get the current allowance.

Updated the converter contract to use safeIncreaseAllowance. The reasoning is that we never decrease the allowance, and even though the allowance should go back zero after going through the AMM doing this just to be extra safe.