### PR TITLE
Emit AddAdmin and RemoveAdmin events in respective functions on Pool contract => issue #902

### DIFF
--- a/source/pool/contracts/Pool.sol
+++ b/source/pool/contracts/Pool.sol
@@ -135,6 +135,7 @@ contract Pool is IPool, Ownable {
   function addAdmin(address _admin) external override onlyOwner {
     require(_admin != address(0), "INVALID_ADDRESS");
     admins[_admin] = true;
+    emit AddAdmin(_admin);
   }
 
   /**
@@ -145,6 +146,7 @@ contract Pool is IPool, Ownable {
   function removeAdmin(address _admin) external override onlyOwner {
     require(admins[_admin] == true, "ADMIN_NOT_SET");
     admins[_admin] = false;
+    emit RemoveAdmin(_admin);
   }
 
   /**

--- a/source/pool/contracts/interfaces/IPool.sol
+++ b/source/pool/contracts/interfaces/IPool.sol
@@ -13,6 +13,8 @@ interface IPool {
   );
   event SetScale(uint256 scale);
   event SetMax(uint256 max);
+  event AddAdmin(address admin);
+  event RemoveAdmin(address admin);
   event DrainTo(address[] tokens, address dest);
 
   function setScale(uint256 _scale) external;

--- a/source/pool/test/integration.js
+++ b/source/pool/test/integration.js
@@ -171,7 +171,10 @@ describe('Pool Integration Tests', () => {
     })
 
     it('withdraw success with new admin', async () => {
-      await pool.connect(deployer).addAdmin(carol.address)
+      await expect(pool.connect(deployer).addAdmin(carol.address)).to.emit(
+        carol.address,
+        'AddAdmin'
+      )
       const claim = await createUnsignedClaim({})
 
       const claimSignature = await createClaimSignature(
@@ -201,7 +204,10 @@ describe('Pool Integration Tests', () => {
     })
 
     it('withdraw reverts when admin is removed', async () => {
-      await pool.connect(deployer).addAdmin(carol.address)
+      await expect(pool.connect(deployer).addAdmin(carol.address)).to.emit(
+        carol.address,
+        'AddAdmin'
+      )
       const claim = await createUnsignedClaim({})
 
       const claimSignature = await createClaimSignature(

--- a/source/pool/test/unit.js
+++ b/source/pool/test/unit.js
@@ -603,7 +603,10 @@ describe('Pool Unit Tests', () => {
 
   describe('Test setting admin', async () => {
     it('Test addAdmin is successful', async () => {
-      await pool.addAdmin(alice.address)
+      await expect(pool.addAdmin(alice.address)).to.emit(
+        alice.address,
+        'AddAdmin'
+      )
       expect(await pool.admins(alice.address)).to.be.equal(true)
     })
 
@@ -621,7 +624,10 @@ describe('Pool Unit Tests', () => {
 
     it('Test removeAdmin is successful', async () => {
       await pool.addAdmin(alice.address)
-      await pool.removeAdmin(alice.address)
+      await expect(pool.removeAdmin(alice.address)).to.emit(
+        alice.address,
+        'RemoveAdmin'
+      )
       expect(await pool.admins(alice.address)).to.be.equal(false)
     })
 


### PR DESCRIPTION
I created the events in the Interface and emitted them in the contract.
I wrote the tests, but I'm getting a strange error that I didn't figure out yet. Seems to be a Promise issue from the tests.
TypeError: Cannot read properties of undefined (reading 'waitForTransaction')
The provider passed in here is undefined. @ethereum-waffle/chai/dist/cjs/matchers/misc/transaction.js:19:21

I will look into it a bit more, but happy to get pointers on that if you have some.
Thanks