### PR TITLE
522: findTokenByAddress fix

### DIFF
--- a/tools/libraries/package.json
+++ b/tools/libraries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/libraries",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "description": "AirSwap: Libraries for Developers",
   "contributors": [
     "Don Mosites",

--- a/tools/libraries/package.json
+++ b/tools/libraries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/libraries",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "AirSwap: Libraries for Developers",
   "contributors": [
     "Don Mosites",

--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -96,7 +96,7 @@ export function findTokenByAddress(
   tokens: TokenInfo[]
 ): TokenInfo {
   return tokens.find((token) => {
-    return token.address === address
+    return token.address.toLowerCase() === address.toLowerCase()
   })
 }
 

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/metadata",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "AirSwap: Token Metadata for Developers",
   "contributors": [
     "Don Mosites",


### PR DESCRIPTION
Fixes [#522 ](https://github.com/airswap/airswap-web/issues/522)

Fixed findTokenByAddress; token addresses can be both lower and uppercase.