### PR TITLE
check sender allowance and balance only if sender is set

### DIFF
--- a/source/swap/contracts/Swap.sol
+++ b/source/swap/contracts/Swap.sol
@@ -353,13 +353,15 @@ contract Swap is ISwap, Ownable2Step, EIP712 {
           order.sender.id,
           totalSenderAmount
         );
-        if (!senderTokenAdapter.hasAllowance(sender)) {
-          errors[errCount] = "SenderAllowanceLow";
-          errCount++;
-        }
-        if (!senderTokenAdapter.hasBalance(sender)) {
-          errors[errCount] = "SenderBalanceLow";
-          errCount++;
+        if (senderWallet != address(0)) {
+          if (!senderTokenAdapter.hasAllowance(sender)) {
+            errors[errCount] = "SenderAllowanceLow";
+            errCount++;
+          }
+          if (!senderTokenAdapter.hasBalance(sender)) {
+            errors[errCount] = "SenderBalanceLow";
+            errCount++;
+          }
         }
         if (!senderTokenAdapter.hasValidParams(sender)) {
           errors[errCount] = "AmountOrIDInvalid";

--- a/source/swap/test/Swap.js
+++ b/source/swap/test/Swap.js
@@ -687,6 +687,25 @@ describe('Swap Unit', () => {
       )
     })
 
+    it('check public order without allowances or balances fails', async () => {
+      await erc20token.mock.allowance.returns('0')
+      await erc20token.mock.balanceOf.returns('0')
+      const order = await createSignedOrder(
+        {
+          sender: { wallet: ADDRESS_ZERO },
+        },
+        signer
+      )
+      const [errors, count] = await swap.check(ADDRESS_ZERO, order)
+      expect(errors[0]).to.be.equal(
+        ethers.utils.formatBytes32String('SignerAllowanceLow')
+      )
+      expect(errors[1]).to.be.equal(
+        ethers.utils.formatBytes32String('SignerBalanceLow')
+      )
+      expect(count).to.be.equal(2)
+    })
+
     it('check with bad kind fails', async () => {
       const order = await createSignedOrder(
         {


### PR DESCRIPTION
Allows check to be run on public orders with a yet unknown sender.