### PR TITLE
DelegatedSwapFor event for Delegate

### DIFF
--- a/source/delegate/contracts/Delegate.sol
+++ b/source/delegate/contracts/Delegate.sol
@@ -33,7 +33,7 @@ contract Delegate is IDelegate, Ownable {
 
   /**
    * @notice Set a Rule
-   * @param _senderWallet address Address of the sender wallet
+   * @param _senderWallet address Address of the delegating sender wallet
    * @param _senderToken address ERC-20 token the sender would transfer
    * @param _senderAmount uint256 Maximum sender amount for the rule
    * @param _signerToken address ERC-20 token the signer would transfer
@@ -80,7 +80,7 @@ contract Delegate is IDelegate, Ownable {
 
   /**
    * @notice Unset a Rule
-   * @param _senderWallet The address of the sender's wallet
+   * @param _senderWallet address Address of the delegating sender wallet
    * @param _senderToken address ERC-20 token the sender would transfer
    * @param _signerToken address ERC-20 token the signer would transfer
    */
@@ -184,8 +184,8 @@ contract Delegate is IDelegate, Ownable {
     rules[_senderWallet][_senderToken][_signerToken]
       .senderFilledAmount += _senderAmount;
 
-    // Emit a DelegateSwap event
-    emit DelegateSwap(_nonce, _signerWallet);
+    // Emit a DelegatedSwapFor event
+    emit DelegatedSwapFor(_senderWallet, _signerWallet, _nonce);
   }
 
   /**

--- a/source/delegate/contracts/interfaces/IDelegate.sol
+++ b/source/delegate/contracts/interfaces/IDelegate.sol
@@ -14,7 +14,11 @@ interface IDelegate {
   }
 
   event Authorize(address signatory, address signer);
-  event DelegateSwap(uint256 nonce, address signerWallet);
+  event DelegatedSwapFor(
+    address indexed senderWallet,
+    address indexed signerWallet,
+    uint256 indexed nonce
+  );
   event Revoke(address tmp, address signer);
 
   event SetRule(

--- a/source/delegate/test/Delegate.js
+++ b/source/delegate/test/Delegate.js
@@ -409,7 +409,7 @@ describe('Delegate Unit', () => {
 
       await expect(
         delegate.connect(signer).swap(sender.address, ...order)
-      ).to.emit(delegate, 'DelegateSwap')
+      ).to.emit(delegate, 'DelegatedSwapFor')
     })
 
     it('successfully swaps with a manager', async () => {
@@ -438,7 +438,7 @@ describe('Delegate Unit', () => {
 
       await expect(
         delegate.connect(signer).swap(sender.address, ...order)
-      ).to.emit(delegate, 'DelegateSwap')
+      ).to.emit(delegate, 'DelegatedSwapFor')
     })
 
     it('fails to swap with no rule', async () => {
@@ -555,7 +555,7 @@ describe('Delegate Unit', () => {
 
       await expect(
         delegate.connect(signer).swap(sender.address, ...order)
-      ).to.emit(delegate, 'DelegateSwap')
+      ).to.emit(delegate, 'DelegatedSwapFor')
 
       const order2 = await createSignedOrderERC20({}, signer)
 

--- a/source/delegate/test/DelegateIntegration.js
+++ b/source/delegate/test/DelegateIntegration.js
@@ -114,7 +114,7 @@ describe('Delegate Integration', () => {
 
       await expect(
         delegate.connect(signer).swap(sender.address, ...order)
-      ).to.emit(delegate, 'DelegateSwap')
+      ).to.emit(delegate, 'DelegatedSwapFor')
 
       expect(await signerToken.balanceOf(sender.address)).to.equal(
         DEFAULT_SIGNER_AMOUNT


### PR DESCRIPTION
* Rename DelegateSwap to DelegatedSwapFor to match Wrapper behavior.
* Add senderWallet parameter to DelegatedSwapFor.
* Index all three parameters of DelegatedSwapFor.