### PR TITLE
CollectionTokenInfo for @airswap/metadata

### DIFF
--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -205,7 +205,7 @@ export async function getCollectionTokenInfo(
         break
     }
   } catch (e) {
-    throw e.message
+    throw `Unable to fetch token metadata: ${e.message}`
   }
   return {
     chainId: (await provider.getNetwork()).chainId,

--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -234,10 +234,10 @@ async function fetchMetaData(uri) {
   return {}
 }
 
-const transformMetadataAttributeToCollectionTokenAttribute = (
+const transformErc721TokenAttributeToCollectionTokenAttribute = (
   attribute: any
 ): CollectionTokenAttribute => ({
-  label: attribute.trait_type,
+  label: attribute.item || attribute.trait_type || '',
   value: `${attribute.value}`,
 })
 
@@ -248,8 +248,15 @@ const transformERC721ToCollectionToken = (
   description: metadata.description,
   image: metadata.image?.replace('ipfs://', 'https://ipfs.io/ipfs/'),
   attributes: (metadata.attributes || []).map(
-    transformMetadataAttributeToCollectionTokenAttribute
+    transformErc721TokenAttributeToCollectionTokenAttribute
   ),
+})
+
+const transformErc1155TokenAttributeToCollectionTokenAttribute = (
+  attribute: any
+): CollectionTokenAttribute => ({
+  label: attribute.trait_type,
+  value: `${attribute.value}`,
 })
 
 const transformERC1155ToCollectionToken = (
@@ -263,7 +270,7 @@ const transformERC1155ToCollectionToken = (
       'https://ipfs.io/ipfs/'
     ) || undefined,
   attributes: (metadata.attributes || []).map(
-    transformMetadataAttributeToCollectionTokenAttribute
+    transformErc1155TokenAttributeToCollectionTokenAttribute
   ),
   createdBy: metadata.created_by,
 })

--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -1,21 +1,27 @@
 import axios from 'axios'
 import * as ethers from 'ethers'
-import { TokenInfo } from '@uniswap/token-lists'
+import {
+  TokenInfo,
+  CollectionTokenInfo,
+  CollectionTokenMetadata,
+  CollectionTokenAttribute,
+} from '@airswap/types'
 import { defaults, tokenListURLs } from './constants'
 import {
   tokenKinds,
   chainNames,
   stakingTokenAddresses,
 } from '@airswap/constants'
+import validUrl from 'valid-url'
 
 const AIRSWAP_LOGO_URI =
   'https://storage.googleapis.com/subgraph-images/158680119781426823563.png'
 const AIRSWAP_SYMBOL = 'AST'
+const DEFAULT_NAME = 'Unknown NFT'
 
 import { abi as ERC165_ABI } from '@openzeppelin/contracts/build/contracts/ERC165.json'
 import { abi as ERC20_ABI } from '@openzeppelin/contracts/build/contracts/ERC20.json'
 import { abi as ERC721_ABI } from '@openzeppelin/contracts/build/contracts/ERC721.json'
-import { abi as ERC777_ABI } from '@openzeppelin/contracts/build/contracts/ERC777.json'
 import { abi as ERC1155_ABI } from '@openzeppelin/contracts/build/contracts/ERC1155.json'
 
 export async function getKnownTokens(
@@ -116,11 +122,10 @@ export function getStakingTokens(): TokenInfo[] {
   return _stakingTokens
 }
 
-export async function getTokenFromContract(
+export async function getTokenKind(
   provider: ethers.providers.BaseProvider,
-  address: string,
-  id?: string
-): Promise<TokenInfo> {
+  address: string
+): Promise<string> {
   const contract = new ethers.Contract(address, ERC165_ABI, provider)
   let supportsERC165 = true
   let tokenKind = tokenKinds.ERC20
@@ -135,24 +140,13 @@ export async function getTokenFromContract(
     if (tokenKind === tokenKinds.ERC20) {
       if (await contract.supportsInterface(tokenKinds.ERC1155)) {
         tokenKind = tokenKinds.ERC1155
-      } else if (await contract.supportsInterface(tokenKinds.ERC777)) {
-        tokenKind = tokenKinds.ERC777
       }
     }
   }
-  switch (tokenKind) {
-    case tokenKinds.ERC721:
-      return getERC721FromContract(provider, address, id)
-    case tokenKinds.ERC777:
-      return getERC777FromContract(provider, address)
-    case tokenKinds.ERC1155:
-      return getERC1155FromContract(provider, address, id)
-    default:
-      return getERC20FromContract(provider, address)
-  }
+  return tokenKind
 }
 
-export async function getERC20FromContract(
+export async function getTokenInfo(
   provider: ethers.providers.BaseProvider,
   address: string
 ): Promise<TokenInfo> {
@@ -162,8 +156,13 @@ export async function getERC20FromContract(
   const contract = new ethers.Contract(address, ERC20_ABI, provider)
   let name
   let symbol
+  let decimals
   try {
-    ;[name, symbol] = await Promise.all([contract.name(), contract.symbol()])
+    ;[name, symbol, decimals] = await Promise.all([
+      contract.name(),
+      contract.symbol(),
+      contract.decimals(),
+    ])
   } catch (e) {
     throw new Error(`Unable to get ERC20 from contract at ${address}`)
   }
@@ -172,110 +171,99 @@ export async function getERC20FromContract(
     address: address.toLowerCase(),
     name,
     symbol,
-    decimals: Number(await contract.decimals()),
-    extensions: {
-      kind: tokenKinds.ERC20,
-    },
+    decimals,
   }
 }
 
-export async function getERC721FromContract(
+export async function getCollectionTokenInfo(
   provider: ethers.providers.BaseProvider,
   address: string,
   id: string
-): Promise<TokenInfo> {
+): Promise<CollectionTokenInfo> {
+  const tokenKind = await getTokenKind(provider, address)
+
+  let uri = null
+  let metadata = null
+
   if (!ethers.utils.isAddress(address)) {
     throw new Error(`Invalid address: ${address}`)
   }
   if (isNaN(Number(id))) {
     throw new Error(`Invalid id: ${id}`)
   }
-  const contract = new ethers.Contract(address, ERC721_ABI, provider)
-  let name
-  let symbol
   try {
-    ;[name, symbol] = await Promise.all([contract.name(), contract.symbol()])
+    switch (tokenKind) {
+      case tokenKinds.ERC721:
+        uri = await new ethers.Contract(address, ERC721_ABI, provider).tokenURI(
+          id
+        )
+        metadata = transformERC721ToCollectionToken(fetchMetaData(uri))
+        break
+      case tokenKinds.ERC1155:
+        uri = await new ethers.Contract(address, ERC1155_ABI, provider).uri(id)
+        metadata = transformERC1155ToCollectionToken(fetchMetaData(uri))
+        break
+    }
   } catch (e) {
-    throw new Error(`Unable to get ERC721 from contract at ${address}`)
+    throw e.message
   }
-  let uri = await contract.tokenURI(id)
-  if (uri.startsWith('ipfs')) {
-    uri = `https://cloudflare-ipfs.com/${uri.replace('://', '/')}`
-  }
-  const res = await axios.get(uri)
   return {
     chainId: (await provider.getNetwork()).chainId,
+    kind: tokenKind,
     address: address.toLowerCase(),
-    name,
-    symbol: symbol || name.toUpperCase(),
-    decimals: Number(0),
-    extensions: {
-      kind: tokenKinds.ERC721,
-      id,
-      metadata: res.data,
-    },
+    id,
+    uri,
+    ...metadata,
   }
 }
 
-export async function getERC777FromContract(
-  provider: ethers.providers.BaseProvider,
-  address: string
-): Promise<TokenInfo> {
-  if (!ethers.utils.isAddress(address)) {
-    throw new Error(`Invalid address: ${address}`)
+async function fetchMetaData(uri) {
+  if (validUrl.isUri(uri)) {
+    if (uri.startsWith('ipfs')) {
+      uri = `https://cloudflare-ipfs.com/${uri.replace('://', '/')}`
+    }
+    const { data } = await axios.get(uri)
+    if (typeof data === 'string')
+      try {
+        return JSON.parse(data)
+      } catch (e) {
+        return {}
+      }
+    return data
   }
-  const contract = new ethers.Contract(address, ERC777_ABI, provider)
-  let name
-  let symbol
-  try {
-    ;[name, symbol] = await Promise.all([contract.name(), contract.symbol()])
-  } catch (e) {
-    throw new Error(`Unable to get ERC777 from contract at ${address}`)
-  }
-  return {
-    chainId: (await provider.getNetwork()).chainId,
-    address: address.toLowerCase(),
-    name,
-    symbol,
-    decimals: Number(await contract.decimals()),
-    extensions: {
-      kind: tokenKinds.ERC777,
-    },
-  }
+  return {}
 }
 
-export async function getERC1155FromContract(
-  provider: ethers.providers.BaseProvider,
-  address: string,
-  id: string
-): Promise<TokenInfo> {
-  if (!ethers.utils.isAddress(address)) {
-    throw new Error(`Invalid address: ${address}`)
-  }
-  if (isNaN(Number(id))) {
-    throw new Error(`Invalid id: ${id}`)
-  }
-  const contract = new ethers.Contract(address, ERC1155_ABI, provider)
-  let uri
-  try {
-    uri = await contract.uri(id)
-  } catch (e) {
-    throw new Error(`Unable to get ERC1155 from contract at ${address}`)
-  }
-  if (uri.startsWith('ipfs')) {
-    uri = `https://cloudflare-ipfs.com/${uri.replace('://', '/')}`
-  }
-  const res = await axios.get(uri)
-  return {
-    chainId: (await provider.getNetwork()).chainId,
-    address: address.toLowerCase(),
-    name: '',
-    symbol: '',
-    decimals: Number(0),
-    extensions: {
-      kind: tokenKinds.ERC1155,
-      id,
-      metadata: res.data,
-    },
-  }
-}
+const transformMetadataAttributeToCollectionTokenAttribute = (
+  attribute: any
+): CollectionTokenAttribute => ({
+  label: attribute.trait_type,
+  value: `${attribute.value}`,
+})
+
+const transformERC721ToCollectionToken = (
+  metadata: any
+): CollectionTokenMetadata => ({
+  name: metadata.name || DEFAULT_NAME,
+  description: metadata.description,
+  image: metadata.image?.replace('ipfs://', 'https://ipfs.io/ipfs/'),
+  attributes: (metadata.attributes || []).map(
+    transformMetadataAttributeToCollectionTokenAttribute
+  ),
+})
+
+const transformERC1155ToCollectionToken = (
+  metadata: any
+): CollectionTokenMetadata => ({
+  name: metadata.name || DEFAULT_NAME,
+  description: metadata.description,
+  image:
+    (metadata.image_url || metadata.image || '').replace(
+      'ipfs://',
+      'https://ipfs.io/ipfs/'
+    ) || undefined,
+  attributes: (metadata.attributes || []).map(
+    transformMetadataAttributeToCollectionTokenAttribute
+  ),
+  createdBy: metadata.created_by,
+})

--- a/tools/metadata/index.ts
+++ b/tools/metadata/index.ts
@@ -197,11 +197,11 @@ export async function getCollectionTokenInfo(
         uri = await new ethers.Contract(address, ERC721_ABI, provider).tokenURI(
           id
         )
-        metadata = transformERC721ToCollectionToken(fetchMetaData(uri))
+        metadata = transformERC721ToCollectionToken(await fetchMetaData(uri))
         break
       case tokenKinds.ERC1155:
         uri = await new ethers.Contract(address, ERC1155_ABI, provider).uri(id)
-        metadata = transformERC1155ToCollectionToken(fetchMetaData(uri))
+        metadata = transformERC1155ToCollectionToken(await fetchMetaData(uri))
         break
     }
   } catch (e) {

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/metadata",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "AirSwap: Token Metadata for Developers",
   "repository": {
     "type": "git",

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -28,7 +28,8 @@
     "axios": "^0.21.4",
     "eth-contract-metadata": "^1.12.1",
     "ethereumjs-abi": "^0.6.8",
-    "ethers": "^5.6.9"
+    "ethers": "^5.6.9",
+    "valid-url": "^1.0.9"
   },
   "publishConfig": {
     "access": "public"

--- a/tools/types/src/typescript.ts
+++ b/tools/types/src/typescript.ts
@@ -83,6 +83,27 @@ export type Token = {
 
 export { TokenInfo } from '@uniswap/token-lists'
 
+export interface CollectionTokenAttribute {
+  label: string
+  value: string | number
+}
+
+export type CollectionTokenMetadata = {
+  name: string
+  image: string
+  description: string
+  attributes: CollectionTokenAttribute[]
+  createdBy?: string
+}
+
+export type CollectionTokenInfo = {
+  chainId: number
+  kind: string
+  address: string
+  id: number
+  uri: string
+} & CollectionTokenMetadata
+
 export type UnsignedClaim = {
   nonce: string
   expiry: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -13643,6 +13643,11 @@ v8-compile-cache@2.3.0, v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
+valid-url@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==
+
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
Introduces functions `getTokenKind`, `getTokenInfo`, and `getCollectionTokenInfo` to fetch data from on-chain assets. In case of a `CollectionTokenInfo` with bad metadata, those fields are left blank except for name as "Unknown NFT".