### PR TITLE
temp replacement for linea staking token

### DIFF
--- a/source/balances/package.json
+++ b/source/balances/package.json
@@ -27,7 +27,7 @@
     "@openzeppelin/contracts": "^4.8.3"
   },
   "devDependencies": {
-    "@airswap/constants": "^4.0.6",
+    "@airswap/constants": "^4.0.8",
     "@airswap/utils": "^4.0.0",
     "prompt-confirm": "^2.0.4"
   },

--- a/source/pool/package.json
+++ b/source/pool/package.json
@@ -28,7 +28,7 @@
     "@openzeppelin/contracts": "^4.8.3"
   },
   "devDependencies": {
-    "@airswap/constants": "^4.0.6",
+    "@airswap/constants": "^4.0.8",
     "@airswap/types": "^4.0.0",
     "@airswap/utils": "^4.0.0",
     "prompt-confirm": "^2.0.4"

--- a/source/registry/package.json
+++ b/source/registry/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@airswap/constants": "^4.0.6",
+    "@airswap/constants": "^4.0.8",
     "@airswap/utils": "^4.0.0",
     "prompt-confirm": "^2.0.4"
   }

--- a/source/swap-erc20/package.json
+++ b/source/swap-erc20/package.json
@@ -27,7 +27,7 @@
     "@openzeppelin/contracts": "^4.8.3"
   },
   "devDependencies": {
-    "@airswap/constants": "^4.0.6",
+    "@airswap/constants": "^4.0.8",
     "@airswap/types": "^4.0.0",
     "@airswap/utils": "^4.0.0",
     "prompt-confirm": "^2.0.4"

--- a/source/swap/package.json
+++ b/source/swap/package.json
@@ -31,7 +31,7 @@
     "@openzeppelin/contracts": "^4.8.3"
   },
   "devDependencies": {
-    "@airswap/constants": "^4.0.6",
+    "@airswap/constants": "^4.0.8",
     "@airswap/types": "^4.0.0",
     "@airswap/utils": "^4.0.0",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.7"

--- a/source/wrapper/package.json
+++ b/source/wrapper/package.json
@@ -29,7 +29,7 @@
     "@openzeppelin/contracts": "^4.8.3"
   },
   "devDependencies": {
-    "@airswap/constants": "^4.0.6",
+    "@airswap/constants": "^4.0.8",
     "@airswap/utils": "^4.0.0",
     "@airswap/types": "^4.0.0",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",

--- a/tools/constants/index.ts
+++ b/tools/constants/index.ts
@@ -129,7 +129,7 @@ export const stakingTokenAddresses: Record<number, string> = {
   [ChainIds.ARBITRUM]: '0xa1135c2f2c7798d31459b5fdaef8613419be1008',
   [ChainIds.FUJI]: '0x48c427e7cEf42399e9e8300fC47875772309e995',
   [ChainIds.AVALANCHE]: '0x702d0f43edd46b77ea2d48570b02c328a20a94a1',
-  [ChainIds.LINEAGOERLI]: '0x2C1b868d6596a18e32E61B901E4060C872647b6C',
+  [ChainIds.LINEAGOERLI]: '0x7823e8dcc8bfc23ea3ac899eb86921f90e80f499',
   [ChainIds.MUMBAI]: '0xd161ddcfcc0c2d823021aa26200824efa75218d1',
   [ChainIds.ARBITRUMGOERLI]: '0x71070c5607358fc25e3b4aaf4fb0a580c190252a',
 }

--- a/tools/constants/package.json
+++ b/tools/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/constants",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "AirSwap: Constants for Developers",
   "repository": {
     "type": "git",

--- a/tools/libraries/package.json
+++ b/tools/libraries/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@airswap/balances": "4.0.1",
-    "@airswap/constants": "^4.0.6",
+    "@airswap/constants": "^4.0.8",
     "@airswap/jsonrpc-client-websocket": "0.0.1",
     "@airswap/registry": "4.0.3",
     "@airswap/maker-registry": "4.0.4",

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/metadata",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "AirSwap: Token Metadata for Developers",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
     "test": "TS_NODE_COMPILER_OPTIONS='{\"strict\":false}' yarn mocha -r ts-node/esm test/*.ts"
   },
   "dependencies": {
-    "@airswap/constants": "^4.0.6",
+    "@airswap/constants": "^4.0.8",
     "@airswap/types": "^4.0.0",
     "@openzeppelin/contracts": "^4.8.3",
     "@uniswap/token-lists": "^1.0.0-beta.24",

--- a/tools/utils/package.json
+++ b/tools/utils/package.json
@@ -21,7 +21,7 @@
     "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"strict\":false}' yarn mocha -r ts-node/esm test/*.ts"
   },
   "dependencies": {
-    "@airswap/constants": "^4.0.6",
+    "@airswap/constants": "^4.0.8",
     "@airswap/types": "^4.0.4",
     "@metamask/eth-sig-util": "^5.0.2",
     "bignumber.js": "^9.0.1",


### PR DESCRIPTION
on Linea, the staking token (usually AST) was set to WETH. the web app is looking for WETH by address and so ends up finding and using the staking token / AST. this PR temporarily updates the staking token to another ERC20 on Linea.