### PR TITLE
Simplify pool interface

### DIFF
--- a/source/pool/contracts/interfaces/IPool.sol
+++ b/source/pool/contracts/interfaces/IPool.sol
@@ -30,53 +30,20 @@ interface IPool {
   function drainTo(address[] calldata tokens, address dest) external;
 
   function withdraw(
-    address token,
-    uint256 nonce,
-    uint256 expiry,
-    uint256 score,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  ) external;
-
-  function withdrawWithRecipient(
-    uint256 minimumAmount,
-    address token,
     address recipient,
+    uint256 minimum,
+    address token,
     uint256 nonce,
     uint256 expiry,
     uint256 score,
     uint8 v,
     bytes32 r,
     bytes32 s
-  ) external;
+  ) external returns (uint256);
 
   function withdrawAndStake(
-    uint256 minimumAmount,
-    address token,
-    uint256 nonce,
-    uint256 expiry,
-    uint256 score,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  ) external;
-
-  function withdrawAndStakeFor(
-    uint256 minimumAmount,
-    address token,
-    address account,
-    uint256 nonce,
-    uint256 expiry,
-    uint256 score,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  ) external;
-
-  function withdrawProtected(
-    uint256 minimumAmount,
     address recipient,
+    uint256 minimum,
     address token,
     uint256 nonce,
     uint256 expiry,

--- a/source/pool/test/integration.js
+++ b/source/pool/test/integration.js
@@ -87,6 +87,8 @@ describe('Pool Integration Tests', () => {
         await pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -136,6 +138,8 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             nonce,
             claimAlice.expiry,
@@ -150,6 +154,8 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(bob)
           .withdraw(
+            bob.address,
+            0,
             feeToken.address,
             nonce,
             claimBob.expiry,
@@ -178,6 +184,8 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -207,6 +215,8 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -237,6 +247,8 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -262,6 +274,8 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -276,6 +290,8 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -306,6 +322,8 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -331,6 +349,8 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -342,7 +362,7 @@ describe('Pool Integration Tests', () => {
       ).to.be.revertedWith('UNAUTHORIZED')
     })
 
-    it('withdrawWithRecipient success', async () => {
+    it('withdraw with different recipient success', async () => {
       const claim = await createUnsignedClaim({})
 
       const claimSignature = await createClaimSignature(
@@ -356,10 +376,10 @@ describe('Pool Integration Tests', () => {
       await expect(
         pool
           .connect(alice)
-          .withdrawWithRecipient(
+          .withdraw(
+            bob.address,
             withdrawMinimum,
             feeToken.address,
-            bob.address,
             claim.nonce,
             claim.expiry,
             claim.score,
@@ -373,7 +393,7 @@ describe('Pool Integration Tests', () => {
       expect(isClaimed).to.equal(true)
     })
 
-    it('withdrawWithRecipient reverts with minimumAmount not met', async () => {
+    it('withdraw with different recipient reverts with minimumAmount not met', async () => {
       const withdrawMinimum = 496
 
       const claim = await createUnsignedClaim({})
@@ -388,10 +408,10 @@ describe('Pool Integration Tests', () => {
       await expect(
         pool
           .connect(alice)
-          .withdrawWithRecipient(
+          .withdraw(
+            bob.address,
             withdrawMinimum,
             feeToken.address,
-            bob.address,
             claim.nonce,
             claim.expiry,
             claim.score,
@@ -417,6 +437,7 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdrawAndStake(
+            alice.address,
             withdrawMinimum,
             feeToken.address,
             claim.nonce,
@@ -452,6 +473,7 @@ describe('Pool Integration Tests', () => {
         pool
           .connect(alice)
           .withdrawAndStake(
+            alice.address,
             withdrawMinimum,
             feeToken2.address,
             claim.nonce,
@@ -464,7 +486,7 @@ describe('Pool Integration Tests', () => {
       ).to.be.revertedWith('INVALID_TOKEN')
     })
 
-    it('withdrawAndStakeFor success', async () => {
+    it('withdrawAndStake for a recipient success', async () => {
       const claim = await createUnsignedClaim({})
 
       const claimSignature = await createClaimSignature(
@@ -478,10 +500,10 @@ describe('Pool Integration Tests', () => {
       await expect(
         pool
           .connect(alice)
-          .withdrawAndStakeFor(
+          .withdrawAndStake(
+            bob.address,
             withdrawMinimum,
             feeToken.address,
-            bob.address,
             claim.nonce,
             claim.expiry,
             claim.score,
@@ -498,7 +520,7 @@ describe('Pool Integration Tests', () => {
       expect(balance).to.equal('495')
     })
 
-    it('withdrawAndStakeFor reverts with wrong token', async () => {
+    it('withdrawAndStake for a recipient reverts with wrong token', async () => {
       const claim = await createUnsignedClaim({})
 
       const claimSignature = await createClaimSignature(
@@ -511,10 +533,10 @@ describe('Pool Integration Tests', () => {
       await expect(
         pool
           .connect(alice)
-          .withdrawAndStakeFor(
+          .withdrawAndStake(
+            bob.address,
             withdrawMinimum,
             feeToken2.address,
-            bob.address,
             claim.nonce,
             claim.expiry,
             claim.score,

--- a/source/pool/test/unit.js
+++ b/source/pool/test/unit.js
@@ -148,6 +148,8 @@ describe('Pool Unit Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -184,6 +186,8 @@ describe('Pool Unit Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -198,6 +202,8 @@ describe('Pool Unit Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -225,6 +231,8 @@ describe('Pool Unit Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -250,6 +258,8 @@ describe('Pool Unit Tests', () => {
         pool
           .connect(alice)
           .withdraw(
+            alice.address,
+            0,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -261,32 +271,7 @@ describe('Pool Unit Tests', () => {
       ).to.be.revertedWith('UNAUTHORIZED')
     })
 
-    it('withdraw reverts with invalid participant claiming', async () => {
-      const claim = await createUnsignedClaim({})
-
-      const claimSignature = await createClaimSignature(
-        claim,
-        deployer,
-        pool.address,
-        CHAIN_ID
-      )
-
-      await expect(
-        pool
-          .connect(bob)
-          .withdraw(
-            feeToken.address,
-            claim.nonce,
-            claim.expiry,
-            claim.score,
-            claimSignature.v,
-            claimSignature.r,
-            claimSignature.s
-          )
-      ).to.be.revertedWith('UNAUTHORIZED')
-    })
-
-    it('withdrawWithRecipient success', async () => {
+    it('withdraw with different recipient success', async () => {
       await feeToken.mock.balanceOf.returns('100000')
       await feeToken.mock.transfer.returns(true)
 
@@ -303,10 +288,10 @@ describe('Pool Unit Tests', () => {
       await expect(
         pool
           .connect(alice)
-          .withdrawWithRecipient(
+          .withdraw(
+            bob.address,
             withdrawMinimum,
             feeToken.address,
-            bob.address,
             claim.nonce,
             claim.expiry,
             claim.score,
@@ -320,7 +305,7 @@ describe('Pool Unit Tests', () => {
       expect(isClaimed).to.equal(true)
     })
 
-    it('withdrawWithRecipient reverts with minimumAmount not met', async () => {
+    it('withdraw with different recipient reverts with minimumAmount not met', async () => {
       await feeToken.mock.balanceOf.returns('100000')
 
       const withdrawMinimum = 496
@@ -337,10 +322,10 @@ describe('Pool Unit Tests', () => {
       await expect(
         pool
           .connect(alice)
-          .withdrawWithRecipient(
+          .withdraw(
+            bob.address,
             withdrawMinimum,
             feeToken.address,
-            bob.address,
             claim.nonce,
             claim.expiry,
             claim.score,
@@ -351,7 +336,7 @@ describe('Pool Unit Tests', () => {
       ).to.be.revertedWith('INSUFFICIENT_AMOUNT')
     })
 
-    it('withdrawWithRecipient reverts if caller not participant', async () => {
+    it('withdraw with different recipient reverts if caller not participant', async () => {
       await feeToken.mock.balanceOf.returns('100000')
 
       const withdrawMinimum = 496
@@ -368,40 +353,9 @@ describe('Pool Unit Tests', () => {
       await expect(
         pool
           .connect(bob)
-          .withdrawWithRecipient(
-            withdrawMinimum,
-            feeToken.address,
+          .withdraw(
             bob.address,
-            claim.nonce,
-            claim.expiry,
-            claim.score,
-            claimSignature.v,
-            claimSignature.r,
-            claimSignature.s
-          )
-      ).to.be.revertedWith('UNAUTHORIZED')
-    })
-
-    it('withdrawProtected reverts if caller not participant', async () => {
-      await feeToken.mock.balanceOf.returns('100000')
-
-      const withdrawMinimum = 496
-
-      const claim = await createUnsignedClaim({})
-
-      const claimSignature = await createClaimSignature(
-        claim,
-        deployer,
-        pool.address,
-        CHAIN_ID
-      )
-
-      await expect(
-        pool
-          .connect(bob)
-          .withdrawProtected(
             withdrawMinimum,
-            bob.address,
             feeToken.address,
             claim.nonce,
             claim.expiry,
@@ -431,6 +385,7 @@ describe('Pool Unit Tests', () => {
         pool
           .connect(alice)
           .withdrawAndStake(
+            alice.address,
             withdrawMinimum,
             feeToken.address,
             claim.nonce,
@@ -466,6 +421,7 @@ describe('Pool Unit Tests', () => {
         pool
           .connect(alice)
           .withdrawAndStake(
+            alice.address,
             withdrawMinimum,
             feeToken2.address,
             claim.nonce,
@@ -478,7 +434,7 @@ describe('Pool Unit Tests', () => {
       ).to.be.revertedWith('INVALID_TOKEN')
     })
 
-    it('withdrawAndStakeFor success', async () => {
+    it('withdrawAndStake for a recipient success', async () => {
       await feeToken.mock.balanceOf.returns('100000')
       await feeToken.mock.approve.returns(true)
       await feeToken.mock.allowance.returns(0)
@@ -497,10 +453,10 @@ describe('Pool Unit Tests', () => {
       await expect(
         pool
           .connect(alice)
-          .withdrawAndStakeFor(
+          .withdrawAndStake(
+            bob.address,
             withdrawMinimum,
             feeToken.address,
-            bob.address,
             claim.nonce,
             claim.expiry,
             claim.score,
@@ -517,7 +473,7 @@ describe('Pool Unit Tests', () => {
       expect(balance).to.equal('495')
     })
 
-    it('withdrawAndStakeFor reverts with wrong token', async () => {
+    it('withdrawAndStake for a recipient reverts with wrong token', async () => {
       const claim = await createUnsignedClaim({})
 
       const claimSignature = await createClaimSignature(
@@ -530,10 +486,10 @@ describe('Pool Unit Tests', () => {
       await expect(
         pool
           .connect(alice)
-          .withdrawAndStakeFor(
+          .withdrawAndStake(
+            bob.address,
             withdrawMinimum,
             feeToken2.address,
-            bob.address,
             claim.nonce,
             claim.expiry,
             claim.score,


### PR DESCRIPTION
Consolidates Pool interface to only `withdraw` and `withdrawAndStake` functions, which both always take a `recipient` and `minimum` arguments.