### PR TITLE
Pool: simplify constructor, staking; remove mapping

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
     "@typescript-eslint/camelcase": 0,
     "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/no-var-requires": 0,
-    "@typescript-eslint/ban-ts-comment": 0
+    "@typescript-eslint/ban-ts-comment": 0,
+    "prefer-const": 1
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,6 @@
-Migrations.sol
-Imports.sol
 build/
 node_modules/
 coverage/
 typechain/
 cache/
+**/coverage.json

--- a/source/pool/contracts/Pool.sol
+++ b/source/pool/contracts/Pool.sol
@@ -34,9 +34,6 @@ contract Pool is IPool, Ownable2Step {
   // Mapping of tree root to account to mark as claimed
   mapping(bytes32 => mapping(address => bool)) public claimed;
 
-  // Mapping of signed hash to boolean to mark as claimed
-  mapping(bytes32 => bool) public hashClaimed;
-
   // Staking contract address
   address public stakingContract;
 
@@ -47,24 +44,12 @@ contract Pool is IPool, Ownable2Step {
    * @notice Constructor
    * @param _scale uint256
    * @param _max uint256
-   * @param _stakingContract address
-   * @param _stakingToken address
    */
-  constructor(
-    uint256 _scale,
-    uint256 _max,
-    address _stakingContract,
-    address _stakingToken
-  ) {
+  constructor(uint256 _scale, uint256 _max) {
     if (_max > MAX_PERCENTAGE) revert MaxTooHigh(_max);
     if (_scale > MAX_SCALE) revert ScaleTooHigh(_scale);
     scale = _scale;
     max = _max;
-    stakingContract = _stakingContract;
-    stakingToken = _stakingToken;
-    admins[msg.sender] = true;
-
-    IERC20(stakingToken).safeApprove(stakingContract, 2 ** 256 - 1);
   }
 
   /**
@@ -124,25 +109,17 @@ contract Pool is IPool, Ownable2Step {
    * @dev Only owner
    * @param _stakingContract address
    */
-  function setStakingContract(
+  function setStaking(
+    address _stakingToken,
     address _stakingContract
   ) external override onlyOwner {
     if (_stakingContract == address(0)) revert AddressInvalid(_stakingContract);
-    // set allowance on old staking contract to zero
-    IERC20(stakingToken).safeApprove(stakingContract, 0);
-    stakingContract = _stakingContract;
-    IERC20(stakingToken).safeApprove(stakingContract, 2 ** 256 - 1);
-  }
-
-  /**
-   * @notice Set staking token address
-   * @dev Only owner
-   * @param _stakingToken address
-   */
-  function setStakingToken(address _stakingToken) external override onlyOwner {
     if (_stakingToken == address(0)) revert AddressInvalid(_stakingToken);
-    // set allowance on old staking token to zero
-    IERC20(stakingToken).safeApprove(stakingContract, 0);
+    if (stakingToken != address(0) && stakingContract != address(0)) {
+      // set allowance on old staking token to zero
+      IERC20(stakingToken).safeApprove(stakingContract, 0);
+    }
+    stakingContract = _stakingContract;
     stakingToken = _stakingToken;
     IERC20(stakingToken).safeApprove(stakingContract, 2 ** 256 - 1);
   }

--- a/source/pool/contracts/Pool.sol
+++ b/source/pool/contracts/Pool.sol
@@ -122,6 +122,7 @@ contract Pool is IPool, Ownable2Step {
     stakingContract = _stakingContract;
     stakingToken = _stakingToken;
     IERC20(stakingToken).safeApprove(stakingContract, 2 ** 256 - 1);
+    emit SetStaking(_stakingToken, _stakingContract);
   }
 
   /**

--- a/source/pool/contracts/interfaces/IPool.sol
+++ b/source/pool/contracts/interfaces/IPool.sol
@@ -44,9 +44,7 @@ interface IPool {
 
   function removeAdmin(address _admin) external;
 
-  function setStakingContract(address _stakingContract) external;
-
-  function setStakingToken(address _stakingToken) external;
+  function setStaking(address _stakingToken, address _stakingContract) external;
 
   function setClaimed(bytes32 root, address[] memory accounts) external;
 

--- a/source/pool/contracts/interfaces/IPool.sol
+++ b/source/pool/contracts/interfaces/IPool.sol
@@ -14,6 +14,7 @@ interface IPool {
   event Enable(bytes32);
   event SetMax(uint256 max);
   event SetScale(uint256 scale);
+  event SetStaking(address stakingToken, address stakigContract);
   event RemoveAdmin(address admin);
   event Withdraw(
     bytes32[] roots,

--- a/source/pool/test/Pool.js
+++ b/source/pool/test/Pool.js
@@ -168,11 +168,14 @@ describe('Pool Unit', () => {
   })
 
   describe('Test staking variables', async () => {
-    it('set stake contract successful', async () => {
-      await pool
-        .connect(deployer)
-        .setStaking(feeToken.address, stakingContract.address)
+    it('set stake token and contract successful', async () => {
+      await expect(
+        pool
+          .connect(deployer)
+          .setStaking(feeToken.address, stakingContract.address)
+      ).to.emit(pool, 'SetStaking')
       expect(await pool.stakingContract()).to.equal(stakingContract.address)
+      expect(await pool.stakingToken()).to.equal(feeToken.address)
     })
 
     it('set stake contract fails when not owner', async () => {
@@ -194,29 +197,6 @@ describe('Pool Unit', () => {
         pool.connect(deployer).setStaking(feeToken.address, ADDRESS_ZERO)
       ).to.be.revertedWith(`AddressInvalid("${ADDRESS_ZERO}")`)
     })
-
-    /*
-    it('set stake token successful', async () => {
-      await feeToken2.mock.approve.returns(true)
-      await feeToken2.mock.allowance.returns(0)
-      await pool.connect(deployer).setStakingToken(feeToken2.address)
-      expect(await pool.stakingToken()).to.equal(feeToken2.address)
-    })
-
-    it('set stake contract fails when not owner', async () => {
-      await feeToken2.mock.approve.returns(true)
-      await feeToken2.mock.allowance.returns(0)
-      await expect(
-        pool.connect(alice).setStakingToken(feeToken2.address)
-      ).to.be.revertedWith('Ownable: caller is not the owner')
-    })
-
-    it('set stake token reverts', async () => {
-      await expect(
-        pool.connect(deployer).setStakingToken(ADDRESS_ZERO)
-      ).to.be.revertedWith(`AddressInvalid("${ADDRESS_ZERO}")`)
-    })
-    */
   })
 
   describe('Test withdraw', async () => {

--- a/source/pool/test/Pool.js
+++ b/source/pool/test/Pool.js
@@ -129,7 +129,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).setClaimed(root, [bob.address])
-      let proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
+      const proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
 
       await expect(
         pool.connect(bob).withdraw(
@@ -227,7 +227,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
+      const proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
 
       await expect(
         pool.connect(bob).withdraw(
@@ -268,7 +268,7 @@ describe('Pool Unit', () => {
 
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
-      let proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
+      const proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
 
       await expect(
         pool.connect(bob).withdraw(
@@ -294,7 +294,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
+      const proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
 
       await expect(
         pool.connect(bob).withdraw(
@@ -332,7 +332,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
+      const proof = getProof(tree, soliditySha3(bob.address, BOB_SCORE))
 
       await expect(
         pool.connect(bob).withdraw(
@@ -358,7 +358,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
 
       const withdrawMinimum = 0
 
@@ -388,7 +388,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
       const withdrawMinimum = 496
 
       const amount = await pool
@@ -420,7 +420,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
 
       const withdrawMinimum = 496
 
@@ -447,7 +447,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
 
       const withdrawMinimum = 0
 
@@ -481,7 +481,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
 
       const withdrawMinimum = 0
 
@@ -509,7 +509,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
 
       const withdrawMinimum = 0
 
@@ -539,7 +539,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
 
       const withdrawMinimum = 0
 
@@ -574,7 +574,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
 
       const isValid = await pool.verify(alice.address, root, ALICE_SCORE, proof)
       expect(isValid).to.be.equal(true)
@@ -584,7 +584,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
 
       const isValid = await pool.verify(bob.address, root, ALICE_SCORE, proof)
       expect(isValid).to.be.equal(false)
@@ -594,7 +594,7 @@ describe('Pool Unit', () => {
       await pool.addAdmin(alice.address)
       const root = getRoot(tree)
       await pool.connect(alice).enable(root)
-      let proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
+      const proof = getProof(tree, soliditySha3(alice.address, ALICE_SCORE))
 
       const isValid = await pool.verify(alice.address, root, BOB_SCORE, proof)
       expect(isValid).to.be.equal(false)

--- a/source/registry/test/unit.js
+++ b/source/registry/test/unit.js
@@ -424,7 +424,7 @@ describe('Registry Unit', () => {
 
   describe('Test Zero Amount Transfer', async () => {
     beforeEach(async () => {
-      let zero_cost = '0'
+      const zero_cost = '0'
       registryZeroCost = await registryFactory.deploy(
         stakingToken.address,
         zero_cost,

--- a/source/staking/test/Staking.js
+++ b/source/staking/test/Staking.js
@@ -398,7 +398,7 @@ describe('Staking Unit', () => {
       await token.mock.transfer.returns(true)
       await staking.connect(account1).stake('100')
 
-      let block = await ethers.provider.getBlock()
+      const block = await ethers.provider.getBlock()
       await ethers.provider.send('evm_mine', [block['timestamp'] + 10])
 
       await staking.connect(account1).unstake('10')
@@ -411,7 +411,7 @@ describe('Staking Unit', () => {
       await token.mock.transfer.returns(true)
       await staking.connect(account1).stake('100')
 
-      let block = await ethers.provider.getBlock()
+      const block = await ethers.provider.getBlock()
       // With a duration of 100, increasing the timestamp by 10 will unlock 10% of the staked balance
       await ethers.provider.send('evm_mine', [block['timestamp'] + 10])
 

--- a/source/swap-erc20/test/SwapERC20.js
+++ b/source/swap-erc20/test/SwapERC20.js
@@ -365,6 +365,17 @@ describe('SwapERC20 Unit', () => {
       )
     })
 
+    it('test swaps gas consumption', async () => {
+      const order = await createSignedOrderERC20({}, signer)
+
+      let transaction = await swap
+        .connect(sender)
+        .swap(sender.address, ...order)
+      const swapReceipt = await transaction.wait()
+      const swapCost = swapReceipt.gasUsed
+      expect(Number(swapCost)).to.be.lessThanOrEqual(115799)
+    })
+
     it('test swaps by signer instead of authorized signatory fail', async () => {
       const order = await createSignedOrderERC20(
         {
@@ -555,6 +566,21 @@ describe('SwapERC20 Unit', () => {
         'SwapERC20'
       )
     })
+
+    it('test swapLight gas consumption', async () => {
+      const order = await createSignedOrderERC20(
+        {
+          protocolFee: PROTOCOL_FEE_LIGHT,
+        },
+        signer
+      )
+
+      const transaction = await swap.connect(sender).swapLight(...order)
+      const swapLightReceipt = await transaction.wait()
+      const swapLightCost = swapLightReceipt.gasUsed
+      expect(Number(swapLightCost)).to.be.lessThanOrEqual(95223)
+    })
+
     it('test light swaps with authorized', async () => {
       const order = await createSignedOrderERC20(
         {

--- a/source/swap-erc20/test/SwapERC20.js
+++ b/source/swap-erc20/test/SwapERC20.js
@@ -368,7 +368,7 @@ describe('SwapERC20 Unit', () => {
     it('test swaps gas consumption', async () => {
       const order = await createSignedOrderERC20({}, signer)
 
-      let transaction = await swap
+      const transaction = await swap
         .connect(sender)
         .swap(sender.address, ...order)
       const swapReceipt = await transaction.wait()


### PR DESCRIPTION
Staking is only on mainnet so removed from constructor.
Combined staking token and contract into single setter.
Removed unused mapping from previous implementation.
Includes latest from develop.