### PR TITLE
ensure that authorized signatory is used if one is set

### DIFF
--- a/packages/swap-erc20/contracts/SwapERC20.sol
+++ b/packages/swap-erc20/contracts/SwapERC20.sol
@@ -283,9 +283,13 @@ contract SwapERC20 is ISwapERC20, Ownable2Step, EIP712 {
     // Ensure the nonce is not yet used and if not mark it used
     if (!_markNonceAsUsed(signatory, nonce)) revert NonceAlreadyUsed(nonce);
 
-    // Ensure the signatory is authorized by the signer wallet
-    if (signerWallet != signatory) {
-      if (authorized[signerWallet] != signatory) revert Unauthorized();
+    // Ensure signatory is authorized to sign
+    if (authorized[signerWallet] != address(0)) {
+      // If one is set by signer wallet, signatory must be authorized
+      if (signatory != authorized[signerWallet]) revert SignatoryUnauthorized();
+    } else {
+      // Otherwise, signatory must be signer wallet
+      if (signatory != signerWallet) revert Unauthorized();
     }
 
     // Transfer token from sender to signer
@@ -676,9 +680,13 @@ contract SwapERC20 is ISwapERC20, Ownable2Step, EIP712 {
     // Ensure the signatory is not null
     if (signatory == address(0)) revert SignatureInvalid();
 
-    // Ensure the signatory is authorized by the signer wallet
-    if (signerWallet != signatory) {
-      if (authorized[signerWallet] != signatory) revert Unauthorized();
+    // Ensure signatory is authorized to sign
+    if (authorized[signerWallet] != address(0)) {
+      // If one is set by signer wallet, signatory must be authorized
+      if (signatory != authorized[signerWallet]) revert SignatoryUnauthorized();
+    } else {
+      // Otherwise, signatory must be signer wallet
+      if (signatory != signerWallet) revert Unauthorized();
     }
 
     // Ensure the nonce is not yet used and if not mark it used

--- a/packages/swap-erc20/contracts/interfaces/ISwapERC20.sol
+++ b/packages/swap-erc20/contracts/interfaces/ISwapERC20.sol
@@ -47,6 +47,7 @@ interface ISwapERC20 {
   error ScaleTooHigh();
   error SignatureInvalid();
   error SignatoryInvalid();
+  error SignatoryUnauthorized();
   error Unauthorized();
 
   function swap(

--- a/packages/swap-erc20/test/unit.js
+++ b/packages/swap-erc20/test/unit.js
@@ -365,6 +365,23 @@ describe('SwapERC20 Unit', () => {
       )
     })
 
+    it('test swaps by signer instead of authorized signatory fail', async () => {
+      const order = await createSignedOrderERC20(
+        {
+          signerWallet: signer.address,
+        },
+        signer
+      )
+
+      await expect(swap.connect(signer).authorize(deployer.address))
+        .to.emit(swap, 'Authorize')
+        .withArgs(deployer.address, signer.address)
+
+      await expect(
+        swap.connect(sender).swap(sender.address, ...order)
+      ).to.be.revertedWith('SignatoryUnauthorized()')
+    })
+
     it('test when signer not authorized', async () => {
       const order = await createSignedOrderERC20(
         {
@@ -554,6 +571,23 @@ describe('SwapERC20 Unit', () => {
       await expect(swap.connect(sender).swapLight(...order)).to.emit(
         swap,
         'SwapERC20'
+      )
+    })
+    it('test light swaps by signer instead of authorized signatory fail', async () => {
+      const order = await createSignedOrderERC20(
+        {
+          protocolFee: PROTOCOL_FEE_LIGHT,
+          signerWallet: anyone.address,
+        },
+        anyone
+      )
+
+      await expect(swap.connect(anyone).authorize(signer.address))
+        .to.emit(swap, 'Authorize')
+        .withArgs(signer.address, anyone.address)
+
+      await expect(swap.connect(sender).swapLight(...order)).to.be.revertedWith(
+        'SignatoryUnauthorized()'
       )
     })
     it('test when expiration has passed', async () => {

--- a/packages/swap/contracts/Swap.sol
+++ b/packages/swap/contracts/Swap.sol
@@ -422,9 +422,14 @@ contract Swap is ISwap, Ownable2Step, EIP712 {
     // Ensure the signatory is not null
     if (signatory == address(0)) revert SignatureInvalid();
 
-    // Ensure the signatory is authorized by the signer wallet
-    if (order.signer.wallet != signatory) {
-      if (authorized[order.signer.wallet] != signatory) revert Unauthorized();
+    // Ensure signatory is authorized to sign
+    if (authorized[order.signer.wallet] != address(0)) {
+      // If one is set by signer wallet, signatory must be authorized
+      if (signatory != authorized[order.signer.wallet])
+        revert SignatoryUnauthorized();
+    } else {
+      // Otherwise, signatory must be signer wallet
+      if (signatory != order.signer.wallet) revert Unauthorized();
     }
 
     // Ensure the nonce is not yet used and if not mark it used

--- a/packages/swap/contracts/interfaces/ISwap.sol
+++ b/packages/swap/contracts/interfaces/ISwap.sol
@@ -52,6 +52,7 @@ interface ISwap {
   error RoyaltyExceedsMax(uint256);
   error TokenKindUnknown();
   error TransferFailed(address, address);
+  error SignatoryUnauthorized();
   error Unauthorized();
 
   function swap(

--- a/packages/swap/test/Swap.js
+++ b/packages/swap/test/Swap.js
@@ -413,7 +413,7 @@ describe('Swap Unit', () => {
         swap,
         'Authorize'
       )
-      await expect(swap.connect(signer).authorize(sender.address)).to.emit(
+      await expect(swap.connect(signer).authorize(deployer.address)).to.emit(
         swap,
         'Authorize'
       )
@@ -427,7 +427,25 @@ describe('Swap Unit', () => {
       )
       await expect(
         swap.connect(sender).swap(sender.address, MAX_ROYALTY, order)
-      ).to.be.revertedWith('Unauthorized()')
+      ).to.be.revertedWith('SignatoryUnauthorized()')
+    })
+
+    it('if set, order signatory must be authorized signatory', async () => {
+      await expect(swap.connect(signer).authorize(anyone.address)).to.emit(
+        swap,
+        'Authorize'
+      )
+      const order = await createSignedOrder(
+        {
+          signer: {
+            wallet: signer.address,
+          },
+        },
+        signer
+      )
+      await expect(
+        swap.connect(sender).swap(sender.address, MAX_ROYALTY, order)
+      ).to.be.revertedWith('SignatoryUnauthorized()')
     })
 
     it('a signer may revoke an authorized signatory', async () => {


### PR DESCRIPTION
avoids possibility that signer and authorized signatory could sign the same order terms.