### PR TITLE
Swap param checks

### DIFF
--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -315,6 +315,10 @@ contract Swap is ISwap, Ownable2Step, EIP712 {
         errors[errCount] = "SignerBalanceLow";
         errCount++;
       }
+      if (!signerTokenAdapter.hasValidParams(order.signer)) {
+        errors[errCount] = "AmountOrIDInvalid";
+        errCount++;
+      }
     }
 
     IAdapter senderTokenAdapter = adapters[order.sender.kind];
@@ -345,6 +349,10 @@ contract Swap is ISwap, Ownable2Step, EIP712 {
         }
         if (!senderTokenAdapter.hasBalance(sender)) {
           errors[errCount] = "SenderBalanceLow";
+          errCount++;
+        }
+        if (!senderTokenAdapter.hasValidParams(order.signer)) {
+          errors[errCount] = "AmountOrIDInvalid";
           errCount++;
         }
         if (order.sender.amount < order.affiliateAmount) {

--- a/source/swap/contracts/adapters/ERC1155Adapter.sol
+++ b/source/swap/contracts/adapters/ERC1155Adapter.sol
@@ -12,8 +12,8 @@ contract ERC1155Adapter is IAdapter {
   bytes4 public constant interfaceId = 0xd9b67a26;
 
   /**
-   * @notice Function to wrap token transfer for different token types
-   * @param party Party from whom swap would be made
+   * @notice Checks balance on an ERC1155
+   * @param party Party params to check
    * @dev Use call: "msg.sender" is Swap contract
    */
   function hasAllowance(Party calldata party) external view returns (bool) {
@@ -22,12 +22,20 @@ contract ERC1155Adapter is IAdapter {
   }
 
   /**
-   * @notice Function to wrap token transfer for different token types
-   * @param party Party from whom swap would be made
+   * @notice Checks balance on an ERC721
+   * @param party Party params to check
    */
   function hasBalance(Party calldata party) external view returns (bool) {
     return
       IERC1155(party.token).balanceOf(party.wallet, party.id) >= party.amount;
+  }
+
+  /**
+   * @notice Checks params for transfer
+   * @param party Party params to check
+   */
+  function hasValidParams(Party calldata party) external pure returns (bool) {
+    return (party.amount != 0);
   }
 
   /**
@@ -46,7 +54,7 @@ contract ERC1155Adapter is IAdapter {
     uint256 id,
     address token
   ) external {
-    if (amount == 0) revert InvalidArgument("amount");
+    if (amount == 0) revert AmountOrIDInvalid("amount");
     IERC1155(token).safeTransferFrom(from, to, id, amount, "0x00");
   }
 }

--- a/source/swap/contracts/adapters/ERC20Adapter.sol
+++ b/source/swap/contracts/adapters/ERC20Adapter.sol
@@ -14,8 +14,8 @@ contract ERC20Adapter is IAdapter {
   bytes4 public constant interfaceId = 0x36372b07;
 
   /**
-   * @notice Function to wrap token transfer for different token types
-   * @param party Party from whom swap would be made
+   * @notice Checks allowance on an ERC20
+   * @param party Party params to check
    * @dev Use call: "msg.sender" is Swap contract
    */
   function hasAllowance(Party calldata party) external view returns (bool) {
@@ -25,11 +25,19 @@ contract ERC20Adapter is IAdapter {
   }
 
   /**
-   * @notice Function to wrap token transfer for different token types
-   * @param party Party from whom swap would be made
+   * @notice Checks balance on an ERC20
+   * @param party Party params to check
    */
   function hasBalance(Party calldata party) external view returns (bool) {
     return IERC20(party.token).balanceOf(party.wallet) >= party.amount;
+  }
+
+  /**
+   * @notice Checks params for transfer
+   * @param party Party params to check
+   */
+  function hasValidParams(Party calldata party) external pure returns (bool) {
+    return (party.id == 0);
   }
 
   /**
@@ -48,7 +56,7 @@ contract ERC20Adapter is IAdapter {
     uint256 id,
     address token
   ) external {
-    if (id != 0) revert InvalidArgument("id");
+    if (id != 0) revert AmountOrIDInvalid("id");
     IERC20(token).safeTransferFrom(from, to, amount);
   }
 }

--- a/source/swap/contracts/adapters/ERC721Adapter.sol
+++ b/source/swap/contracts/adapters/ERC721Adapter.sol
@@ -12,8 +12,8 @@ contract ERC721Adapter is IAdapter {
   bytes4 public constant interfaceId = 0x80ac58cd;
 
   /**
-   * @notice Function to wrap token transfer for different token types
-   * @param party Party from whom swap would be made
+   * @notice Checks allowance on an ERC721
+   * @param party Party params to check
    * @dev Use call: "msg.sender" is Swap contract
    */
   function hasAllowance(Party calldata party) external view returns (bool) {
@@ -21,11 +21,19 @@ contract ERC721Adapter is IAdapter {
   }
 
   /**
-   * @notice Function to wrap token transfer for different token types
-   * @param party Party from whom swap would be made
+   * @notice Checks balance on an ERC721
+   * @param party Party params to check
    */
   function hasBalance(Party calldata party) external view returns (bool) {
     return IERC721(party.token).ownerOf(party.id) == party.wallet;
+  }
+
+  /**
+   * @notice Checks params for transfer
+   * @param party Party params to check
+   */
+  function hasValidParams(Party calldata party) external pure returns (bool) {
+    return (party.amount == 0);
   }
 
   /**
@@ -44,7 +52,7 @@ contract ERC721Adapter is IAdapter {
     uint256 id,
     address token
   ) external {
-    if (amount != 0) revert InvalidArgument("amount");
+    if (amount != 0) revert AmountOrIDInvalid("amount");
     IERC721(token).safeTransferFrom(from, to, id);
   }
 }

--- a/source/swap/contracts/interfaces/IAdapter.sol
+++ b/source/swap/contracts/interfaces/IAdapter.sol
@@ -17,7 +17,7 @@ interface IAdapter {
   /**
    * @notice Revert if provided an invalid transfer argument
    */
-  error InvalidArgument(string);
+  error AmountOrIDInvalid(string);
 
   /**
    * @notice Return the ERC165 interfaceId this adapter supports
@@ -25,16 +25,22 @@ interface IAdapter {
   function interfaceId() external view returns (bytes4);
 
   /**
-   * @notice Function to wrap token transfer for different token types
-   * @param party Party from whom swap would be made
+   * @notice Checks balance on a token
+   * @param party Party params to check
    */
   function hasAllowance(Party calldata party) external view returns (bool);
 
   /**
-   * @notice Function to wrap token transfer for different token types
-   * @param party Party from whom swap would be made
+   * @notice Checks balance on a token
+   * @param party Party params to check
    */
   function hasBalance(Party calldata party) external view returns (bool);
+
+  /**
+   * @notice Checks params for transfer
+   * @param party Party params to check
+   */
+  function hasValidParams(Party calldata party) external view returns (bool);
 
   /**
    * @notice Function to wrap token transfer for different token types

--- a/source/swap/test/ERC1155Adapter.js
+++ b/source/swap/test/ERC1155Adapter.js
@@ -54,7 +54,9 @@ describe('ERC1155Adapter Unit', () => {
   })
 
   it('transfer succeeds', async () => {
-    await token.mock.safeTransferFrom.returns()
+    await token.mock[
+      'safeTransferFrom(address,address,uint256,uint256,bytes)'
+    ].returns()
     await expect(
       adapter
         .connect(anyone)
@@ -66,5 +68,18 @@ describe('ERC1155Adapter Unit', () => {
           party.token
         )
     ).to.not.be.reverted
+  })
+
+  it('transfer with zero amount fails', async () => {
+    await token.mock[
+      'safeTransferFrom(address,address,uint256,uint256,bytes)'
+    ].returns()
+    await expect(
+      adapter
+        .connect(anyone)
+        .transfer(party.wallet, anyone.address, '0', party.id, party.token)
+    )
+      .to.be.revertedWith('AmountOrIDInvalid')
+      .withArgs('amount')
   })
 })

--- a/source/swap/test/ERC20Adapter.js
+++ b/source/swap/test/ERC20Adapter.js
@@ -75,7 +75,7 @@ describe('ERC20Adapter Unit', () => {
         .connect(anyone)
         .transfer(party.wallet, anyone.address, party.amount, '1', party.token)
     )
-      .to.be.revertedWith('InvalidArgument')
+      .to.be.revertedWith('AmountOrIDInvalid')
       .withArgs('id')
   })
 })

--- a/source/swap/test/ERC721Adapter.js
+++ b/source/swap/test/ERC721Adapter.js
@@ -68,7 +68,7 @@ describe('ERC721Adapter Unit', () => {
         .connect(anyone)
         .transfer(party.wallet, anyone.address, '1', party.id, party.token)
     )
-      .to.be.revertedWith('InvalidArgument')
+      .to.be.revertedWith('AmountOrIDInvalid')
       .withArgs('amount')
   })
 })

--- a/source/swap/test/Swap.js
+++ b/source/swap/test/Swap.js
@@ -4,7 +4,12 @@ const { ethers, waffle } = require('hardhat')
 const { deployMockContract } = waffle
 const IERC20 = require('@openzeppelin/contracts/build/contracts/IERC20.json')
 const IERC721 = require('@openzeppelin/contracts/build/contracts/ERC721Royalty.json')
-const { createOrder, createOrderSignature } = require('@airswap/utils')
+const IERC1155 = require('@openzeppelin/contracts/build/contracts/IERC1155.json')
+const {
+  createOrder,
+  createOrderSignature,
+  checkResultToErrors,
+} = require('@airswap/utils')
 const { TokenKinds, ADDRESS_ZERO } = require('@airswap/constants')
 
 const CHAIN_ID = 31337
@@ -25,6 +30,8 @@ let erc20token
 let erc20adapter
 let erc721token
 let erc721adapter
+let erc1155token
+let erc1155adapter
 let swap
 
 async function signOrder(order, wallet, swapContract) {
@@ -78,8 +85,9 @@ describe('Swap Unit', () => {
       await ethers.getContractFactory('ERC20Adapter')
     ).deploy()
     await erc20adapter.deployed()
+
     erc721token = await deployMockContract(deployer, IERC721.abi)
-    await erc721token.mock.isApprovedForAll.returns(true)
+    await erc721token.mock.getApproved.returns(sender.address)
     await erc721token.mock.ownerOf.returns(sender.address)
     await erc721token.mock[
       'safeTransferFrom(address,address,uint256)'
@@ -88,10 +96,22 @@ describe('Swap Unit', () => {
       await ethers.getContractFactory('ERC721Adapter')
     ).deploy()
     await erc721adapter.deployed()
+
+    erc1155token = await deployMockContract(deployer, IERC1155.abi)
+    await erc1155token.mock.isApprovedForAll.returns(true)
+    await erc1155token.mock.balanceOf.returns(DEFAULT_AMOUNT)
+    await erc1155token.mock[
+      'safeTransferFrom(address,address,uint256,uint256,bytes)'
+    ].returns()
+    erc1155adapter = await (
+      await ethers.getContractFactory('ERC1155Adapter')
+    ).deploy()
+    await erc1155adapter.deployed()
+
     swap = await (
       await ethers.getContractFactory('Swap')
     ).deploy(
-      [erc20adapter.address, erc721adapter.address],
+      [erc20adapter.address, erc721adapter.address, erc1155adapter.address],
       TokenKinds.ERC20,
       PROTOCOL_FEE,
       protocolFeeWallet.address
@@ -588,6 +608,56 @@ describe('Swap Unit', () => {
       const order = await createSignedOrder({}, signer)
       const errors = await swap.check(sender.address, order)
       expect(errors[1]).to.equal(0)
+    })
+
+    it('check with invalid erc20 params fails', async () => {
+      const order = await createSignedOrder(
+        {
+          signer: {
+            kind: TokenKinds.ERC20,
+            id: '1',
+          },
+        },
+        signer
+      )
+      const [errors] = await swap.check(sender.address, order)
+      expect(errors[0]).to.be.equal(
+        ethers.utils.formatBytes32String('AmountOrIDInvalid')
+      )
+    })
+
+    it('check with invalid erc721 params fails', async () => {
+      const order = await createSignedOrder(
+        {
+          signer: {
+            kind: TokenKinds.ERC721,
+            token: erc721token.address,
+            amount: '1',
+          },
+        },
+        signer
+      )
+      const [errors] = await swap.check(sender.address, order)
+      expect(errors[2]).to.be.equal(
+        ethers.utils.formatBytes32String('AmountOrIDInvalid')
+      )
+    })
+
+    it('check with invalid erc1155 params fails', async () => {
+      const order = await createSignedOrder(
+        {
+          signer: {
+            kind: TokenKinds.ERC1155,
+            token: erc1155token.address,
+            amount: '0',
+          },
+        },
+        signer
+      )
+      const [errors] = await swap.check(sender.address, order)
+      expect(errors[0]).to.be.equal(
+        ethers.utils.formatBytes32String('AmountOrIDInvalid')
+      )
     })
 
     it('check without allowances or balances fails', async () => {

--- a/source/swap/test/Swap.js
+++ b/source/swap/test/Swap.js
@@ -5,11 +5,7 @@ const { deployMockContract } = waffle
 const IERC20 = require('@openzeppelin/contracts/build/contracts/IERC20.json')
 const IERC721 = require('@openzeppelin/contracts/build/contracts/ERC721Royalty.json')
 const IERC1155 = require('@openzeppelin/contracts/build/contracts/IERC1155.json')
-const {
-  createOrder,
-  createOrderSignature,
-  checkResultToErrors,
-} = require('@airswap/utils')
+const { createOrder, createOrderSignature } = require('@airswap/utils')
 const { TokenKinds, ADDRESS_ZERO } = require('@airswap/constants')
 
 const CHAIN_ID = 31337


### PR DESCRIPTION
Adds `hasValidParams` to Adapters.
ERC20: requires id to be zero.
ERC721: requires amount to be zero.
ERC1155: requires amount to be nonzero.