### PR TITLE
Swap audit 3.1

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -77,7 +77,7 @@ module.exports = {
   solidity: {
     compilers: [
       {
-        version: '0.8.7',
+        version: '0.8.17',
         settings: {
           optimizer: {
             enabled: true,

--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 /* solhint-disable var-name-mixedcase */
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/source/swap/contracts/interfaces/ISwap.sol
+++ b/source/swap/contracts/interfaces/ISwap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 interface ISwap {
   struct Order {


### PR DESCRIPTION
Changes 
- Locked solidity version to 0.8.17 in both Swap.sol and ISwap.sol
- Changed solidity version in the hardhat config located at the root, from 0.8.7 to 0.8.17