### PR TITLE
Adds order hashing to utils

### DIFF
--- a/source/pool/package.json
+++ b/source/pool/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@airswap/constants": "3.0.1",
     "@airswap/staking": "3.0.1",
-    "@airswap/utils": "3.0.0",
+    "@airswap/utils": "3.0.1",
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@airswap/constants": "3.0.1",
-    "@airswap/utils": "3.0.0",
+    "@airswap/utils": "3.0.1",
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@airswap/constants": "3.0.1",
     "@airswap/swap": "3.0.1",
-    "@airswap/utils": "3.0.0",
+    "@airswap/utils": "3.0.1",
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/tools/libraries/package.json
+++ b/tools/libraries/package.json
@@ -33,7 +33,7 @@
     "@airswap/registry": "3.0.1",
     "@airswap/swap": "3.0.1",
     "@airswap/typescript": "3.0.0",
-    "@airswap/utils": "3.0.0",
+    "@airswap/utils": "3.0.1",
     "@airswap/wrapper": "3.0.2",
     "bignumber.js": "^9.0.0",
     "browser-or-node": "^1.3.0",

--- a/tools/utils/index.ts
+++ b/tools/utils/index.ts
@@ -26,16 +26,14 @@ import {
   EIP712Claim,
 } from '@airswap/typescript'
 
-function stringify(types: any, primaryType: string): string {
-  let str = `${primaryType}(`
-  const keys = Object.keys(types[primaryType])
-  for (let i = 0; i < keys.length; i++) {
-    str += `${types[primaryType][i].type} ${types[primaryType][i].name}`
-    if (i !== keys.length - 1) {
-      str += ','
-    }
-  }
-  return `${str})`
+function stringify(
+  types: { [key: string]: { type: string; name: string }[] },
+  primaryType: string
+): string {
+  return types[primaryType].reduce((str, value, index, values) => {
+    const isEnd = index !== values.length - 1
+    return str + `${value.type} ${value.name}${isEnd ? ',' : ')'}`
+  }, `${primaryType}(`)
 }
 
 export const EIP712_DOMAIN_TYPEHASH = ethUtil.keccak256(

--- a/tools/utils/index.ts
+++ b/tools/utils/index.ts
@@ -26,6 +26,23 @@ import {
   EIP712Claim,
 } from '@airswap/typescript'
 
+function stringify(types: any, primaryType: string): string {
+  let str = `${primaryType}(`
+  const keys = Object.keys(types[primaryType])
+  for (let i = 0; i < keys.length; i++) {
+    str += `${types[primaryType][i].type} ${types[primaryType][i].name}`
+    if (i !== keys.length - 1) {
+      str += ','
+    }
+  }
+  return `${str})`
+}
+
+export const EIP712_DOMAIN_TYPEHASH = ethUtil.keccak256(
+  stringify(EIP712Swap, 'EIP712Domain')
+)
+export const ORDER_TYPEHASH = ethUtil.keccak256(stringify(EIP712Swap, 'Order'))
+
 // eslint-disable-next-line  @typescript-eslint/explicit-module-boundary-types
 export function createOrder({
   expiry = Math.round(Date.now() / 1000 + SECONDS_IN_DAY).toString(),
@@ -113,6 +130,64 @@ export function getSignerFromSwapSignature(
     },
     sig,
   })
+}
+
+export function hashOrder(order: UnsignedOrder): Buffer {
+  return ethUtil.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      [
+        'bytes32',
+        'uint256',
+        'uint256',
+        'address',
+        'address',
+        'uint256',
+        'uint256',
+        'address',
+        'address',
+        'uint256',
+      ],
+      [
+        ORDER_TYPEHASH,
+        order.nonce,
+        order.expiry,
+        order.signerWallet,
+        order.signerToken,
+        order.signerAmount,
+        order.protocolFee,
+        order.senderWallet,
+        order.senderToken,
+        order.senderAmount,
+      ]
+    )
+  )
+}
+
+export function hashDomain(swapContract: string): Buffer {
+  return ethUtil.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      ['bytes32', 'bytes32', 'bytes32', 'address'],
+      [
+        EIP712_DOMAIN_TYPEHASH,
+        ethUtil.keccak256(DOMAIN_NAME_SWAP),
+        ethUtil.keccak256(DOMAIN_VERSION_SWAP),
+        swapContract,
+      ]
+    )
+  )
+}
+
+export function getOrderHash(
+  order: UnsignedOrder,
+  swapContract: string
+): Buffer {
+  return ethUtil.keccak256(
+    Buffer.concat([
+      Buffer.from('1901', 'hex'),
+      hashDomain(swapContract),
+      hashOrder(order),
+    ])
+  )
 }
 
 export function isValidOrder(order: Order): boolean {

--- a/tools/utils/package.json
+++ b/tools/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/utils",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "AirSwap: Utilities for Developers",
   "contributors": [
     "Don Mosites"


### PR DESCRIPTION
Usage:
```
import { getOrderHash } from '@airswap/utils';
getOrderHash(unsignedOrder, swapContract).toString('base64');
```