### PR TITLE
@airswap/swap-erc20: use ERC20 for all balanceOf calls

### DIFF
--- a/source/swap-erc20/contracts/SwapERC20.sol
+++ b/source/swap-erc20/contracts/SwapERC20.sol
@@ -510,8 +510,7 @@ contract SwapERC20 is ISwapERC20, Ownable, EIP712 {
     }
 
     if (order.senderWallet != address(0)) {
-      uint256 senderBalance = SafeTransferLib.balanceOf(
-        order.senderToken,
+      uint256 senderBalance = ERC20(order.senderToken).balanceOf(
         order.senderWallet
       );
 
@@ -752,7 +751,7 @@ contract SwapERC20 is ISwapERC20, Ownable, EIP712 {
       if (stakingToken != address(0)) {
         // Only check bonus if staking is set
         bonusAmount = calculateBonus(
-          SafeTransferLib.balanceOf(stakingToken, msg.sender),
+          ERC20(stakingToken).balanceOf(msg.sender),
           feeAmount
         );
       }


### PR DESCRIPTION
Use `ERC20` for all `balanceOf` and `allowance` calls.
Use `SafeTransferLib` for all transfers.