### PR TITLE
Simplified _hashOrder function - fixes #992

### DIFF
--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -251,36 +251,9 @@ contract Swap is ISwap, Ownable, EIP712 {
               order.nonce,
               order.expiry,
               protocolFee,
-              keccak256(
-                abi.encode(
-                  PARTY_TYPEHASH,
-                  order.signer.wallet,
-                  order.signer.token,
-                  order.signer.kind,
-                  order.signer.id,
-                  order.signer.amount
-                )
-              ),
-              keccak256(
-                abi.encode(
-                  PARTY_TYPEHASH,
-                  order.sender.wallet,
-                  order.sender.token,
-                  order.sender.kind,
-                  order.sender.id,
-                  order.sender.amount
-                )
-              ),
-              keccak256(
-                abi.encode(
-                  PARTY_TYPEHASH,
-                  order.affiliate.wallet,
-                  order.affiliate.token,
-                  order.affiliate.kind,
-                  order.affiliate.id,
-                  order.affiliate.amount
-                )
-              )
+              keccak256(abi.encode(PARTY_TYPEHASH, order.signer)),
+              keccak256(abi.encode(PARTY_TYPEHASH, order.sender)),
+              keccak256(abi.encode(PARTY_TYPEHASH, order.affiliate))
             )
           )
         )


### PR DESCRIPTION
Simplified _hashOrder function by encoding each party as a whole for better readability