### PR TITLE
fix(jayson): Fix url for maker when configuring jayson

### DIFF
--- a/tools/libraries/package.json
+++ b/tools/libraries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airswap/libraries",
-  "version": "4.0.20",
+  "version": "4.0.21",
   "description": "AirSwap: Libraries for Developers",
   "repository": {
     "type": "git",

--- a/tools/libraries/src/Server.ts
+++ b/tools/libraries/src/Server.ts
@@ -367,6 +367,7 @@ export class Server extends TypedEmitter<ServerEvents> {
     const options = {
       protocol: parsedUrl.protocol,
       hostname: parsedUrl.hostname,
+      path: parsedUrl.path,
       port: parsedUrl.port,
       timeout: REQUEST_TIMEOUT,
     }


### PR DESCRIPTION
Issue: When maker is having this kind of endpoint: https://marker.com/my_cutom_path
jayson is configured with only https://marker.com